### PR TITLE
Add stub page for OpsGenie link

### DIFF
--- a/content/engineering/cloud-saas/index.md
+++ b/content/engineering/cloud-saas/index.md
@@ -1,0 +1,5 @@
+# Cloud SaaS
+
+(This page is a stub to allow OpsGenie to link to the Cloud SaaS team in the handbook without a 404. This is a hopefully temporary workaround.)
+
+The [Cloud SaaS team](../cloud/saas/index.md) is part of the [Cloud Org](../cloud/index.md).


### PR DESCRIPTION
This is a stub page to [address OpsGenie links on a temporary basis](https://github.com/sourcegraph/sourcegraph/pull/26865#issue-770255165).
