### PR TITLE
Remove reference to "US English" being an American-only thing

### DIFF
--- a/content/product/licensing.md
+++ b/content/product/licensing.md
@@ -1,6 +1,6 @@
 # Licensing
 
-Licensing at Sourcegraph can be confusing: the word "license" (or "licence", for the non-Americans in the crowd) is used in two overlapping contexts within Sourcegraph:
+Licensing at Sourcegraph can be confusing: the word "license" (or "licence") is used in two overlapping contexts within Sourcegraph:
 
 1. The software license under which our users obtain and potentially modify our source code, and
 2. The [team or enterprise plan](https://about.sourcegraph.com/pricing) that users are paying for on Sourcegraph Enterprise, which is controlled via a [license key](../ce/license_keys.md). (The Free plan does not have a license key.)


### PR DESCRIPTION
US English spelling is commonly used outside the US in the Philippines, Israel, Japan,
Saudi Arabia, South Korea, Taiwan, parts of Germany and much of Latin America.

(Source: https://wikitravel.org/en/English_language_varieties)