### PR TITLE
Show edit data button for some pages

### DIFF
--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -52,22 +52,22 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
             </div>
         )}
         <div className="sidebar-bottom-links">
-            {page.path == 'company/team/index.md' && (
-                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/team.yml`}>
+            {page.path === 'company/team/index.md' && (
+                <Link href="https://github.com/sourcegraph/handbook/edit/main/data/team.yml">
                     Edit this data on GitHub
                 </Link>
             )}
-            {page.path == 'product/feature_maturity.md' && (
-                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/features.yml`}>
+            {page.path === 'product/feature_maturity.md' && (
+                <Link href="https://github.com/sourcegraph/handbook/edit/main/data/features.yml">
                     Edit this data on GitHub
                 </Link>
             )}
-            {page.path == 'product/feature_compatibility.md' && (
-                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/features.yml`}>
+            {page.path === 'product/feature_compatibility.md' && (
+                <Link href="https://github.com/sourcegraph/handbook/edit/main/data/features.yml">
                     Edit this data on GitHub
                 </Link>
             )}
-            {page.path != 'company/team/index.md' && page.path != 'product/feature_maturity.md' && page.path != 'product/feature_compatibility.md' && (
+            {page.path !== 'company/team/index.md' && page.path !== 'product/feature_maturity.md' && page.path !== 'product/feature_compatibility.md' && (
                 <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${page.path}`}>
                     Edit this page on GitHub
                 </Link>

--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -52,9 +52,26 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
             </div>
         )}
         <div className="sidebar-bottom-links">
-            <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${page.path}`}>
-                Edit this page on GitHub
-            </Link>
+            {page.path == 'company/team/index.md' && (
+                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/team.yml`}>
+                    Edit this data on GitHub
+                </Link>
+            )}
+            {page.path == 'product/feature_maturity.md' && (
+                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/features.yml`}>
+                    Edit this data on GitHub
+                </Link>
+            )}
+            {page.path == 'product/feature_compatibility.md' && (
+                <Link href={`https://github.com/sourcegraph/handbook/edit/main/data/features.yml`}>
+                    Edit this data on GitHub
+                </Link>
+            )}
+            {page.path != 'company/team/index.md' && page.path != 'product/feature_maturity.md' && page.path != 'product/feature_compatibility.md' && (
+                <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${page.path}`}>
+                    Edit this page on GitHub
+                </Link>
+            )}
         </div>
     </section>
 )

--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -67,11 +67,13 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
                     Edit this data on GitHub
                 </Link>
             )}
-            {page.path != 'company/team/index.md' && page.path != 'product/feature_maturity.md' && page.path != 'product/feature_compatibility.md' && (
-                <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${page.path}`}>
-                    Edit this page on GitHub
-                </Link>
-            )}
+            {page.path != 'company/team/index.md' &&
+                page.path != 'product/feature_maturity.md' &&
+                page.path != 'product/feature_compatibility.md' && (
+                    <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${page.path}`}>
+                        Edit this page on GitHub
+                    </Link>
+                )}
         </div>
     </section>
 )


### PR DESCRIPTION
The "edit this page" button doesn't make sense on pages that are driven by data, so this updates those links to point to the data file source instead.