### PR TITLE
Clarify temporary projects

### DIFF
--- a/content/engineering/environments.md
+++ b/content/engineering/environments.md
@@ -7,7 +7,7 @@ This page describes our different cloud environments.
 We utilize multiple Google Cloud projects and folders to organize our workloads and manage access control for our engineers, as well as limit the scope of roles and service accounts across projects.
 
 All **Permanent** Projects and permissions are defined in [infrastructure/gcp](https://github.com/sourcegraph/infrastructure/tree/main/gcp).
-Temporary projects should be created as needed in [Engineering Projects](Engineering-Projects)
+Temporary projects should be created as needed in [Engineering Projects](#engineering-projects)
 
 ### Root Projects
 

--- a/content/engineering/environments.md
+++ b/content/engineering/environments.md
@@ -6,7 +6,8 @@ This page describes our different cloud environments.
 
 We utilize multiple Google Cloud projects and folders to organize our workloads and manage access control for our engineers, as well as limit the scope of roles and service accounts across projects.
 
-All Projects and permissions are defined in [infrastructure/gcp](https://github.com/sourcegraph/infrastructure/tree/main/gcp).
+All **Permanent** Projects and permissions are defined in [infrastructure/gcp](https://github.com/sourcegraph/infrastructure/tree/main/gcp).
+Temporary projects should be created as needed in [Engineering Projects](Engineering-Projects)
 
 ### Root Projects
 


### PR DESCRIPTION
Adding every temporary project as a GCP project is an excessive burden. We should only add **permanent** projects to the infra folder.