### PR TITLE
Automatically update branches that have automerge enabled

### DIFF
--- a/.github/workflows/update-branches.yml
+++ b/.github/workflows/update-branches.yml
@@ -1,0 +1,17 @@
+name: Update all pull requests that have automerge enabled
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update branches
+        uses: brainly/autoupdate-branch
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This makes it so that when you have a PR you want to merge, all you need to do is enable automerge for it, and then you can leave it alone and it will merge eventually.
This is currently not possible, because the branch may get outdated before checks pass.