### PR TITLE
Write _redirects to out directory for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next",
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "generate-redirects": "node src/scripts/generate-redirects.mjs",
-    "netlify-build": "yarn run generate-redirects && yarn run copy-assets && next build && next export && next-sitemap",
+    "netlify-build": "yarn run copy-assets && next build && next export && next-sitemap && yarn run generate-redirects",
     "build": "next build",
     "postbuild": "next-sitemap",
     "check-internal-links": "find ./content -name \\*.md -exec markdown-link-check --config .github/workflows/link-check-internal.json --quiet {} \\;",

--- a/src/scripts/generate-redirects.mjs
+++ b/src/scripts/generate-redirects.mjs
@@ -14,4 +14,4 @@ const lines =
 
 console.log('Redirects:\n', lines)
 
-await fs.writeFile(new URL('../../_redirects', import.meta.url), lines)
+await fs.writeFile(new URL('../../out/_redirects', import.meta.url), lines)


### PR DESCRIPTION
I saw a warning in the Netlify logs and noticed that redirects were not working in production because the file was written to the wrong directory.