### PR TITLE
Move product principles to be with the rest

### DIFF
--- a/content/company/strategy/index.md
+++ b/content/company/strategy/index.md
@@ -48,6 +48,26 @@ Our [values](../values.md) are the principles and beliefs that help us achieve o
   - This entails designing for extensibility in our product (and documenting it more thoroughly) as a first-order priority.
 - Sourcegraph provides greater value the larger a software team. We are building not just for individual developers, but for development teams. We believe software development is increasingly a multiplayer game.
 
+Additionally, Sourcegraph is:
+
+- **A personal tool within a larger workflow**
+  Sourcegraph is a powerful yet personal tool that exists within a larger workflow. Design for familiar patterns with thoughtful defaults, while embracing personalization and adaptability.
+
+- **Made for everyone**
+  Our purpose is to make it so everyone can code. This demands we make Sourcegraph accessible and useful for all developers through universal, inclusive design.
+
+- **Gracefully manage complexity**
+  Sourcegraph supports complex product requirements, but also empowers users to manage this complexity for their individual needs.
+
+- **Code as content**
+  More time is spent reading than writing code. Elevate the craft of code as content.
+
+- **Trust is earned**
+  Sourcegraph is the source of truth, but this trust is earned. Accuracy, transparency, recency, and honesty together work to uphold this source of truth.
+
+- **Create momentum**
+  Help developers create and maintain flow. To do this, Sourcegraph must be fast in every way. We design purposefully to help users iterate and build momentum.
+
 ### Assumptions
 
 - Sufficiently good code search will be useful to every developer many times per day (on average). It may take a while to convert any specific person into a frequent code search power user, but it will happen eventually.

--- a/content/product/product_management/index.md
+++ b/content/product/product_management/index.md
@@ -14,11 +14,13 @@ This page contains information that is relevant for how to do well at your job a
 - [Feature rollout](rollout_process.md) - how we test, rollout and launch new features.
 - [Feature deprecation](deprecation_process.md) - how we deprecate features when necessary.
 
-### Strategy page updates
+### Strategy pages
 
-We use [strategy pages](../../company/strategy/index.md#per-area-strategy-pages) to communicate where each of our product teams is headed, for the areas of the product that they work on. Newly created teams should begin documenting the scope of their team as well as their mission, vision, and more by creating one of these pages as part of the process of forming.
+Sourcegraph has a top-level [strategy page](../../company/strategy/index.md) that describes at a high level where our product is headed and why. Everyone contributes to this page, and it's important to be familiar with its contents.
 
-All in-place product engineering teams should have their own strategy page, and should update it on a monthly cadence (at the same time the [PMM roadmap](https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) (internal only) is updated) by proposing a new pull request to update their content. Everyone on the team should be invited to contribute, and the update should be shared with important stakeholders. This helps us keep everyone aligned, and ensures we have a single source of truth for our product directions. The specific day of the month that the team updates the doc is up to the team internally to decide, the important part is that it is never more than a month out of date.
+We also use [per-area strategy pages](../../company/strategy/index.md#per-area-strategy-pages) to communicate where each of our product teams is headed, for the areas of the product that they work on. Newly created teams should begin documenting the scope of their team as well as their mission, vision, principles, and more by creating one of these pages as part of the process of forming.
+
+All product engineering teams should have their own strategy page, and should update it on a monthly cadence (at the same time the [PMM roadmap](https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) (internal only) is updated) by proposing a new pull request to update their content. Everyone on the team should be invited to contribute, and the update should be shared with important stakeholders. This helps us keep everyone aligned, and ensures we have a single source of truth for our product directions. The specific day of the month that the team updates the doc is up to the team internally to decide, the important part is that it is never more than a month out of date.
 
 ## Glossary
 
@@ -82,26 +84,6 @@ Our principles were [co-created](https://docs.google.com/document/d/1zRbtZR68ZIT
 - Engineers.
 - Marketing.
 - And other stakeholders involved in the design process.
-
-### Our principles
-
-- **A personal tool within a larger workflow**
-  Sourcegraph is a powerful yet personal tool that exists within a larger workflow. Design for familiar patterns with thoughtful defaults, while embracing personalization and adaptability.
-
-- **Made for everyone**
-  Our purpose is to make it so everyone can code. This demands we make Sourcegraph accessible and useful for all developers through universal, inclusive design.
-
-- **Gracefully manage complexity**
-  Sourcegraph supports complex product requirements, but also empowers users to manage this complexity for their individual needs.
-
-- **Code as content**
-  More time is spent reading than writing code. Elevate the craft of code as content.
-
-- **Trust is earned**
-  Sourcegraph is the source of truth, but this trust is earned. Accuracy, transparency, recency, and honesty together work to uphold this source of truth.
-
-- **Create momentum**
-  Help developers create and maintain flow. To do this, Sourcegraph must be fast in every way. We design purposefully to help users iterate and build momentum.
 
 ## Tools/Templates
 


### PR DESCRIPTION
We had similar product principles in two places, this takes the one from the product management handbook area and adds them along with the rest on the strategy page.