### PR TITLE
Document launch tiers and process

### DIFF
--- a/content/marketing/product-marketing/marketing_launch_tiers.md
+++ b/content/marketing/product-marketing/marketing_launch_tiers.md
@@ -4,6 +4,8 @@ All product and feature launches should be assigned a launch tier of L1, L2, or 
 
 The marketing launch tier should be established as early in the product development lifecycle as possible (during beta at the latest).
 
+In reviewing the [PMM Roadmap](https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) monthly, product and marketing leadership determine which features contained therein are L1, L2, or L3 levels. The tier of a given upcoming feature can always be found (once determined) in the row at the bottom of each feature slide.
+
 ## L1 launch
 
 L1 launches are reserved for the most important product announcements of the year. L1 launches:

--- a/content/product/product_management/index.md
+++ b/content/product/product_management/index.md
@@ -16,14 +16,11 @@ This page contains information that is relevant for how to do well at your job a
 
 ### Definitions
 
-<dl>
-    <dt>Product priorities</dt>
-    <dd>An ordered list of problem statements or outcomes that product has evidence is important</dt>
-    <dt>Roadmap</dt>
-    <dd>The tasks and timeline for when each will be worked on</dt>
-    <dt>Backlog</dt>
-    <dd>The ordered list of items to be tackled after items on the roadmap are complete.</dt>
-</dl>
+- Product priorities: An ordered list of problem statements or outcomes that product has evidence is important
+- Roadmap: The tasks and timeline for when each will be worked on
+- Backlog: The ordered list of items to be tackled after items on the roadmap are complete
+
+Launch tier levels are also an important concept to be aware of, and definitions are documented on the [marketing launch page](../marketing/product-marketing/marketing_launch_tiers.md).
 
 ## Release early, release often
 

--- a/content/product/product_management/index.md
+++ b/content/product/product_management/index.md
@@ -20,7 +20,7 @@ This page contains information that is relevant for how to do well at your job a
 - Roadmap: The tasks and timeline for when each will be worked on
 - Backlog: The ordered list of items to be tackled after items on the roadmap are complete
 
-Launch tier levels are also an important concept to be aware of, and definitions are documented on the [marketing launch page](../marketing/product-marketing/marketing_launch_tiers.md).
+Launch tier levels are also an important concept to be aware of, and definitions are documented on the [marketing launch page](../../marketing/product-marketing/marketing_launch_tiers.md).
 
 ## Release early, release often
 

--- a/content/product/product_management/rollout_process.md
+++ b/content/product/product_management/rollout_process.md
@@ -4,6 +4,10 @@ Features come in many different sizes and shapes, and the process for introducin
 
 Some features have a [beta or experimental label](../beta_and_experimental_feature_labels.md), you can read more about how that works there.
 
+## Launch Tiers
+
+Product features fall into different buckets depending on how much engagement with marketing is needed. Definitions for [L1, L2, and L3 launches](../marketing/product-marketing/marketing_launch_tiers.md) can be found in the marketing handbook.
+
 ## Sourcegraph Cloud
 
 Sourcegraph Cloud is continuously deployed with all new updates to master. We maintain a [releasability contract](../../engineering/continuous_releasability.md) and require all new features to be released behind a feature flag to ensure that functionality can be turned off if a problem arises.

--- a/content/product/product_management/rollout_process.md
+++ b/content/product/product_management/rollout_process.md
@@ -6,7 +6,7 @@ Some features have a [beta or experimental label](../beta_and_experimental_featu
 
 ## Launch Tiers
 
-Product features fall into different buckets depending on how much engagement with marketing is needed. Definitions for [L1, L2, and L3 launches](../marketing/product-marketing/marketing_launch_tiers.md) can be found in the marketing handbook.
+Product features fall into different buckets depending on how much engagement with marketing is needed. Definitions for [L1, L2, and L3 launches](../../marketing/product-marketing/marketing_launch_tiers.md) can be found in the marketing handbook.
 
 ## Sourcegraph Cloud
 


### PR DESCRIPTION
This adds a bit of info to the handbook about how launch tiers are decided and documented. The bit about adding it to the PMM roadmap slides (https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) is new, with the intention of having a single place where it is written down. 

Because this documents existing process it seems non-controversial, and I'm going ahead with merging and sharing in Slack. If we want to change the place where tier levels are documented that's fine with me, and can happen in a follow-up MR.