### PR TITLE
exclude beta and experimental features from SLAs

### DIFF
--- a/content/support/index.md
+++ b/content/support/index.md
@@ -145,7 +145,7 @@ We rely mostly on our ethos to inform our decisions and actions, allowing for th
 
 ## SLAs
 
-Our default contractual service level agreeements (SLAs) are described below. Additionally, we have the following internal SLAs:
+Our default contractual service level agreeements (SLAs) are described below. The SLAs apply to generally available products and exclude [beta and experimental features](https://docs.sourcegraph.com/admin/beta_and_experimental_features). Additionally, we have the following internal SLAs:
 
 - We aim to respond to all customers on all issues within 1 hour between 9:00-0:00 UTC (2am-5pm PT) Monday-Friday (priority given to customers in our pre-sales process)
 - We aim to resolve all issues within an average of no more than one week.


### PR DESCRIPTION
@virginiaulrich @Joelkw - this is an optional add for clarity. I added the exclusion in the beta and experimental features page: https://docs.sourcegraph.com/admin/beta_and_experimental_features. If you like it, keep it (or edit it). If not, fine to remove my addition.