### PR TITLE
delete job description template & guidelines page

### DIFF
--- a/content/talent/hiring/job_description_guidelines.md
+++ b/content/talent/hiring/job_description_guidelines.md
@@ -1,5 +1,0 @@
-# Job description template and guidelines
-
-## Job description format
-
-Please refer to the [job description template document](https://docs.google.com/document/d/1rJAYyARbegvvH_e-VTrHoFhU9cDG5WfHov3L12NeCO8/edit)


### PR DESCRIPTION
The template listed here is linked to from this page: https://github.com/sourcegraph/handbook/blob/main/content/talent/hiring/index.md

I'm proposing deleting this page because it contains information that exists elsewhere. Additionally, this page is not linked to from anywhere in the Handbook today. This is preventing us from re-implementing a Handbook check requiring all pages to be linked to within the Handbook. If we would like to keep this page, we need to link to it from somewhere in the Handbook.