### PR TITLE
Prevent redirect loops

### DIFF
--- a/src/scripts/getMovedPagesFromHistory.js
+++ b/src/scripts/getMovedPagesFromHistory.js
@@ -18,6 +18,14 @@ async function getMovedPagesFromHistory() {
       return { source, destination }
     })
     .filter(({ source, destination }) => destination.toLowerCase() !== source.toLowerCase())
+    // Make sure to filter out all redirects that lead to a destination that has ANOTHER redirect EARLIER in the list.
+    // Else it would create a redirect loop.
+    // This way, the top-most (most recent) entries win.
+    // Other redirect chains, that don't lead to loops, are fine.
+    .filter(({ destination }, index, list) => {
+      const otherIndex = list.findIndex(({ source }) => source === destination)
+      return otherIndex === -1 || otherIndex > index
+    })
 
   return movedFilesFromHistory
 }


### PR DESCRIPTION
`/ops/bizops` and `/bizops` were in a redirect loop as they had been moved back and forth in the history. This prevents such loops, favoring the most recent redirect as the new location and dropping older redirects for the destination.