### PR TITLE
Remove obsolete `export` from tutorial.md

### DIFF
--- a/content/engineering/deployments/debugging/tutorial.md
+++ b/content/engineering/deployments/debugging/tutorial.md
@@ -6,7 +6,6 @@ Next, open a new terminal and set two environment variables for ergonomics for t
 
 ```
 export CLOUDSDK_CORE_PROJECT=sourcegraph-dogfood
-export CLOUDSDK_COMPUTE_REGION=us-central1
 export CLOUDSDK_COMPUTE_REGION=us-central1-f
 ```
 


### PR DESCRIPTION
I believe having the second `export` statement to the same field just overwrites it, right?

Tested this on my machine, and used `echo` to check the value after each statement. It looks like the 2nd statement will just overwrite the value that was declared in the 1st statement.