### PR TITLE
Use WRITE_ACCESS_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -48,4 +48,4 @@ jobs:
           prettier_options: --write **/*.{js,css,scss,ts,tsx,md,html,yml,yaml,json}
           commit_message: squash! Prettier
         env:
-          GITHUB_TOKEN: ${{ secrets.PRETTIER_ACTION_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_GITHUB_TOKEN }}

--- a/.github/workflows/update-branches.yml
+++ b/.github/workflows/update-branches.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Update branches
         uses: brainly/autoupdate-branch@2.0.0
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          repo-token: '${{ secrets.WRITE_ACCESS_GITHUB_TOKEN }}'


### PR DESCRIPTION
To make sure that the push triggers GitHub actions to run again, a different token needs to be used (just like for the Prettier action).