### PR TITLE
dx: migrate finalized parts of strategy to handbook

### DIFF
--- a/content/direction/enablement/dev-experience/index.md
+++ b/content/direction/enablement/dev-experience/index.md
@@ -16,7 +16,7 @@ Engineers should be able to spend their time solving problems that matter to the
 
 ## Guiding principles
 
-We inherit Sourcegraph's [engineering principles and practices](../../principles-and-practices.md) and [Enablement org's principles and practices](../../developer-insights/index.md#principles-and-practices). In addition, the following principles guide the work we do in dev experience. Sometimes adhering to one causes us to compromise another, but they guide our decisions on what matters.
+We inherit Sourcegraph's [engineering principles and practices](../../../engineering/principles-and-practices.md) and [Enablement org's principles and practices](../../../engineering/enablement/index.md#principles-and-practices). In addition, the following principles guide the work we do in dev experience. Sometimes adhering to one causes us to compromise another, but they guide our decisions on what matters.
 
 - **We don't own the developer experience at Sourcegraph – we simply focus on it.** Sourcegraph engineers own the developer experience as a collective.
 - **We ship open products.** Our products are open to contributions to anyone in the company, documented, and provide migration paths if necessary. Our decisions are clearly and publicly communicated for everyone to understand our reasoning. We want to make it simple for everyone to benefit from and work on Sourcegraph’s developer experience.

--- a/content/direction/enablement/dev-experience/index.md
+++ b/content/direction/enablement/dev-experience/index.md
@@ -1,6 +1,6 @@
 # Developer experience direction
 
-This page outlines the vision, strategy, and goals of the [Developer experience team](../../../engineering/enablement/developer-experience/index.md).
+This page outlines the vision, strategy, and goals of the [Developer experience team](../../../engineering/enablement/dev-experience/index.md).
 
 ## Mission
 

--- a/content/direction/enablement/dev-experience/index.md
+++ b/content/direction/enablement/dev-experience/index.md
@@ -1,6 +1,6 @@
-# Developer experience direction
+# Developer Experience team direction
 
-This page outlines the vision, strategy, and goals of the [Developer experience team](../../../engineering/enablement/dev-experience/index.md).
+This page outlines the vision, strategy, and goals of the [Developer Experience team](../../../engineering/enablement/dev-experience/index.md).
 
 ## Mission
 

--- a/content/direction/enablement/dev-experience/index.md
+++ b/content/direction/enablement/dev-experience/index.md
@@ -56,10 +56,10 @@ Our high-level roadmap is blurry; we aim to work on the most impactful problems.
   - Tactic: Evaluate and decide if we continue with OkayHQ.
   - OKR: Those metrics are sufficient to corroborate existing DX hypotheses (or invalidate them).
 
-## Next (6-12 months)
+### Next (6-12 months)
 
 We are currently drafting opportunities and projects we plan to explore over next year in our [strategy draft document](https://docs.google.com/document/d/1IrIe7NUEr_0RscvWDuvtjAKFRIp4agpc_in1_6T5WBQ/edit#).
 
-## Later
+### Later
 
 We are currently drafting future bets in our [strategy draft document](https://docs.google.com/document/d/1IrIe7NUEr_0RscvWDuvtjAKFRIp4agpc_in1_6T5WBQ/edit#).

--- a/content/direction/enablement/developer-experience/index.md
+++ b/content/direction/enablement/developer-experience/index.md
@@ -1,0 +1,65 @@
+# Developer experience direction
+
+This page outlines the vision, strategy, and goals of the [Developer experience team](../../../engineering/enablement/developer-experience/index.md).
+
+## Mission
+
+Make it so that every developer feels empowered to be productive in contributing to the Sourcegraph application.
+
+## Vision
+
+We want teammates and contributors to be delighted by the experience of working on Sourcegraph — to have a feeling so strong that it becomes a key contributor to their happiness and an asset in our recruitment of new teammates.
+
+What is a delightful experience for developers exactly? While it's different for everyone, these experiences all share common traits: reproducibility, predictability, short feedback loop, previewing changes.
+
+Engineers should be able to spend their time solving problems that matter to them and focus on their goals.
+
+## Guiding principles
+
+We inherit Sourcegraph's [engineering principles and practices](../../principles-and-practices.md) and [Enablement org's principles and practices](../../developer-insights/index.md#principles-and-practices). In addition, the following principles guide the work we do in dev experience. Sometimes adhering to one causes us to compromise another, but they guide our decisions on what matters.
+
+- **We don't own the developer experience at Sourcegraph – we simply focus on it.** Sourcegraph engineers own the developer experience as a collective.
+- **We ship open products.** Our products are open to contributions to anyone in the company, documented, and provide migration paths if necessary. Our decisions are clearly and publicly communicated for everyone to understand our reasoning. We want to make it simple for everyone to benefit from and work on Sourcegraph’s developer experience.
+- **We bandage first, then plan for surgery.** Fix local problems first, then generalize if and only if it makes sense.
+  - What we cannot take upon right now, we make its status clear and provide stewardship.
+    - We should never refuse to fix a "now" problem in favour of a long-term solution, only to cancel the fix because the priorities changed in between. More than not addressing the issue at hand, it prevents our users from fixing the problem for themselves in the meantime.
+  - We deliver small and iterative  experiments and collect feedback. We communicate regularly on their status to enable others to provide inputs. We should reap the benefits of what we work on as we go, not at the end.
+- **We listen and observe.** Our users often know best what's immediately good for them because they are the ones experiencing it every day.
+We are not a dependency. We actively seek to avoid blocking product teams. We focus on improving and expediting progress, not being critical to it.
+
+## Measuring success
+
+To help us understand if we’re going in the right direction and to measure the progress we’re making, we want to use the following indicators:
+
+- 🎯 Increased developer satisfaction in the surveys, tangible examples in the happiness logs
+- 🎯 TTFPR: time to first PR for new engineers (10th Pr, etc.)
+- 🎯 We maintain or improve our NPS rating in Q3 & Q4 / or aim to keep it above 60 as a baseline.
+- 🎯 Total number of contributors to the DX ecosystem
+- 🎯 Mean Time To Change
+
+## Roadmap
+
+### Now (3 months)
+
+Our high-level roadmap is blurry; we aim to work on the most impactful problems.
+
+- **Make the CI pipeline reliable, understandable, and actionable in case of failures.**
+  - Tactic: Get back to Green and disable flakey tests.
+  - Tactic: Lower the entry barrier to interacting with CI: pare down pipeline complexity, papercuts, improve documentation and tooling, pipeline output investment, etc.
+  - OKR1: 95% green builds on main
+  - OKR2: decrease mean build time for pull requests
+- **Most obvious and immediate pain points impacting the onboarding are fixed.**
+  - Tactic: Groom arbitrary list, focus on low hanging fruits,actively contribute to sg setup effort.
+  - OKR: Improved NPS, Time To Tenth PR
+- **DX is observable**
+  - Tactic: Find reliable metrics that we can start monitoring with low prior engineering efforts.
+  - Tactic: Evaluate and decide if we continue with OkayHQ.
+  - OKR: Those metrics are sufficient to corroborate existing DX hypotheses (or invalidate them).
+
+## Next (6-12 months)
+
+We are currently drafting opportunities and projects we plan to explore over next year in our [strategy draft document](https://docs.google.com/document/d/1IrIe7NUEr_0RscvWDuvtjAKFRIp4agpc_in1_6T5WBQ/edit#).
+
+## Later
+
+We are currently drafting future bets in our [strategy draft document](https://docs.google.com/document/d/1IrIe7NUEr_0RscvWDuvtjAKFRIp4agpc_in1_6T5WBQ/edit#).

--- a/content/direction/enablement/developer-experience/index.md
+++ b/content/direction/enablement/developer-experience/index.md
@@ -23,9 +23,9 @@ We inherit Sourcegraph's [engineering principles and practices](../../principles
 - **We bandage first, then plan for surgery.** Fix local problems first, then generalize if and only if it makes sense.
   - What we cannot take upon right now, we make its status clear and provide stewardship.
     - We should never refuse to fix a "now" problem in favour of a long-term solution, only to cancel the fix because the priorities changed in between. More than not addressing the issue at hand, it prevents our users from fixing the problem for themselves in the meantime.
-  - We deliver small and iterative  experiments and collect feedback. We communicate regularly on their status to enable others to provide inputs. We should reap the benefits of what we work on as we go, not at the end.
+  - We deliver small and iterative experiments and collect feedback. We communicate regularly on their status to enable others to provide inputs. We should reap the benefits of what we work on as we go, not at the end.
 - **We listen and observe.** Our users often know best what's immediately good for them because they are the ones experiencing it every day.
-We are not a dependency. We actively seek to avoid blocking product teams. We focus on improving and expediting progress, not being critical to it.
+  We are not a dependency. We actively seek to avoid blocking product teams. We focus on improving and expediting progress, not being critical to it.
 
 ## Measuring success
 

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -1,22 +1,18 @@
 # Dev Experience team
 
-The Dev Experience team (part of the [Enablement](../index.md) org) TODO complete intro.
+The Dev Experience team (part of the [Enablement](../index.md) org) is a team focused on improving the developer experience of Sourcegraph.
 
 ## Members
 
-- [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) (acting [Product Manager](../../../product/roles/index.md#product-manager))
+- Taylor Sperry (Technical [Product Manager](../../../product/roles/index.md#product-manager))
 - [Patrick Dubroy](../../../company/team/index.md#patrick-dubroy-he-him) (acting [Engineering Manager](../../roles.md#engineering-manager))
   - [Asdine El Hrychy](../../../company/team/index.md#asdine-el-hrychy)
   - [JH Chabran](../../../company/team/index.md#jh-chabran-he-him)
   - [Robert Lin](../../../company/team/index.md#robert-lin)
 
-## Mission
+## Direction
 
-TODO
-
-## Vision
-
-TODO
+See our [Developer experience direction](../../../direction/enablement/developer-experience/index.md) to learn about our vission, mission, guiding principles, and overall direction.
 
 ## Responsibilities
 
@@ -27,10 +23,6 @@ TODO
 - #dev-experience channel or @dev-experience-team in Slack.
 - [team/dev-experience](https://github.com/sourcegraph/sourcegraph/labels/team%2Fdev-experience) label and [@sourcegraph/dev-experience](https://github.com/orgs/sourcegraph/teams/dev-experience) team on GitHub.
 
-## Goals
-
-TODO
-
 ## Growth plan
 
 TODO
@@ -39,10 +31,10 @@ TODO
 
 TODO
 
-## Principles
-
-We inherit Sourcegraph's [engineering principles and practices](../../principles-and-practices.md) and [Enablement org's principles and practices](../../developer-insights/index.md#principles-and-practices). In addition, we have a few processes and practices specific to our team as detailed below.
-
 ## Processes
 
-TODO
+*This section is a work in progress.*
+
+- [Planning board](https://github.com/orgs/sourcegraph/projects/212)
+- [Team sync](https://docs.google.com/document/d/1Lm6GT-F4v9OTa5wxa1-AKLtNwlDkORbbeGjqVd9kWPg/edit)
+- [Newsletter](https://docs.google.com/document/d/1O5iUZ3cQ4c7sGhlFHDW2MXpfgLzIPFszN1jgXFUKNRo/edit#)

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -33,7 +33,7 @@ TODO
 
 ## Processes
 
-*This section is a work in progress.*
+_This section is a work in progress._
 
 - [Planning board](https://github.com/orgs/sourcegraph/projects/212)
 - [Team sync](https://docs.google.com/document/d/1Lm6GT-F4v9OTa5wxa1-AKLtNwlDkORbbeGjqVd9kWPg/edit)

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -22,6 +22,7 @@ TODO
 
 - #dev-experience channel or @dev-experience-team in Slack.
 - [team/dev-experience](https://github.com/sourcegraph/sourcegraph/labels/team%2Fdev-experience) label and [@sourcegraph/dev-experience](https://github.com/orgs/sourcegraph/teams/dev-experience) team on GitHub.
+  - We also monitor and track issues with the [dx](https://github.com/sourcegraph/sourcegraph/labels/dx) label.
 
 ## Growth plan
 
@@ -35,6 +36,8 @@ TODO
 
 _This section is a work in progress._
 
+- Internal team channel in #dev-experience-internal
 - [Planning board](https://github.com/orgs/sourcegraph/projects/212)
 - [Team sync](https://docs.google.com/document/d/1Lm6GT-F4v9OTa5wxa1-AKLtNwlDkORbbeGjqVd9kWPg/edit)
 - [Newsletter](https://docs.google.com/document/d/1O5iUZ3cQ4c7sGhlFHDW2MXpfgLzIPFszN1jgXFUKNRo/edit#)
+- Daily updates via [Geekbot](https://app.geekbot.com/dashboard/standup/90468/view/insights) to #dev-experience-updates

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -12,7 +12,7 @@ The Developer Experience team (part of the [Enablement](../index.md) org) is a t
 
 ## Direction
 
-See our [Developer experience direction](../../../direction/enablement/dev-experience/index.md) to learn about our vission, mission, guiding principles, and overall direction.
+See the [Developer Experience team direction](../../../direction/enablement/dev-experience/index.md) to learn about our vission, mission, guiding principles, and overall direction.
 
 ## Responsibilities
 

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -12,7 +12,7 @@ The Dev Experience team (part of the [Enablement](../index.md) org) is a team fo
 
 ## Direction
 
-See our [Developer experience direction](../../../direction/enablement/developer-experience/index.md) to learn about our vission, mission, guiding principles, and overall direction.
+See our [Developer experience direction](../../../direction/enablement/dev-experience/index.md) to learn about our vission, mission, guiding principles, and overall direction.
 
 ## Responsibilities
 

--- a/content/engineering/enablement/dev-experience/index.md
+++ b/content/engineering/enablement/dev-experience/index.md
@@ -1,6 +1,6 @@
-# Dev Experience team
+# Developer Experience team
 
-The Dev Experience team (part of the [Enablement](../index.md) org) is a team focused on improving the developer experience of Sourcegraph.
+The Developer Experience team (part of the [Enablement](../index.md) org) is a team focused on improving the developer experience of Sourcegraph.
 
 ## Members
 


### PR DESCRIPTION
This PR migrates most of the more finalized parts of the [Developer experience strategy](https://docs.google.com/document/d/1IrIe7NUEr_0RscvWDuvtjAKFRIp4agpc_in1_6T5WBQ/edit#) to the handbook, with most of the direction parts going into [Enablement direction](https://handbook.sourcegraph.com/direction/enablement) parts of the handbook (as I've seen [Delivery do](https://handbook.sourcegraph.com/direction/enablement/delivery))

Might not be 100% aligned with a template if there is one but figured it's good to get this in here sooner rather than later :)

Also added quick links to things we've been using for processes, though I imagine this will be made more formal later on

- preview: [team page](https://deploy-preview-238--sourcegraph-handbook.netlify.app/engineering/enablement/dev-experience)
- preview: [team direction](https://deploy-preview-238--sourcegraph-handbook.netlify.app/direction/enablement/developer-experience)