### PR TITLE
Convert a lot of HTML to Markdown

### DIFF
--- a/content/bizops/customer_data_policy.md
+++ b/content/bizops/customer_data_policy.md
@@ -28,7 +28,7 @@ This document explains how Sourcegraph handles user data and information.
 | Slack shared channels                                                         | ✔️                | ✔️            | Customer support channels and private messages are maintained indefinitely. See our full [Slack retention policy](../communication/team_chat.md#retention) for more information | All Sourcegraph teammates |
 | View full [list of sales tools](../sales/onboarding/index.md#getting-started) | ✔️                | ✔️            | Retain all outbound customer communication                                                                                                                                      | All Sourcegraph teammates |
 
-<b>\*For self-hosted, Sourcegraph can only view instance admin and opted-in users' contact information.</b>
+**For self-hosted, Sourcegraph can only view instance admin and opted-in users' contact information.**
 
 ## FAQs
 

--- a/content/bizops/customer_ops_tools.md
+++ b/content/bizops/customer_ops_tools.md
@@ -73,40 +73,32 @@ For additional color on how we use Salesforce at Sourcegraph, see this [page](..
 **_Key Salesforce Objects_**
 
 <table>
-  <tr>
-   <td><strong>Salesforce Object</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>Lead
-   </td>
-   <td>Leads are single individuals that have not been qualified, and therefore are not associated with an account or opportunity. In order for a lead to be converted into a contact, it must be associated with a specific account. A lead can only be converted into a contact, it cannot be both a lead and a contact.
-<p>
+<tr>
+<th>Salesforce Object</th>
+<th>Description</th>
+</tr>
+<tr>
+<td>Lead</td>
+<td>
+
+Leads are single individuals that have not been qualified, and therefore are not associated with an account or opportunity. In order for a lead to be converted into a contact, it must be associated with a specific account. A lead can only be converted into a contact, it cannot be both a lead and a contact.
 
 It is important to note that Salesforce functionality limits connecting lead data to accounts. The only way to transfer data associated with a lead to a specific account is to first convert the lead to an account and contact (with or without an opportunity).
 
-   </td>
-  </tr>
-  <tr>
-   <td>Contact
-   </td>
-   <td>Contacts are individuals associated with a particular account and, where possible, opportunity. Contacts can be added manually or converted from pre-existing leads. Contacts from each individual opportunity are aggregated at the account level.
-   </td>
-  </tr>
-  <tr>
-   <td>Account
-   </td>
-   <td>Accounts represent the ultimate parent organization of any set of related companies input into Salesforce. Accounts are created before opportunities and all opportunities must be associated with an account. By default, in Salesforce, lead objects are not associated with accounts. We utilize a custom automation which attempts to associate leads to the accounts they likely represent, but this automation does sometimes have errors.  
-   </td>
-  </tr>
-  <tr>
-   <td>Opportunity
-   </td>
-   <td>When a lead has revenue potential, it is converted into an opportunity. Opportunities can also be created manually, without first requiring the conversion of a lead by navigating to the contact and creating a new opportunity from the related opportunities list.
-   </td>
-  </tr>
+</td>
+</tr>
+<tr>
+  <td>Contact</td>
+  <td>Contacts are individuals associated with a particular account and, where possible, opportunity. Contacts can be added manually or converted from pre-existing leads. Contacts from each individual opportunity are aggregated at the account level.</td>
+</tr>
+<tr>
+  <td>Account</td>
+  <td>Accounts represent the ultimate parent organization of any set of related companies input into Salesforce. Accounts are created before opportunities and all opportunities must be associated with an account. By default, in Salesforce, lead objects are not associated with accounts. We utilize a custom automation which attempts to associate leads to the accounts they likely represent, but this automation does sometimes have errors.</td>
+</tr>
+<tr>
+  <td>Opportunity</td>
+  <td>When a lead has revenue potential, it is converted into an opportunity. Opportunities can also be created manually, without first requiring the conversion of a lead by navigating to the contact and creating a new opportunity from the related opportunities list.</td>
+</tr>
 </table>
 
 **Attribution Reporting**

--- a/content/communication/content_guidelines/actionable_language.md
+++ b/content/communication/content_guidelines/actionable_language.md
@@ -18,16 +18,18 @@ Some specific guidelines for writing headings and subheadings:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Get started with code search</li>
-</ul>
+
+##### Yes
+
+- Get started with code search
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Get Started with Code Search.</li>
-</ul>
+
+##### No
+
+- Get Started with Code Search.
+
 </div>
 </div>
 
@@ -37,16 +39,18 @@ For labels and microcopy, prioritize short and actionable content by removing ar
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Install now</li>
-</ul>
+
+##### Yes
+
+- Install now
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Install this extension</li>
-</ul>
+
+##### No
+
+- Install this extension
+
 </div>
 </div>
 
@@ -62,16 +66,18 @@ Start sentences with strong verbs that help users understand what they will do. 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Add repositories from your code host.</li>
-</ul>
+
+##### Yes
+
+- Add repositories from your code host.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Repositories from your code host will appear here after you add them.</li>
-</ul>
+
+##### No
+
+- Repositories from your code host will appear here after you add them.
+
 </div>
 </div>
 
@@ -81,16 +87,18 @@ Look for combinations of verbs and nouns that can be replaced by a single verb.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li><strong>Search</strong> for your repo to get started.</li>
-</ul>
+
+##### Yes
+
+- **Search** for your repo to get started.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li><strong>Make a search</strong> for your repo to get started.</li>
-</ul>
+
+##### No
+
+- **Make a search** for your repo to get started.
+
 </div>
 </div>
 
@@ -100,16 +108,18 @@ Give users confidence about what they should do.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Add your repos from your code host and start searching code.</li>
-</ul>
+
+##### Yes
+
+- Add your repos from your code host and start searching code.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Add your repos from your code host and you can start searching code.</li>
-</ul>
+
+##### No
+
+- Add your repos from your code host and you can start searching code.
+
 </div>
 </div>
 
@@ -121,16 +131,18 @@ Always write button labels in sentence case.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Create new batch change</li>
-</ul>
+
+##### Yes
+
+- Create new batch change
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Create New Batch Change</li>
-</ul>
+
+##### No
+
+- Create New Batch Change
+
 </div>
 </div>
 
@@ -140,18 +152,20 @@ When buttons enable user actions, the formula is `verb` + `noun`.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Add repo</li>
-<li>Explore extensions</li>
-</ul>
+
+##### Yes
+
+- Add repo
+- Explore extensions
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Add</li>
-<li>Explore</li>
-</ul>
+
+##### No
+
+- Add
+- Explore
+
 </div>
 </div>
 
@@ -161,16 +175,18 @@ When buttons are used as calls to action in confirmations, the formula `verb` + 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Discard changes? <strong>Cancel / Discard</strong></li>
-</ul>
+
+##### Yes
+
+- Discard changes? **Cancel / Discard**
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Discard changes? <strong>No / Yes</strong></li>
-</ul>
+
+##### No
+
+- Discard changes? **No / Yes**
+
 </div>
 </div>
 
@@ -184,16 +200,18 @@ The length of a button label when the button’s purpose is conversion isn’t u
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Start searching code now</li>
-</ul>
+
+##### Yes
+
+- Start searching code now
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Try now</li>
-</ul>
+
+##### No
+
+- Try now
+
 </div>
 </div>
 
@@ -207,16 +225,15 @@ Buttons can also be an opportunity to use microcopy to create a more positive ex
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>I tried, I’m stuck, I need help</li>
-</ul>
+
+##### Yes
+
+- I tried, I’m stuck, I need help
 
 Instead of <sup>\*</sup>
 
-<ul>
-<li>Get help</li>
-</ul>
+- Get help
+
 </div>
 </div>
 
@@ -232,18 +249,20 @@ Links should provide information about what to expect about the associated actio
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>See <a href="#_" aria-disabled="true">how to add repositories</a>.</li>
-</ul>
+
+##### Yes
+
+- See <a href="#_" aria-disabled="true">how to add repositories</a>.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Want to add repositories? <a href="#_" aria-disabled="true">Click here</a>.</li>
-<li>See <a href="#_" aria-disabled="true">this page</a> for how to add repositories.</li>
-<li>See <a href="#_" aria-disabled="true">documentation</a> for how to add repositories.</li>
-</ul>
+
+##### No
+
+- Want to add repositories? <a href="#_" aria-disabled="true">Click here</a>.
+- See <a href="#_" aria-disabled="true">this page</a> for how to add repositories.
+- See <a href="#_" aria-disabled="true">documentation</a> for how to add repositories.
+
 </div>
 </div>
 
@@ -253,16 +272,18 @@ Links in full sentences shouldn’t link the whole sentence, but instead only th
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Learn how to <a href="#_" aria-disabled="true">create your first batch change</a>.</li>
-</ul>
+
+##### Yes
+
+- Learn how to <a href="#_" aria-disabled="true">create your first batch change</a>.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li><a href="#_" aria-disabled="true">Learn how to create your first batch change</a>.</li>
-</ul>
+
+##### No
+
+- <a href="#_" aria-disabled="true">Learn how to create your first batch change</a>.
+
 </div>
 </div>
 
@@ -272,17 +293,19 @@ Links that aren’t in full sentences should be treated similarly to buttons, an
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li><a href="#_" aria-disabled="true">View all search options</a></li>
-<li><a href="#_" aria-disabled="true">Forgot password?</a></li>
-</ul>
+
+##### Yes
+
+- <a href="#_" aria-disabled="true">View all search options</a>
+- <a href="#_" aria-disabled="true">Forgot password?</a>
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li><a href="#_" aria-disabled="true">View all search options.</a>.</li>
-</ul>
+
+##### No
+
+- <a href="#_" aria-disabled="true">View all search options.</a>.
+
 </div>
 </div>
 
@@ -302,16 +325,18 @@ Keep it conversational. Adjusting the tone of voice to be more formal rather tha
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Password must contain at least 12 characters</li>
-</ul>
+
+##### Yes
+
+- Password must contain at least 12 characters
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Password format is invalid (minimum 12 characters)</li>
-</ul>
+
+##### No
+
+- Password format is invalid (minimum 12 characters)
+
 </div>
 </div>
 
@@ -321,16 +346,18 @@ Again, keep it conversational. We’d never say “error!” in conversation if 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Sorry, we couldn’t save your changes. Try again?</li>
-</ul>
+
+##### Yes
+
+- Sorry, we couldn’t save your changes. Try again?
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Failed to save changes.</li>
-</ul>
+
+##### No
+
+- Failed to save changes.
+
 </div>
 </div>
 
@@ -354,16 +381,18 @@ Confirmation message **titles** should:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Discard unsaved changes?</li>
-</ul>
+
+##### Yes
+
+- Discard unsaved changes?
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Discard?</li>
-</ul>
+
+##### No
+
+- Discard?
+
 </div>
 </div>
 
@@ -375,16 +404,18 @@ Confirmation message **body content** should:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>This can’t be undone</li>
-</ul>
+
+##### Yes
+
+- This can’t be undone
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>If you discard changes, your list will remain unchanged.</li>
-</ul>
+
+##### No
+
+- If you discard changes, your list will remain unchanged.
+
 </div>
 </div>
 
@@ -394,16 +425,18 @@ Confirmation message **calls to action** should:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Discard changes? <strong>Cancel / Discard</strong></li>
-</ul>
+
+##### Yes
+
+- Discard changes? **Cancel / Discard**
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Discard changes? <strong>No / Yes</strong></li>
-</ul>
+
+##### No
+
+- Discard changes? **No / Yes**
+
 </div>
 </div>
 
@@ -427,16 +460,18 @@ Imagine if we let people share a book recommendation. When the recommendation is
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Your new code monitor is now watching for events.</li>
-</ul>
+
+##### Yes
+
+- Your new code monitor is now watching for events.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Code monitor successfully created.</li>
-</ul>
+
+##### No
+
+- Code monitor successfully created.
+
 </div>
 </div>
 
@@ -454,16 +489,18 @@ Avoid using negative words or phrases. Empty states are transitional and reveal 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Your saved searches will appear here</li>
-</ul>
+
+##### Yes
+
+- Your saved searches will appear here
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Oops, you have no saved searches</li>
-</ul>
+
+##### No
+
+- Oops, you have no saved searches
+
 </div>
 </div>
 
@@ -473,16 +510,18 @@ If relevant, tell users exactly how to start using a feature and provide an acti
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Your saved searches will appear here. <a href="#_" aria-disabled="true">Create your first saved search!</a></li>
-</ul>
+
+##### Yes
+
+- Your saved searches will appear here. <a href="#_" aria-disabled="true">Create your first saved search!</a>
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>No saved searches</li>
-</ul>
+
+##### No
+
+- No saved searches
+
 </div>
 </div>
 
@@ -508,10 +547,11 @@ When the response to an input field might be from a wide range of options, place
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Search by language, repo, or organization</li>
-</ul>
+
+##### Yes
+
+- Search by language, repo, or organization
+
 </div>
 </div>
 
@@ -521,10 +561,11 @@ Sometimes, an example will make it easier for users to understand how to answer 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Such as “repo:sourcegraph/sourcegraph”</li>
-</ul>
+
+##### Yes
+
+- Such as “repo:sourcegraph/sourcegraph”
+
 </div>
 </div>
 
@@ -544,15 +585,17 @@ This is particularly important for helper messages on input fields.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>8–12 characters</li>
-</ul>
+
+##### Yes
+
+- 8–12 characters
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Password must be between 8–12 characters</li>
-</ul>
+
+##### No
+
+- Password must be between 8–12 characters
+
 </div>
 </div>

--- a/content/communication/content_guidelines/style_and_mechanics.md
+++ b/content/communication/content_guidelines/style_and_mechanics.md
@@ -14,24 +14,26 @@ Avoid abbreviations, acronyms, latinisms, and jargon when possible. Use complete
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>for example</li>
-<li>that is</li>
-<li>as opposed to</li>
-<li>through</li>
-<li>Salesforce</li>
-</ul>
+
+##### Yes
+
+- for example
+- that is
+- as opposed to
+- through
+- Salesforce
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>e.g.</li>
-<li>i.e.</li>
-<li>v.</li>
-<li>via</li>
-<li>SF</li>
-</ul>
+
+##### No
+
+- e.g.
+- i.e.
+- v.
+- via
+- SF
+
 </div>
 </div>
 
@@ -51,16 +53,18 @@ Generally, use active voice and avoid passive voice. In active voice, the subjec
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Added repository.</li>
-</ul>
+
+##### Yes
+
+- Added repository.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Repository was added.</li>
-</ul>
+
+##### No
+
+- Repository was added.
+
 </div>
 </div>
 
@@ -68,16 +72,18 @@ Use passive voice when you don’t want to assign responsibility for an action. 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Your access token was invalid.</li>
-</ul>
+
+##### Yes
+
+- Your access token was invalid.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Invalid access token.</li>
-</ul>
+
+##### No
+
+- Invalid access token.
+
 </div>
 </div>
 
@@ -89,16 +95,18 @@ Use present tense to describe the result of actions.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Batch change created</li>
-</ul>
+
+##### Yes
+
+- Batch change created
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Batch change has been created</li>
-</ul>
+
+##### No
+
+- Batch change has been created
+
 </div>
 </div>
 
@@ -132,18 +140,20 @@ Our voice is conversational. When we’re talking, we connect words with article
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Create a new batch change</li>
-<li>Save your changes</li>
-</ul>
+
+##### Yes
+
+- Create a new batch change
+- Save your changes
+
 </div>
 <div class="item no">
-<h5>When necessary</h5>
-<ul>
-<li>Create batch change</li>
-<li>Save changes</li>
-</ul>
+
+##### When necessary
+
+- Create batch change
+- Save changes
+
 </div>
 </div>
 
@@ -151,16 +161,18 @@ Write without rigidity.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Create an account to manage extensions.</li>
-</ul>
+
+##### Yes
+
+- Create an account to manage extensions.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>An account is required to manage extensions.</li>
-</ul>
+
+##### No
+
+- An account is required to manage extensions.
+
 </div>
 </div>
 
@@ -170,16 +182,18 @@ Avoid any instructions or language that requires the user to see the layout or d
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Choose a repository group.</li>
-</ul>
+
+##### Yes
+
+- Choose a repository group.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Choose a repository group at the bottom right of this page.</li>
-</ul>
+
+##### No
+
+- Choose a repository group at the bottom right of this page.
+
 </div>
 </div>
 
@@ -191,22 +205,24 @@ Avoid any instructions or language that requires the user to see the layout or d
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>30+ results</li>
-<li>Last updated two days ago</li>
-<li>Only 5% of developers prefer working in an office.</li>
-<li>More than 6 out of 10 software professionals reported a significant increase...</li>
-</ul>
+
+##### Yes
+
+- 30+ results
+- Last updated two days ago
+- Only 5% of developers prefer working in an office.
+- More than 6 out of 10 software professionals reported a significant increase...
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Thirty or more results</li>
-<li>Last updated 2 days ago</li>
-<li>Only five % of developers prefer working in an office.</li>
-<li>More than six out of ten software professionals reported a significant increase...</li>
-</ul>
+
+##### No
+
+- Thirty or more results
+- Last updated 2 days ago
+- Only five % of developers prefer working in an office.
+- More than six out of ten software professionals reported a significant increase...
+
 </div>
 </div>
 
@@ -214,11 +230,12 @@ Numbers over three digits get commas.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>144</li>
-<li>1,200</li>
-</ul>
+
+##### Yes
+
+- 144
+- 1,200
+
 </div>
 </div>
 
@@ -228,12 +245,13 @@ Spell out the day of the week and the month whenever possible. Abbreviate when s
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Thursday, April 16</li>
-<li>April 16</li>
-<li>Apr 16</li>
-</ul>
+
+##### Yes
+
+- Thursday, April 16
+- April 16
+- Apr 16
+
 </div>
 </div>
 
@@ -241,15 +259,16 @@ When possible, use natural language to describe dates.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Today</li>
-<li>Yesterday</li>
-<li>Tomorrow</li>
-<li>This week</li>
-<li>Next week</li>
-<li>Two weeks from now</li>
-</ul>
+
+##### Yes
+
+- Today
+- Yesterday
+- Tomorrow
+- This week
+- Next week
+- Two weeks from now
+
 </div>
 </div>
 
@@ -257,17 +276,19 @@ When date is written in numerals, the standard format is `YYYY-MM-DD`.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>2020-09-08</li>
-</ul>
+
+##### Yes
+
+- 2020-09-08
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>08.09.2020</li>
-<li>08-09-2020</li>
-</ul>
+
+##### No
+
+- 08.09.2020
+- 08-09-2020
+
 </div>
 </div>
 
@@ -277,16 +298,18 @@ Use the % symbol instead of spelling out “percent.”
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>2%</li>
-</ul>
+
+##### Yes
+
+- 2%
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Two percent</li>
-</ul>
+
+##### No
+
+- Two percent
+
 </div>
 </div>
 
@@ -296,10 +319,11 @@ Use an en dash (–) to indicate a range or span of numbers. Do not use spaces b
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Viewing results 100–150</li>
-</ul>
+
+##### Yes
+
+- Viewing results 100–150
+
 </div>
 </div>
 
@@ -311,22 +335,24 @@ When writing about US currency, use the dollar sign ($) before the amount. Prefe
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>$10</li>
-<li>$42</li>
-<li>$1,500</li>
-<li>$149.99</li>
-</ul>
+
+##### Yes
+
+- $10
+- $42
+- $1,500
+- $149.99
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>$10.00</li>
-<li>$ 42</li>
-<li>$1500</li>
-<li>$149,99</li>
-</ul>
+
+##### No
+
+- $10.00
+- $ 42
+- $1500
+- $149,99
+
 </div>
 </div>
 
@@ -334,18 +360,20 @@ When writing about monthly pricing, follow the convention: $0/mo. Do not use spa
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>$150/mo</li>
-</ul>
+
+##### Yes
+
+- $150/mo
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>$150 / month</li>
-<li>$150/month</li>
-<li>$150/pm</li>
-</ul>
+
+##### No
+
+- $150 / month
+- $150/month
+- $150/pm
+
 </div>
 </div>
 
@@ -353,39 +381,43 @@ Use shorthand suffixes for shortening numbers in the thousands (`k`), millions (
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>$100b</li>
-</ul>
+
+##### Yes
+
+- $100b
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>$100,000</li>
-<li>$100B</li>
-<li>$100Bn</li>
-<li>$100 billion</li>
-</ul>
+
+##### No
+
+- $100,000
+- $100B
+- $100Bn
+- $100 billion
+
 </div>
 </div>
 
 ### Telephone numbers
 
-Use the country code, prefixed with `+`, without a space. Use spaces between sets of numbers for readability. The number of digits in each set of numbers may <a href="https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers" target="_blank">differ by country</a>.
+Use the country code, prefixed with `+`, without a space. Use spaces between sets of numbers for readability. The number of digits in each set of numbers may [differ by country](https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers).
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>+1 123 456 7890</li>
-</ul>
+
+##### Yes
+
+- +1 123 456 7890
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>123 456 870</li>
-<li>1-123-456-789</li>
-</ul>
+
+##### No
+
+- 123 456 870
+- 1-123-456-789
+
 </div>
 </div>
 
@@ -395,18 +427,20 @@ When writing about a time of the day, use numerals and lowercase am or pm, with 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>5 pm</li>
-<li>8:30 pm</li>
-</ul>
+
+##### Yes
+
+- 5 pm
+- 8:30 pm
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>5pm</li>
-<li>8:30PM</li>
-</ul>
+
+##### No
+
+- 5pm
+- 8:30PM
+
 </div>
 </div>
 
@@ -414,11 +448,12 @@ Use an en dash (–) between times to indicate a time period. Don’t insert spa
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>8 am–12 pm</li>
-<li>6:30 am–18:00 pm</li>
-</ul>
+
+##### Yes
+
+- 8 am–12 pm
+- 6:30 am–18:00 pm
+
 </div>
 </div>
 
@@ -426,11 +461,12 @@ When referring to an amount of time, use numerals and the full word, with a spac
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Saved 20 minutes ago</li>
-<li>30 seconds ago</li>
-</ul>
+
+##### Yes
+
+- Saved 20 minutes ago
+- 30 seconds ago
+
 </div>
 </div>
 
@@ -446,12 +482,13 @@ In Markdown content in our handbook you don't need to worry about this rule: dum
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>This batch change’s results are now available</li>
-<li>This batch change is Jen’s favourite</li>
-<li>Chris’s favourite batch change</li>
-</ul>
+
+##### Yes
+
+- This batch change’s results are now available
+- This batch change is Jen’s favourite
+- Chris’s favourite batch change
+
 </div>
 </div>
 
@@ -461,17 +498,16 @@ Use a colon to offset a list.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Saved searches support three filters: diffs, commits, and repositories.</li>
-</ul>
+
+##### Yes
+
+- Saved searches support three filters: diffs, commits, and repositories.
 
 When a list begins with an interface label, capitalize the first word of the list.
 
-<ul>
 <li>
 Supported filters: Diffs, commits, and repositories.</li>
-</ul>
+
 </div>
 </div>
 
@@ -481,16 +517,18 @@ Prefer the Oxford or serial comma when writing a list.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Saved searches support three filters: diffs, commits, and repositories.</li>
-</ul>
+
+##### Yes
+
+- Saved searches support three filters: diffs, commits, and repositories.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Saved searches support three filters: diffs, commits and repositories</li>
-</ul>
+
+##### No
+
+- Saved searches support three filters: diffs, commits and repositories
+
 </div>
 </div>
 
@@ -500,17 +538,19 @@ Use a hyphen (-) without spaces before and after to link words into a single phr
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
+
+##### Yes
+
 <li>Our short-term plan is to...
 </li>
-</ul>
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>In the short-term, we will work on...</li>
-</ul>
+
+##### No
+
+- In the short-term, we will work on...
+
 </div>
 </div>
 
@@ -518,10 +558,11 @@ Use an en dash (–) to indicate a [range or span](#ranges-and-spans), without s
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>2–6 possible results</li>
-</ul>
+
+##### Yes
+
+- 2–6 possible results
+
 </div>
 </div>
 
@@ -529,10 +570,11 @@ Use an em (—) dash without spaces to separate clauses in paragraph copy.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>This new feature—a first in advanced workflow tooling—will empower developers around the world.</li>
-</ul>
+
+##### Yes
+
+- This new feature—a first in advanced workflow tooling—will empower developers around the world.
+
 </div>
 </div>
 
@@ -544,16 +586,18 @@ When ellipses are used to clip a line of copy, clip after at least 2 characters.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Provides basic code intelligence for Java usi…</li>
-</ul>
+
+##### Yes
+
+- Provides basic code intelligence for Java usi…
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Provides basic code intelligence for Java u…</li>
-</ul>
+
+##### No
+
+- Provides basic code intelligence for Java u…
+
 </div>
 </div>
 
@@ -563,16 +607,18 @@ Use periods in complete sentences. Don’t use periods in headlines or labels. P
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Updated to only show included filters (diffs, commits).</li>
-</ul>
+
+##### Yes
+
+- Updated to only show included filters (diffs, commits).
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Updated to only show included filters (diffs, commits.)</li>
-</ul>
+
+##### No
+
+- Updated to only show included filters (diffs, commits.)
+
 </div>
 </div>
 
@@ -584,18 +630,20 @@ In HTML, using `<q></q>` will automatically apply the correct quotation marks fo
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Add an insight to “Test Dashboard”</li>
-<li>“When quoting inside existing quotes, ‘Single quotes’ are the way to go”</li>
-</ul>
+
+##### Yes
+
+- Add an insight to “Test Dashboard”
+- “When quoting inside existing quotes, ‘Single quotes’ are the way to go”
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Add an insight to ‘Test Dashboard’</li>
-<li>“When quoting inside existing quotes, avoid “double quoting””</li>
-</ul>
+
+##### No
+
+- Add an insight to ‘Test Dashboard’
+- “When quoting inside existing quotes, avoid “double quoting””
+
 </div>
 </div>
 
@@ -606,18 +654,20 @@ In HTML, the easiest way to add the appropriate typographic quotation marks is t
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>‘Example’</li>
-<li>“Example Two”</li>
-</ul>
+
+##### Yes
+
+- ‘Example’
+- “Example Two”
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>'Example'</li>
-<li>"Example two"</li>
-</ul>
+
+##### No
+
+- 'Example'
+- "Example two"
+
 </div>
 </div>
 
@@ -627,16 +677,18 @@ Don't use spaces between two terms separated by a slash.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>tool/editor</li>
-</ul>
+
+##### Yes
+
+- tool/editor
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>tool / editor</li>
-</ul>
+
+##### No
+
+- tool / editor
+
 </div>
 </div>
 
@@ -648,16 +700,18 @@ When written in paragraph copy, write out country, state, and province names on 
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Now available in Winnipeg.</li>
-</ul>
+
+##### Yes
+
+- Now available in Winnipeg.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Now available in WPG.</li>
-</ul>
+
+##### No
+
+- Now available in WPG.
+
 </div>
 </div>
 
@@ -667,16 +721,18 @@ Use positive language rather than negative language. Positives are easier to rea
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Add a repo to start searching your code.</li>
-</ul>
+
+##### Yes
+
+- Add a repo to start searching your code.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>If you don’t add a repo, you won’t be able to search your code.</li>
-</ul>
+
+##### No
+
+- If you don’t add a repo, you won’t be able to search your code.
+
 </div>
 </div>
 
@@ -686,16 +742,18 @@ If a sentence begins with a negative word, the sentence’s implication can be m
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Remember to add a search filter</li>
-</ul>
+
+##### Yes
+
+- Remember to add a search filter
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Don’t forget to add a search filter</li>
-</ul>
+
+##### No
+
+- Don’t forget to add a search filter
+
 </div>
 </div>
 
@@ -705,16 +763,18 @@ A common error when writing questions is not constructing the sentence as a ques
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Why are search scopes useful?</li>
-</ul>
+
+##### Yes
+
+- Why are search scopes useful?
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Why search scopes are useful?</li>
-</ul>
+
+##### No
+
+- Why search scopes are useful?
+
 </div>
 </div>
 
@@ -738,16 +798,18 @@ You don't need to use the full name of the product each time you refer to it, bu
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Use the Phabricator integration to get Sourcegraph features in code review.</li>
-</ul>
+
+##### Yes
+
+- Use the Phabricator integration to get Sourcegraph features in code review.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Use the Sourcegraph Phabricator integration to get Sourcegraph features in code review <em>(sounds repetitive and stilted)</em>.</li>
-</ul>
+
+##### No
+
+- Use the Sourcegraph Phabricator integration to get Sourcegraph features in code review _(sounds repetitive and stilted)_.
+
 </div>
 </div>
 
@@ -755,17 +817,19 @@ Always title case our name. Don’t abbreviate or add a space to our name.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Sourcegraph</li>
-</ul>
+
+##### Yes
+
+- Sourcegraph
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>SG</li>
-<li>Source Graph</li>
-</ul>
+
+##### No
+
+- SG
+- Source Graph
+
 </div>
 </div>
 
@@ -784,22 +848,24 @@ List of product names:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>With Sourcegraph Universal Code Search you can...</li>
-<li>You can search across all your repositories with Universal Code Search.</li>
-<li>Companies benefit from a universal code search tool because...</li>
-<li>Sourcegraph Batch Changes are... Batch Changes allow you to...</li>
-<li>To create a batch change...</li>
-</ul>
+
+##### Yes
+
+- With Sourcegraph Universal Code Search you can...
+- You can search across all your repositories with Universal Code Search.
+- Companies benefit from a universal code search tool because...
+- Sourcegraph Batch Changes are... Batch Changes allow you to...
+- To create a batch change...
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Use Sourcegraph universal code search to...</li>
-<li>With code insights you can...</li>
-<li>Here’s how to use code intelligence.</li>
-</ul>
+
+##### No
+
+- Use Sourcegraph universal code search to...
+- With code insights you can...
+- Here’s how to use code intelligence.
+
 </div>
 </div>
 
@@ -809,20 +875,22 @@ We don't capitalize features or integrations.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Use the Phabricator integration to...</li>
-<li>Want to use this in your code review tool? Use Sourcegraph’s <a href="#_" aria-disabled="true">GitHub integration</a>.</li>
-<li>Here’s how to use code search.</li>
-</ul>
+
+##### Yes
+
+- Use the Phabricator integration to...
+- Want to use this in your code review tool? Use Sourcegraph’s <a href="#_" aria-disabled="true">GitHub integration</a>.
+- Here’s how to use code search.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Use the Phabricator Integration to... <em>(the capital “I” makes it into a proper noun, which implies it’s a product.”)</em></li>
-<li>Want to use this in your code review tool? Use <a href="#_" aria-disabled="true">Sourcegraph for GitHub</a>. <em>(Implies that “Sourcegraph for GitHub” is an official product name.)</em></li>
-<li>Here’s how to use Code Search.</li>
-</ul>
+
+##### No
+
+- Use the Phabricator Integration to... _(the capital “I” makes it into a proper noun, which implies it’s a product.”)_
+- Want to use this in your code review tool? Use <a href="#_" aria-disabled="true">Sourcegraph for GitHub</a>. _(Implies that “Sourcegraph for GitHub” is an official product name.)_
+- Here’s how to use Code Search.
+
 </div>
 </div>
 
@@ -830,16 +898,18 @@ Use the natural plural/singular form. If a product or feature name is a plural n
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Batch Changes are available.</li>
-</ul>
+
+##### Yes
+
+- Batch Changes are available.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Batch Changes is available.</li>
-</ul>
+
+##### No
+
+- Batch Changes is available.
+
 </div>
 </div>
 
@@ -847,16 +917,18 @@ Refer to the natural noun of the product or feature directly.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Batch Changes are available.</li>
-</ul>
+
+##### Yes
+
+- Batch Changes are available.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>The Batch Changes product is available.</li>
-</ul>
+
+##### No
+
+- The Batch Changes product is available.
+
 </div>
 </div>
 
@@ -874,19 +946,21 @@ Default to person-first language rather than identity-first language.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>they have a disability</li>
-<li>person with disability</li>
-<li>people living with disabilities</li>
-</ul>
+
+##### Yes
+
+- they have a disability
+- person with disability
+- people living with disabilities
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>they are disabled</li>
-<li>disabled person</li>
-</ul>
+
+##### No
+
+- they are disabled
+- disabled person
+
 </div>
 </div>
 
@@ -900,16 +974,18 @@ Avoid gendered terms.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Artisan</li>
-</ul>
+
+##### Yes
+
+- Artisan
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Craftsman</li>
-</ul>
+
+##### No
+
+- Craftsman
+
 </div>
 </div>
 
@@ -931,16 +1007,18 @@ Some words to watch out for:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>After you’ve entered a search query</li>
-</ul>
+
+##### Yes
+
+- After you’ve entered a search query
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Once you’ve entered a search query</li>
-</ul>
+
+##### No
+
+- Once you’ve entered a search query
+
 </div>
 </div>
 
@@ -948,16 +1026,18 @@ Some words to watch out for:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Choose the correct search</li>
-</ul>
+
+##### Yes
+
+- Choose the correct search
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Choose the right search</li>
-</ul>
+
+##### No
+
+- Choose the right search
+
 </div>
 </div>
 
@@ -965,16 +1045,18 @@ Some words to watch out for:
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Because you have a code monitor enabled, you can get email notifications for new events</li>
-</ul>
+
+##### Yes
+
+- Because you have a code monitor enabled, you can get email notifications for new events
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Since you have a code monitor enabled, you can get email notifications for new events</li>
-</ul>
+
+##### No
+
+- Since you have a code monitor enabled, you can get email notifications for new events
+
 </div>
 </div>
 
@@ -984,18 +1066,20 @@ In most languages, idioms are commonly-known phrases packed with meaning. Howeve
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Let’s get started</li>
-<li>This information might change</li>
-</ul>
+
+##### Yes
+
+- Let’s get started
+- This information might change
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Let’s get crackin’</li>
-<li>Take this with a grain of salt</li>
-</ul>
+
+##### No
+
+- Let’s get crackin’
+- Take this with a grain of salt
+
 </div>
 </div>
 
@@ -1005,10 +1089,11 @@ Use bold when referring to buttons in documentation.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Click <strong>Add user</strong>.</li>
-</ul>
+
+##### Yes
+
+- Click **Add user**.
+
 </div>
 </div>
 
@@ -1016,10 +1101,11 @@ In documentation, use bold and a symbol, such as a bracket (`>`), to display men
 
 <div class="usage">
 <div class="item yes">
-<h5>Example</h5>
-<ul>
-<li><strong>File > Print</strong> indicates that a user selects the Print option from the File menu</li>
-</ul>
+
+##### Example
+
+- **File > Print** indicates that a user selects the Print option from the File menu
+
 </div>
 </div>
 
@@ -1029,16 +1115,18 @@ Never directly reference the item (button, menu), just reference the label.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Click <strong>Add user</strong>.</li>
-</ul>
+
+##### Yes
+
+- Click **Add user**.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Click the <strong>Add user</strong> button.</li>
-</ul>
+
+##### No
+
+- Click the **Add user** button.
+
 </div>
 </div>
 
@@ -1046,10 +1134,11 @@ Match the actual case of the UI text in other products even if it violates our s
 
 <div class="usage">
 <div class="item yes">
-<h5>Example</h5>
-<ul>
-<li>In the <strong>Single Sign On Url</strong> field, ...</li>
-</ul>
+
+##### Example
+
+- In the **Single Sign On Url** field, ...
+
 </div>
 </div>
 
@@ -1057,10 +1146,11 @@ Refer to and cite other documents by quoting and linking their title. The quotat
 
 <div class="usage">
 <div class="item yes">
-<h5>Example</h5>
-<ul>
-<li>For more information, see “<a href="#_" aria-disabled="true">Monitoring and tracing</a>”.</li>
-</ul>
+
+##### Example
+
+- For more information, see “<a href="#_" aria-disabled="true">Monitoring and tracing</a>”.
+
 </div>
 </div>
 
@@ -1095,9 +1185,10 @@ Where a narrator describes code, search queries, or other text that also appears
 
 <div class="usage">
 <div class="item yes">
-<h5>Example</h5>
-<ul>
-<li>Search query in video says `ReadFile`, but automatic transcript says `read file`. Transcript should be updated to `ReadFile` as shown in the video.</li>
-</ul>
+
+##### Example
+
+- Search query in video says `ReadFile`, but automatic transcript says `read file`. Transcript should be updated to `ReadFile` as shown in the video.
+
 </div>
 </div>

--- a/content/communication/content_guidelines/terminology_guidelines.md
+++ b/content/communication/content_guidelines/terminology_guidelines.md
@@ -22,16 +22,18 @@ You don't need to use the full name of the product each time you refer to it, bu
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Use the Phabricator integration to get Sourcegraph features in code review.</li>
-</ul>
+
+##### Yes
+
+- Use the Phabricator integration to get Sourcegraph features in code review.
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>Use the Sourcegraph Phabricator integration to get Sourcegraph features in code review. <em>(sounds repetitive and stilted)</em></li>
-</ul>
+
+##### No
+
+- Use the Sourcegraph Phabricator integration to get Sourcegraph features in code review. _(sounds repetitive and stilted)_
+
 </div>
 </div>
 
@@ -39,17 +41,19 @@ Always title case our name. Don’t abbreviate or add a space to our name.
 
 <div class="usage">
 <div class="item yes">
-<h5>Yes</h5>
-<ul>
-<li>Sourcegraph</li>
-</ul>
+
+##### Yes
+
+- Sourcegraph
+
 </div>
 <div class="item no">
-<h5>No</h5>
-<ul>
-<li>SG</li>
-<li>Source Graph</li>
-</ul>
+
+##### No
+
+- SG
+- Source Graph
+
 </div>
 </div>
 

--- a/content/communication/content_guidelines/voice_and_tone.md
+++ b/content/communication/content_guidelines/voice_and_tone.md
@@ -45,22 +45,21 @@ There are four dimensions of tone that we can use to adjust the tone of any give
 Our **tone** comes through the words we use and how we string them together. Our **voice** shapes which words are part of our vocabulary, and provides a “range” along these dimensions of tone that will keep our voice consistent even as our tone changes.
 
 <div class="tone-sample">
-<h3>Tone is tricky!</h3>
-<p>The difference between voice and tone and how to use them together is tricky. Here’s a specific non-Sourcegraph example of how <strong>voice</strong> affects vocabulary, while <strong>tone</strong> affects specific word choice.</p>
 
-<p>Imagine a voice that is <strong>Sage</strong>. A phrase varied on the enthusiastic vs. matter-of-fact scale might be written like:</p>
+### Tone is tricky!
 
-<ul>
-<li>Enthusiastic: “This is lovely!”</li>
-<li>Matter-of-fact: “This is good.”</li>
-</ul>
+The difference between voice and tone and how to use them together is tricky. Here’s a specific non-Sourcegraph example of how **voice** affects vocabulary, while **tone** affects specific word choice.
 
-<p>In contrast, a voice that is <strong>Energetic</strong> would sound very different on the same scale:</p>
+Imagine a voice that is **Sage**. A phrase varied on the enthusiastic vs. matter-of-fact scale might be written like:
 
-<ul>
-<li>Enthusiastic: “This is utterly stupendous!”</li>
-<li>Matter-of-fact: “This is great.”</li>
-</ul>
+- Enthusiastic: “This is lovely!”
+- Matter-of-fact: “This is good.”
+
+In contrast, a voice that is **Energetic** would sound very different on the same scale:
+
+- Enthusiastic: “This is utterly stupendous!”
+- Matter-of-fact: “This is great.”
+
 </div>
 
 **Further reading:**
@@ -74,18 +73,20 @@ Our **tone** comes through the words we use and how we string them together. Our
 
 <div class="usage">
 <div class="item yes">
-<h5>Do</h5>
-<ul>
-<li>Be encouraging and positive</li>
-<li>Express interest</li>
-</ul>
+
+##### Do
+
+- Be encouraging and positive
+- Express interest
+
 </div>
 <div class="item no">
-<h5>Don’t</h5>
-<ul>
-<li>Don’t take credit for their success</li>
-<li>Don’t assume it was easy</li>
-</ul>
+
+##### Don’t
+
+- Don’t take credit for their success
+- Don’t assume it was easy
+
 </div>
 </div>
 
@@ -93,18 +94,20 @@ Our **tone** comes through the words we use and how we string them together. Our
 
 <div class="usage">
 <div class="item yes">
-<h5>Do</h5>
-<ul>
-<li>Express confidence</li>
-<li>Connect value to action</li>
-</ul>
+
+##### Do
+
+- Express confidence
+- Connect value to action
+
 </div>
 <div class="item no">
-<h5>Don’t</h5>
-<ul>
-<li>Don’t create uncertainty</li>
-<li>Don’t tell people “what to do”</li>
-</ul>
+
+##### Don’t
+
+- Don’t create uncertainty
+- Don’t tell people “what to do”
+
 </div>
 </div>
 
@@ -112,18 +115,20 @@ Our **tone** comes through the words we use and how we string them together. Our
 
 <div class="usage">
 <div class="item yes">
-<h5>Do</h5>
-<ul>
-<li>Be honest and direct about problems and provide next steps</li>
-<li>Use conversational but straightforward language</li>
-</ul>
+
+##### Do
+
+- Be honest and direct about problems and provide next steps
+- Use conversational but straightforward language
+
 </div>
 <div class="item no">
-<h5>Don’t</h5>
-<ul>
-<li>Don’t minimize the problem</li>
-<li>Don’t use negative or technical words</li>
-<li>Don’t assign emotion</li>
-</ul>
+
+##### Don’t
+
+- Don’t minimize the problem
+- Don’t use negative or technical words
+- Don’t assign emotion
+
 </div>
 </div>

--- a/content/communication/team_chat.md
+++ b/content/communication/team_chat.md
@@ -24,8 +24,10 @@ Exceptions:
 
 1. When using Slack for work-related purposes, avoid private messages. [Private messages discourage collaboration](https://blog.flowdock.com/2014/04/30/beware-of-private-conversations/). You might actually be contacting the wrong person, and they cannot easily redirect you to the right person. If the person is unavailable at the moment, it is less efficient because other people can't jump in and help. Use a public channel and mention the person or group you want to reach. This ensures it is easy for other people to chime in, involve other people if needed, and learn from whatever is discussed.
 1. If someone sends you a work-related private message, it is OK to let them know you'd like to take the conversation to a public channel, linking to this section of the handbook. The process might look something like:
-   - In the private message: <code>Thanks for reaching out. That's a great question/idea that I think the rest of the team could benefit from. I'm going to move this to #public-channel based on [our desire to avoid private messages](#avoid-private-messages).</code>
-   - In the appropriate public channel: `@person asked "question" in a DM, pulling that out here if anyone else has input.`
+   - In the private message:
+     > Thanks for reaching out. That's a great question/idea that I think the rest of the team could benefit from. I'm going to move this to #public-channel based on [our desire to avoid private messages](#avoid-private-messages).
+   - In the appropriate public channel:
+     > @person asked "question" in a DM, pulling that out here if anyone else has input.
    - Answer the question in a thread on that channel message, allowing others to benefit.
 1. If you must send a work-related private message, [don't start a conversation with "Hi" or "Hey"](http://www.nohello.com/) because that interrupts their work without communicating anything. If you have a quick question, just ask the question directly, and the person will respond asynchronously. If you truly need to have a synchronous communication, then start by asking for that explicitly, while mentioning the subject. For example: "I'm having trouble understanding issue XYZ. Can we talk about it quickly?".
 

--- a/content/company/onepager-async.svg
+++ b/content/company/onepager-async.svg
@@ -144,7 +144,7 @@
           </text>
           <text role="listitem" transform="matrix(381 0 0 381 297561 438531)">
             <tspan x="0" y="0">Document in a</tspan>
-            <a href="https://about.sourcegraph.com/handbook/communication#sources-of-truth" xml:space="preserve"><tspan>source of </tspan><tspan x="0" dy="29">truth</tspan></a>
+            <a href="/communication#sources-of-truth" xml:space="preserve" target="_top"><tspan>source of </tspan><tspan x="0" dy="29">truth</tspan></a>
             <tspan> and share results</tspan>
             <tspan x="0" dy="29">with pertinent teammates</tspan>
           </text>

--- a/content/company/team/locations.md
+++ b/content/company/team/locations.md
@@ -18,7 +18,7 @@ To add your own location:
 1. Click the map pin icon (looks like a google map location) on the right side of the map, and drop it in your location.
 1. Scroll to the bottom of the text that you pasted in, where your new pin will appear.
 1. In the `properties` section, add your name: `"name": "<yourname>"`. The final result will look like:
-   ```
+   ```json
    {
        "type": "Feature",
        "properties": {
@@ -39,7 +39,7 @@ To add your own location:
 
 1. Use [this site](https://www.latlong.net/) to get your city's latitude and longitude coordinates.
 1. Edit the following bit of JSON to include your name and coordinates (be sure to put longitude first):
-   ```
+   ```json
      {
        "type": "Feature",
        "properties": {

--- a/content/editing/handbook-images-video.md
+++ b/content/editing/handbook-images-video.md
@@ -30,7 +30,18 @@
 
 The easiest way to add a video to the Handbook is to embed it. Most video hosting sites, like Youtube or Loom, include an “embed” option in their sharing menu. The link should look something like this:
 
-`&lt;div style="position: relative; padding-bottom: 56.25%; height: 0;">&lt;iframe src="video URL" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">&lt;/iframe>&lt;/div>`
+```html
+<div style="position: relative; padding-bottom: 56.25%; height: 0;">
+  <iframe
+    src="video URL"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+  ></iframe>
+</div>
+```
 
 Copy and paste that link into your markdown file as you would any other piece of text. Check your handbook page after merging your changes to verify your video is playing correctly.
 

--- a/content/people-ops/onboarding/onboarding-for-hiring-managers.md
+++ b/content/people-ops/onboarding/onboarding-for-hiring-managers.md
@@ -5,72 +5,80 @@ As the company grows, new hires are joining almost every week. The onboarding pr
 ## Before first day
 
 <table>
-  <tr>
-   <td>Once the teammate signs the contract, they will complete <a href="https://docs.google.com/forms/d/e/1FAIpQLSfW4N-YNAoGo5LW0bBs5AM_2xLlwmEEY650qxuQlSMVoM0rtQ/viewform?usp=sf_link"> this form</a> asking for certain information we need to get them onboarded:
-<p>
-<ul>
-<li> We confirm start date
-<li> We ask for a selfie
-<li> We ask for their phone number, for account setup
-</ul>
+<tr>
+<td>
+
+Once the teammate signs the contract, they will complete [this form asking for certain information we need to get them onboarded](https://docs.google.com/forms/d/e/1FAIpQLSfW4N-YNAoGo5LW0bBs5AM_2xLlwmEEY650qxuQlSMVoM0rtQ/viewform?usp=sf_link):
+
+- We confirm start date
+- We ask for a selfie
+- We ask for their phone number, for account setup
 
 And GitHub username, if they have one.
 
-   </td>
-   <td>PeopleOps
-   </td>
-  </tr>
-  <tr>
-   <td>About a week before the first day, the Hiring Manager needs to fill out this <a href="https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform?usp=sf_link">Google Form</a> with all the relevant tools, channels and groups the new hire needs to be added to be able to start on day one. Also, here is where the Onboarding buddy is informed. <b>Please take the time to confirm with the buddy that they are willing and available before nominating them</b>.
-   </td>
-   <td>Hiring Manager
-   </td>
-  </tr>
-   <tr>
-   <td>Tech Ops will create their Sourcegraph email and add them to the basic onboarding tools:
-<p>
-<ul>
-<li> Slack
-<li> Zoom
-<li> 1password
-<li> Greenhouse
-<li> Lattice
-<li> Process St.
-   </ul>
-   </td>
-   <td>Tech Ops
-   </td>
-  </tr>
-  <tr>
-   <td>PeopleOps will communicate in #teammate-announce all new teammates starting the following week, including their role and live email.
-<p>
-  <p>
+</td>
+<td>PeopleOps</td>
+</tr>
+
+<tr>
+<td>
+
+About a week before the first day, the Hiring Manager needs to fill out [this Google Form with all the relevant tools, channels and groups the new hire needs to be added](https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform?usp=sf_link) to be able to start on day one. Also, here is where the Onboarding buddy is informed. **Please take the time to confirm with the buddy that they are willing and available before nominating them**.
+
+</td>
+<td>Hiring Manager</td>
+</tr>
+
+<tr>
+<td>
+
+Tech Ops will create their Sourcegraph email and add them to the basic onboarding tools:
+
+- Slack
+- Zoom
+- 1password
+- Greenhouse
+- Lattice
+- Process St.
+
+</td>
+<td>Tech Ops</td>
+</tr>
+
+<tr>
+<td>
+
+PeopleOps will communicate in #teammate-announce all new teammates starting the following week, including their role and live email.
+
 They will also be added to these calendar events: Meet the founders, New teammate happy hour, Meet & Greet - New cohort, and a check in with PeopleOps on their one month mark.
-   </td>
-   <td>PeopleOps
-   </td>
- 
-  <tr>
-   <td>Now that you have your new teammate's email you should:
-<p>
-   <ul>
-<li> Create recurring 1:1 with new teammate
-<li> Add new teammate to any team/role specific meetings and calls
-     </ul>
-<p>
-  You must also make sure to provide documentation and context on on going projects your team is working on.
-  <p>
+
+</td>
+<td>PeopleOps</td>
+
+<tr>
+<td>
+
+Now that you have your new teammate's email you should:
+
+- Create recurring 1:1 with new teammate
+- Add new teammate to any team/role specific meetings and calls
+
+You must also make sure to provide documentation and context on on going projects your team is working on.
+
 Having this done before day one will make it easier for the new hire and an overall better experience.
-   </td>
-   <td>Hiring Manager
-   </td>
-  </tr>
-  <tr>
-   <td>The Friday before they start, we will send an email. Here they will have the login details to start on their first day, the link to their Process St checklist and useful information (Onboarding buddy program, the Monday’s company meeting where they will be introduced, we are handbook first, etc.).
-   </td>
-   <td>PeopleOps
-   </td>
-  </tr>
+
+</td>
+<td>Hiring Manager</td>
+</tr>
+
+<tr>
+<td>
+
+The Friday before they start, we will send an email. Here they will have the login details to start on their first day, the link to their Process St checklist and useful information (Onboarding buddy program, the Monday’s company meeting where they will be introduced, we are handbook first, etc.).
+
+</td>
+<td>PeopleOps</td>
+</tr>
 </table>
 
 ## First day
@@ -79,8 +87,7 @@ Having this done before day one will make it easier for the new hire and an over
   <tr>
    <td>You should notify new hires of any 1:1s they should have (any people on their team, or adjacent teams they will work closely with) so they can set them up.
    </td>
-   <td>Hiring Manager
-   </td>
+   <td>Hiring Manager</td>
   </tr>
 </table>
 
@@ -96,28 +103,27 @@ Having this done before day one will make it easier for the new hire and an over
   <tr>
    <td>Checking the checklist before hand, will help keep in mind the content new hires will find there: the information they will be linked to, the tasks they have to complete and how much of the handbook they’ll cover.
    </td>
-   <td>Hiring Manager
-   </td>
+   <td>Hiring Manager</td>
   </tr>
 </table>
 
 ## Impact review cycles
 
 <table>
-  <tr>
-   <td>New teammates will go through their <a href="./onboarding-feedback-milestones.md"> Onboarding Feedback Milestones</a> on their first, second and third month with us. Please read the handbook page that walks you through what they are and why we find them valuable. 
-     <p>
-       You will use Lattice to take notes during the Milestones. You will be notified via email and through the Slack integration when it's time for you to have them. As per their onboarding checklist, teammates are responsible to schedule the meetings for you both to have the conversation. 
-   </td>
-   <td>Hiring Manager
-   </td>
-  </tr>
-  <tr>
-   <td>On the teammates 6 month mark, and every six months after that, manager and teammate will be part of the 360 Impact review cycle.
-   </td>
-   <td>Hiring Manager & Teammate
-   </td>
-  </tr>
+<tr>
+<td>
+
+New teammates will go through their [Onboarding Feedback Milestones](./onboarding-feedback-milestones.md) on their first, second and third month with us. Please read the handbook page that walks you through what they are and why we find them valuable.
+
+You will use Lattice to take notes during the Milestones. You will be notified via email and through the Slack integration when it's time for you to have them. As per their onboarding checklist, teammates are responsible to schedule the meetings for you both to have the conversation.
+
+</td>
+<td>Hiring Manager</td>
+</tr>
+<tr>
+<td>On the teammates 6 month mark, and every six months after that, manager and teammate will be part of the 360 Impact review cycle.</td>
+<td>Hiring Manager & Teammate</td>
+</tr>
 </table>
 
 For any extra context, information or suggestions, please contact Inés Roitman (@Ines)

--- a/content/tech-ops/systems_list.md
+++ b/content/tech-ops/systems_list.md
@@ -1,3 +1,3 @@
 ## Systems List
 
-<a href = "https://docs.google.com/spreadsheets/d/1tzP64dj2CrddDLTZuLFWmpXoNB9lUaOstRUj3FaN_Rs/edit#gid=0"> Systems List Google Drive </a>
+[Systems List Google Drive](https://docs.google.com/spreadsheets/d/1tzP64dj2CrddDLTZuLFWmpXoNB9lUaOstRUj3FaN_Rs/edit#gid=0)


### PR DESCRIPTION
Our new markdown renderer supports using Markdown _within_ HTML, as long as the Markdown stands in its own block. This is specified in the CommonMark spec.

This allows us to simplify some pages that had to resort to HTML for e.g. tables, by not having to then also make all _content_ HTML, but using markdown within the table cells. Our content guidelines also become simpler as they used `<div>` wrappers. This should hopefully be easier for people to understand and edit.

cc @quinnkeast 