### PR TITLE
remove old 1-year vision section, link to new FY23 strategy

### DIFF
--- a/content/company/strategy/index.md
+++ b/content/company/strategy/index.md
@@ -83,7 +83,7 @@ A complete list of feature areas by maturity, tier, or by code host compatibilit
 
 ## FY23 strategy
 
-> Target ~5-7(TBD) specific use cases for existing customers first to grow ARR ~___x(TBD).
+> Target ~5-7(TBD) specific use cases for existing customers first to grow ARR ~\_\_\_x(TBD).
 
 See the ["FY23 strategy"](https://docs.google.com/document/d/11ot7RoJ18mmjeP8Zb4TJMJsdQf5ZmGErkPq1VDW80d4/edit) doc for full details. (We will copy this doc into the handbook when it is finished being edited.)
 

--- a/content/company/strategy/index.md
+++ b/content/company/strategy/index.md
@@ -81,80 +81,11 @@ Additionally, our [product design principles](../../product/design/product_desig
 
 A complete list of feature areas by maturity, tier, or by code host compatibility can be found on [our feature reference pages](../../product/index.md#product-team-and-feature-reference).
 
-## One year vision
+## FY23 strategy
 
-> Problem statement: In large and complex codebases ([Big Code](#big-code)), it's hard for developers to discover, understand, and fix code.
+> Target ~5-7(TBD) specific use cases for existing customers first to grow ARR ~___x(TBD).
 
-Sourcegraph is the one place to find and fix things across all code.
-
-- Sourcegraph knows almost everything that can be known about your code (code structure, Git metadata, build, code hosts, runtime metrics, code reviews, docs, issues, project management, etc.).
-- It's easy to find and use this information on Sourcegraph itself and in your editor, code host, and code reviews.
-- When you need to find something in or about your code (which happens many times per day), you usually start on Sourcegraph.
-- To spread adoption of a new dev tool/practice or make a large-scale code change, you use Sourcegraph because you trust everyone uses it.
-
-### Build Sourcegraph into the development workflow
-
-#### Challenge to overcome
-
-We measure the value Sourcegraph brings to developers by measuring how often they use Sourcegraph in their daily workflows. We believe the [natural frequency of usage](https://amplitude.com/blog/2016/10/11/product-usage-interval) (how often people use Sourcegraph) as a key part of every developer’s workflow is many times per day. Our current usage metrics are good, but are not as high as they should be to match this natural frequency of usage.
-
-#### What we want to achieve
-
-Sourcegraph is an essential and frequently used part of the developer’s day to day workflow because it is the place that gives developers all context about their code. Sourcegraph is The One Search Bar to find information you need about your code. Search is easy to do from anywhere, aware of your current context, and integrated deeply into your common workflows; it's not just a list of matches.
-
-We will measure this by:
-
-- Number of daily active users
-- Number of times Sourcegraph is used per day
-
-#### How we're going to do this
-
-- Insert Sourcegraph into more places in the developer workflow, so developers are being prompted to go use Sourcegraph.
-- Give developers more reasons to come back with greater frequency by adding more value for them inside of Sourcegraph (e.g., information about code that doesn't live in the code itself).
-
-### Support a broader set of configurations and workflows
-
-#### Challenge to overcome
-
-Many organizations have unique code setups and workflows that require workarounds to support, or prevent them from using Sourcegraph entirely.
-
-#### What we want to achieve
-
-Sourcegraph is the code search solution for every developer and every organization, regardless of their setup. At any organization, Sourcegraph is how developers are able to work with large and complex development workflows. Sourcegraph sustainably supports configuration of unique infrastructure and code setups.
-
-#### How we're going to do this
-
-- Solve use cases that are present at many large enterprises.
-- Reduce friction in getting Sourcegraph deployed at scale.
-- More integrated support for non-Git version control systems.
-
-### Surface insights into code and development
-
-#### Challenge to overcome
-
-Software development executives have a hard time understanding what is going on with their large teams, the projects they are investing in, and the impact developers and teams have inside of their organization. The insights and information they need is hard to come by and is not solved by other tools or services because it relies on data the development teams produce to be tied to higher order concerns.
-
-#### What we want to achieve
-
-Sourcegraph has access to the low level data needed to build insights that are high quality and meaningful. Sourcegraph feeds the symbiotic relationship between developer produced data and executive insights, creating a cyclical feedback loop of immense value. Engineering leaders turn to Sourcegraph to understand what is going on in their organization.
-
-#### How we're going to do this
-
-- Do research to understand what questions engineering leaders want to answer about their organization's code.
-- Add features to Sourcegraph that provide insights that are valuable to both leaders and developers.
-
-## Three-year vision: democratize code search
-
-We will make universal code search accessible to everyone.
-
-Code search is a powerful tool that becomes indispensable when you work on large, shared codebases or depend heavily on the universe of open-source code outside your organization. It's like fire––powerful and versatile and those who've seen the light can't imagine going back to the darkness. Let's bring code search down from the Mount Olympus of Tech and make it accessible to everyone, not just the 0.1% of developers who work at Google and other tech giants.
-
-- Fast code search that scales to giant codebases and the universe of open-source code.
-- Precise code navigation that makes walking the reference graph as simple as point-and-click.
-- Make large scale code changes possible (universal search-and-replace).
-- Integrate with code hosts and code review tools to bring these developer superpowers to everywhere SWEs need to understand code.
-- Sourcegraph becomes a natural hub to distribute other dev tools, due to its extensibility and the fact that the average developer using Sourcegraph does so several times per day.
-- Sourcegraph provides analytics about what parts of the code are changing and makes this view accessible to every individual developer.
+See the ["FY23 strategy"](https://docs.google.com/document/d/11ot7RoJ18mmjeP8Zb4TJMJsdQf5ZmGErkPq1VDW80d4/edit) doc for full details. (We will copy this doc into the handbook when it is finished being edited.)
 
 ## Five-year vision: democratize code
 


### PR DESCRIPTION
The 1-year vision is from last year and is getting outdated. This adds a link to the new FY23 strategy, which is not quite complete but is much more up to date than the other content. The FY23 strategy right now doesn't include the product vision but it will when it enumerates the specific use cases for us to target (which we are working with the team to select now).