### PR TITLE
Add sources of prioritization

### DIFF
--- a/content/ce/working-with-product.md
+++ b/content/ce/working-with-product.md
@@ -1,6 +1,6 @@
 # Working with Product
 
-This page has some basic info on how CEs work with the product team. For more info, see [Tracking and Sharing User Feedback](../product/product_management/user_feedback.md) and [Surfacing Feedback to the Product Team](../product/surfacing_product_feedback.md).
+This page has some basic info on how CEs work with the product team. For more info, see [Tracking and Sharing User/Stakeholder Feedback](../product/product_management/user_stakeholder_feedback.md) and [Surfacing Feedback to the Product Team](../product/surfacing_product_feedback.md).
 
 ## Adding GitHub Issues to Boards
 

--- a/content/company/goals/2022_Q4.md
+++ b/content/company/goals/2022_Q4.md
@@ -32,6 +32,8 @@ In addition to the objectives above each organization within product & engineeri
 - [Code Graph](../strategy/code-graph/index.md#themes--goals)
 - [Cloud](../../engineering/cloud/index.md#okrs-fy22q4)
 
+Product and Engineering are tracking these goals on our [OKR dashboard](https://github.com/orgs/sourcegraph/projects/214/views/11) (internal only) using the approach outlined on the [Product Management home](../../product/product_management#okr-and-roadmap-tracking) page.
+
 ## Marketing
 
 ## Operations (BizOps, Finance, TechOps, Legal)

--- a/content/editing/handbook-check-failures.md
+++ b/content/editing/handbook-check-failures.md
@@ -26,9 +26,9 @@ If you're not sure what the error message means or can't determine how to fix it
 
 - [Example](https://github.com/sourcegraph/about/runs/2976049292)
 - Your error contains text like this:
-  - `handbook/product/user_feedback.md: must link to .md file, not ../support/support-workflow`
+  - `handbook/product/user_stakeholder_feedback.md: must link to .md file, not ../support/support-workflow`
 - Breaking down the error:
-  - `handbook/product/user_feedback.md:`
+  - `handbook/product/user_stakeholder_feedback.md:`
   - This is telling you what file is causing the failure. In this case, it’s something happening within in the “User Feedback” Handbook page file, nested under the “Product” section of the Handbook.
   - `must link to .md file, not ../support/support-workflow `
   - This is telling you that you must link to an .md file, rather than just a URL. See [this page](linking-within-handbook.md) for more information about linking.

--- a/content/product/product_management/index.md
+++ b/content/product/product_management/index.md
@@ -8,7 +8,7 @@ This page contains information that is relevant for how to do well at your job a
 - [Pricing](pricing.md) - how we decide what tier a feature goes in/how much an add-on feature costs.
 - [Tracking issues](../../engineering/tracking_issues.md) - how we keep track of planned and on-going work.
 - [Prioritizing](prioritizing.md) - how we prioritize work, and how to get things prioritized.
-- [Tracking user feedback](user_feedback.md) - sources of feedback and how we keep track of that feedback.
+- [Tracking user & stakeholder feedback](user_stakeholder_feedback.md) - sources of feedback and how we keep track of that feedback.
 - [Responding to user feedback](responding_to_user_feedback.md) - how we respond to user feedback for the feedback channels the product team owns.
 - [Feature rollout](rollout_process.md) - how we test, rollout and launch new features.
 - [Learning](product_learning.md) - how we learn from what we shipped.

--- a/content/product/product_management/prioritizing.md
+++ b/content/product/product_management/prioritizing.md
@@ -4,6 +4,15 @@
 
 We use personas to understand our users and what they need as we prioritize our work. More can be read on the [personas page](../../marketing/personas.md) in the marketing handbook, which also links to a presentation with the actual personas in it.
 
+## Inputs to prioritization
+
+There are several sources that product managers look at when deciding what's important to prioritize next.
+
+- [Your own strategy](../../company/strategy/index.md#per-area-strategy-pages) and where you are trying to go
+- [The overall company strategy](../../company/strategy/index.md) and how you fit in
+- [Company and product/engineering goals](../../company/goals/index.md) and how you can drive them forward
+- [User & stakeholder feedback](user_stakeholder_feedback.md) to realize our value of being [customer-first](../../company/values.md#customer-first)
+
 ## Saying "no"
 
 We receive tons of feature requests and bug reports, more than we can handle. This means we must frequently say "no" or prioritize things less urgently than some people would like. Our job is to find the most important things to work on.

--- a/content/product/product_management/responding_to_user_feedback.md
+++ b/content/product/product_management/responding_to_user_feedback.md
@@ -1,6 +1,6 @@
 # Responding to user feedback
 
-The product team owns a number of [user feedback sources](user_feedback.md).
+The product team owns a number of [user & stakeholder feedback sources](user_stakeholder_feedback.md).
 
 ## Cross-team communication and recording responses
 
@@ -59,7 +59,7 @@ For both self-contained product feedback slack posts and for new GitHub issues w
 
 ### Feedback email list
 
-The PM on feedback rotation owns keeping track, replying and/or forwarding any relevant feedback that comes through the feedback@sourcegraph.com [mailing list](user_feedback.md#feedbacksourcegraphcom) to the area's PM (or EM in the case that the team .
+The PM on feedback rotation owns keeping track, replying and/or forwarding any relevant feedback that comes through the feedback@sourcegraph.com [mailing list](user_stakeholder_feedback.md#feedbacksourcegraphcom) to the area's PM (or EM in the case that the team .
 
 ## Browser uninstall form feedback
 

--- a/content/product/product_management/user_stakeholder_feedback.md
+++ b/content/product/product_management/user_stakeholder_feedback.md
@@ -1,6 +1,6 @@
 # Tracking & sharing user feedback
 
-Our passionate users provide a constant stream of thoughtful feedback and love engaging with us to help them and their teams solve their toughest problems. This trust and feedback is a gift, and we take it seriously and listen carefully to what users tell us.
+Our passionate users and stakeholders, both internal and external, provide a constant stream of thoughtful feedback and love engaging with us to help them and their teams solve their toughest problems. This trust and feedback is a gift, and we take it seriously and listen carefully to what users tell us.
 
 _This page is most relevant to product team members. If you want to know how to best share feedback with the product team, please see [surfacing product feedback](../surfacing_product_feedback.md)._
 
@@ -11,7 +11,7 @@ _This page is most relevant to product team members. If you want to know how to 
 - [Twitter](#twitter)
 - [Slack](#slack)
 - [Support tickets](#support-tickets)
-- [Sales feedback](#sales-feedback)
+- [Sales/CE feedback](#sales-ce-feedback)
 - [HubSpot forms](#hubspot-forms)
 - [NPS survey](#nps-survey)
 - [Browser extension uninstall feedback](#browser-extension-uninstall-feedback)
@@ -57,11 +57,12 @@ See [How to reference customer names in public tickets](prioritizing.md#how-to-r
 - **Purpose:** A path for existing customers to get responsive support.
 - **Owner:** CS team owns support tickets in Zendesk. If product team members want more insight into the support feedback, they can review [the support dashboard](https://sourcegraph.looker.com/dashboards-next/177) or scan the [customer issues repo](https://github.com/sourcegraph/customer/issues), and cross-reference both with slack searches in support channels. Additionally, at the end of every quarter, the Head of Customer Support provides the product team with [a qualitative summary](https://drive.google.com/drive/folders/12kZOFbnXX8vfzLvso1hO-lf-t-HzJIr-?usp=sharing) and links to details of the major support trends from the prior three months.
 
-### Sales feedback
+### Sales/CE feedback
 
 - **Purpose:** Customers and prospects often give product feedback on calls with sales members.
-
 - **Owner:** The Sales team owns feedback from sales calls.
+
+The Sales and CE teams also provide a [product gaps dashboard](https://sourcegraph2020.lightning.force.com/lightning/r/Report/00O5b000005HH53EAG/view) (internal only) that tracks features that are impacting deals.
 
 ### Hubspot forms
 

--- a/content/product/product_management/user_stakeholder_feedback.md
+++ b/content/product/product_management/user_stakeholder_feedback.md
@@ -11,7 +11,7 @@ _This page is most relevant to product team members. If you want to know how to 
 - [Twitter](#twitter)
 - [Slack](#slack)
 - [Support tickets](#support-tickets)
-- [Sales/CE feedback](#sales-ce-feedback)
+- [Sales/CE feedback](#salesce-feedback)
 - [HubSpot forms](#hubspot-forms)
 - [NPS survey](#nps-survey)
 - [Browser extension uninstall feedback](#browser-extension-uninstall-feedback)


### PR DESCRIPTION
There wasn't a common index of sources of prioritization, only of specifically user feedback. This adds that more general index and updates related content with what is already true today, most importantly by adding a link to the product gaps dashboard to the sales/CE feedback section.