### PR TITLE
Flag BB Server auth as false (not supported)

### DIFF
--- a/data/features.yml
+++ b/data/features.yml
@@ -354,7 +354,7 @@ user_authentication:
     gitlab_enterprise: true
     github_com: true
     github_enterprise: true
-    bitbucket_server: true
+    bitbucket_server: false
     bitbucket_cloud: false
     phabricator: false
     codecommit: false


### PR DESCRIPTION
Correct error suggesting that we do support BB Server User Auth.

See here for more info https://docs.sourcegraph.com/admin/config/authorization_and_authentication#bitbucket-server-authorization