### PR TITLE
Use div wrapper for responsive tables

### DIFF
--- a/content/marketing/index.md
+++ b/content/marketing/index.md
@@ -1,6 +1,6 @@
 # Marketing
 
-![Sourcegraph Marketing team logo](https://sourcegraphstatic.com/marketing-logo.gif)
+<img align="right" src="https://sourcegraphstatic.com/marketing-logo.gif" style="max-height:100%" alt="Sourcegraph Marketing team logo"/>
 
 ## How to contact Marketing
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "gray-matter": "^4.0.3",
     "hast": "^1.0.0",
     "hast-util-find-and-replace": "^4.0.0",
+    "hast-util-is-element": "^2.1.1",
     "hast-util-select": "^5.0.1",
     "hast-util-to-string": "^2.0.0",
     "hastscript": "^7.0.2",

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -132,8 +132,3 @@
     color: inherit;
     opacity: 0.8;
 }
-
-/* Ensure no content goes outside of wrapper within markdown body */
-.markdown-body .headingWrapper {
-    overflow-x: auto;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,7 +2667,7 @@ hast-util-is-element@^1.1.0:
   resolved "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
   integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
 
-hast-util-is-element@^2.0.0:
+hast-util-is-element@^2.0.0, hast-util-is-element@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.1.tgz"
   integrity sha512-ag0fiZfRWsPiR1udvnSbaazJLGv8qd8E+/e3rW8rUZhbKG4HNJmFL4QkEceN+22BgE+uozXY30z/s+2dL6Z++g==


### PR DESCRIPTION
Previously, the overflow was assigned to the entire `<section class="headingWrapper">`, which also made other content (e.g. headings) scroll with it and caused issues with floating images.

This instead uses a small rehype plugin to wrap only the _tables_ in `<div class="table-responsive">`, which is provided by Bootstrap: https://getbootstrap.com/docs/5.1/content/tables/#responsive-tables