### PR TITLE
Update/fix the instructions on running the handbook locally

### DIFF
--- a/content/editing/run-a-local-preview.md
+++ b/content/editing/run-a-local-preview.md
@@ -2,4 +2,4 @@
 
 > NOTE: This is optional.
 
-See the [handbook section](https://github.com/sourcegraph/about#handbook) in the repository README.
+See the [repository README](https://github.com/sourcegraph/handbook). 

--- a/content/editing/run-a-local-preview.md
+++ b/content/editing/run-a-local-preview.md
@@ -2,4 +2,4 @@
 
 > NOTE: This is optional.
 
-See the [repository README](https://github.com/sourcegraph/handbook). 
+See the [repository README](https://github.com/sourcegraph/handbook).


### PR DESCRIPTION
[These](https://github.com/sourcegraph/about#handbook) are now not as relevant as [these](https://github.com/sourcegraph/handbook)!