### PR TITLE
Onboarding Comments

### DIFF
--- a/content/product/onboarding/index.md
+++ b/content/product/onboarding/index.md
@@ -70,7 +70,7 @@ Remember:
 
 ### Get to know the product
 
-- Review [product resources](../index.md#resources)
+- Review [product references](../index.md#references)
 - Learn how the Customer Engineering team gives demos and talks about the product in the [product demo recording](https://drive.google.com/file/d/1idbCnce5MIvtAV0GOOwgB68zQJB2WmZ9/view).
 - Read about [search queries](https://docs.sourcegraph.com/code-search) and perform your first searches.
 - Work through the questions from the [Sales Onboarding Quiz](../../sales/onboarding/quiz.md) to make sure you understand key concepts. Feel free to skip any obvious answers and discuss any questions you have or knowledge gaps with your manager.


### PR DESCRIPTION
- There's no "Resources" section on the Product page. I'm guessing it's been changed to "References."
- Link to Demo videos broken.
- Should OKRs link [here](https://handbook.sourcegraph.com/company/goals) instead of to deprecated spreadsheet?
- Should Product documentation link [here](https://handbook.sourcegraph.com/engineering/product_documentation)? Link broken.
- Add https://handbook.sourcegraph.com/product/design/research/user-testing-com to UserTesting