### PR TITLE
create handbook content best practices page

### DIFF
--- a/content/communication/content_guidelines/index.md
+++ b/content/communication/content_guidelines/index.md
@@ -12,6 +12,7 @@ The goal of these content guidelines is to help us to:
 - [Actionable language](./actionable_language.md) gives us specific patterns to follow in product and UX copywriting.
 - [Style & mechanics](./style_and_mechanics.md) helps us be clear and consistent in our writing.
 - [Terminology guidelines](./terminology_guidelines.md) give us a source of truth for which words to use.
+- [Handbook Content Best Practices](../../handbook/editing/handbook-content-best-practices.md) helps with handbook-specific content structure.
 
 ## Effectiveness over correctness
 

--- a/content/handbook/editing/handbook-content-best-practices.md
+++ b/content/handbook/editing/handbook-content-best-practices.md
@@ -7,6 +7,7 @@ This page is intended to give advice when you're making decisions about handbook
 ## Creating a new page vs adding to an existing page
 
 There is no hard and fast rule on when to create a new page vs adding a new one. Some things to consider:
+
 1. Does the content you're adding fit into the narrative of an existing page?
 1. Can you add this to an existing page without making that page too long to consume?
 1. Does the page feel like a "wall of text"?
@@ -18,20 +19,20 @@ In general, we want to avoid extremely long pages, and bias towards snackable co
 Should I create a new directory (also called a folder) or add my new content to an existing one? The answer is: it depends. To help in making your decision, ask yourself this:
 
 1. Does this content pair with or compliment existing content?
-  - **If yes**, it should go in the same directory as its companion content.
-  - **If no**, you may want to create a new directory. It's helpful to create a directory rather than just a single file in case you want to add more related files later. See [where should my content go](#where-should-my-content-go) for help with deciding where that new directory should go.
 
-Reach out to the [content curators](#content-curators) for help if you're unsure. 
+- **If yes**, it should go in the same directory as its companion content.
+- **If no**, you may want to create a new directory. It's helpful to create a directory rather than just a single file in case you want to add more related files later. See [where should my content go](#where-should-my-content-go) for help with deciding where that new directory should go.
+
+Reach out to the [content curators](#content-curators) for help if you're unsure.
 
 ## Where should my file or directory go?
 
 To determine where your content should go:
 
-1. Consider the **primary** viewer. Since our handbook is public, anyone can read the content, but you probably have an intended audience in mind. If your content is a company-wide policy or process, it probably belongs in a directory holding company-wide content. If it's a policy or process only your team uses, it probably fits best in your team directory. 
-  -**Note:** If your primary viewer is a user of the Sourcegraph product, it should live in the [Sourcegraph Docs](docs.sourcegraph.com).
+1. Consider the **primary** viewer. Since our handbook is public, anyone can read the content, but you probably have an intended audience in mind. If your content is a company-wide policy or process, it probably belongs in a directory holding company-wide content. If it's a policy or process only your team uses, it probably fits best in your team directory. -**Note:** If your primary viewer is a user of the Sourcegraph product, it should live in the [Sourcegraph Docs](docs.sourcegraph.com).
 1. Determine what type of content you are creating. Is it a process describing how we work? Is it a policy that must be followed? Look for a directory with similar types of content. Like content should live together.
 
-Reach out to the [content curators](#content-curators) for help if you're unsure. 
+Reach out to the [content curators](#content-curators) for help if you're unsure.
 
 ## Page structure and use of headings
 
@@ -41,11 +42,12 @@ In terms of structure, favor using headings to break up your page. This helps vi
 
 ## Content objectives
 
-As stated in our [Handbook Usage](../index.md#handbook-usage) page, most content in this handbook is meant to help rather than being absolute rules (unless stated). If you're documenting a process or policy that *must* be followed, indicate this at the top of your page.
+As stated in our [Handbook Usage](../index.md#handbook-usage) page, most content in this handbook is meant to help rather than being absolute rules (unless stated). If you're documenting a process or policy that _must_ be followed, indicate this at the top of your page.
 
 ## Deleting outdated content
 
 Outdated or inaccurate content should be removed from the handbook whenever it's noticed. Keeping content that is no longer relevant leads to:
+
 - **Confusion:** Which version of the content is correct?
 - **Bloated handbook pages:** Long pages are hard to consume, and should only contain the necessary content.
 
@@ -55,6 +57,7 @@ When deleting content or a page that you don't normally maintain, it's best to d
 
 ## Content Curators
 
-Two [guiding principles](../index.md#guiding-princples) of the Handbook are that everyone can edit the Handbook, and that the Handbook is maintained by everyone. Sometimes, it can be difficult to know *where* to put the content you're looking to add. The @handbook-content-curators group in Slack is here to help. You can tag that group in the #handbook Slack channel for help with things like:
+Two [guiding principles](../index.md#guiding-princples) of the Handbook are that everyone can edit the Handbook, and that the Handbook is maintained by everyone. Sometimes, it can be difficult to know _where_ to put the content you're looking to add. The @handbook-content-curators group in Slack is here to help. You can tag that group in the #handbook Slack channel for help with things like:
+
 1. Where should I put this new page or directory?
 1. Should I create a new page for this content, or embed in an existing page?

--- a/content/handbook/editing/handbook-content-best-practices.md
+++ b/content/handbook/editing/handbook-content-best-practices.md
@@ -1,2 +1,1 @@
 # Handbook Content Best Practices
-

--- a/content/handbook/editing/handbook-content-best-practices.md
+++ b/content/handbook/editing/handbook-content-best-practices.md
@@ -29,7 +29,7 @@ Reach out to the [content curators](#content-curators) for help if you're unsure
 
 To determine where your content should go:
 
-1. Consider the **primary** viewer. Since our handbook is public, anyone can read the content, but you probably have an intended audience in mind. If your content is a company-wide policy or process, it probably belongs in a directory holding company-wide content. If it's a policy or process only your team uses, it probably fits best in your team directory. -**Note:** If your primary viewer is a user of the Sourcegraph product, it should live in the [Sourcegraph Docs](docs.sourcegraph.com).
+1. Consider the **primary** viewer. Since our handbook is public, anyone can read the content, but you probably have an intended audience in mind. If your content is a company-wide policy or process, it probably belongs in a directory holding company-wide content. If it's a policy or process only your team uses, it probably fits best in your team directory. -**Note:** If your primary viewer is a user of the Sourcegraph product, it should live in the [Sourcegraph Docs](https://docs.sourcegraph.com/).
 1. Determine what type of content you are creating. Is it a process describing how we work? Is it a policy that must be followed? Look for a directory with similar types of content. Like content should live together.
 
 Reach out to the [content curators](#content-curators) for help if you're unsure.

--- a/content/handbook/editing/handbook-content-best-practices.md
+++ b/content/handbook/editing/handbook-content-best-practices.md
@@ -1,1 +1,60 @@
 # Handbook Content Best Practices
+
+## Overview
+
+This page is intended to give advice when you're making decisions about handbook content. These aren't mandatory and every case is slightly different, but following best practices will allow us to keep a more organized and easy-to-navigate handbook. TL;DR: our [content curators](#content-curators) are here to help if you're unsure where to add your content, or how to structure a page.
+
+## Creating a new page vs adding to an existing page
+
+There is no hard and fast rule on when to create a new page vs adding a new one. Some things to consider:
+1. Does the content you're adding fit into the narrative of an existing page?
+1. Can you add this to an existing page without making that page too long to consume?
+1. Does the page feel like a "wall of text"?
+
+In general, we want to avoid extremely long pages, and bias towards snackable content. They can become more cumbersome than helpful. This often happens when well-intended changes are made by continuously adding bits of content to existing pages, without stopping to think "Is it time to break this out into more than one page?". Doing so can be time consuming, but it will lead to more readable content throughout the handbook. The [content curators](#content-curators) can help with these types of decisions.
+
+## Creating a new directory vs adding to an existing directory
+
+Should I create a new directory (also called a folder) or add my new content to an existing one? The answer is: it depends. To help in making your decision, ask yourself this:
+
+1. Does this content pair with or compliment existing content?
+  - **If yes**, it should go in the same directory as its companion content.
+  - **If no**, you may want to create a new directory. It's helpful to create a directory rather than just a single file in case you want to add more related files later. See [where should my content go](#where-should-my-content-go) for help with deciding where that new directory should go.
+
+Reach out to the [content curators](#content-curators) for help if you're unsure. 
+
+## Where should my file or directory go?
+
+To determine where your content should go:
+
+1. Consider the **primary** viewer. Since our handbook is public, anyone can read the content, but you probably have an intended audience in mind. If your content is a company-wide policy or process, it probably belongs in a directory holding company-wide content. If it's a policy or process only your team uses, it probably fits best in your team directory. 
+  -**Note:** If your primary viewer is a user of the Sourcegraph product, it should live in the [Sourcegraph Docs](docs.sourcegraph.com).
+1. Determine what type of content you are creating. Is it a process describing how we work? Is it a policy that must be followed? Look for a directory with similar types of content. Like content should live together.
+
+Reach out to the [content curators](#content-curators) for help if you're unsure. 
+
+## Page structure and use of headings
+
+We don't currently have page templates for most areas of the handbook, though this is something we would like to work towards in FY23.
+
+In terms of structure, favor using headings to break up your page. This helps visually break up the page for the viewer, and assists in searchability of content. Headings are weighted heavier in handbook search results, so using a descriptive heading will likely help viewers get to your content more quickly.
+
+## Content objectives
+
+As stated in our [Handbook Usage](../index.md#handbook-usage) page, most content in this handbook is meant to help rather than being absolute rules (unless stated). If you're documenting a process or policy that *must* be followed, indicate this at the top of your page.
+
+## Deleting outdated content
+
+Outdated or inaccurate content should be removed from the handbook whenever it's noticed. Keeping content that is no longer relevant leads to:
+- **Confusion:** Which version of the content is correct?
+- **Bloated handbook pages:** Long pages are hard to consume, and should only contain the necessary content.
+
+When deleting content or a page that you don't normally maintain, it's best to double check with the content owners to be sure what you're deleting is no longer needed. To see who has contributed to a page, look for the "contributors" section on the right side of any handbook page and click on an avatar to see that person's Github profile:
+
+![Handbook contributors](https://storage.googleapis.com/sourcegraph-assets/handbook/handbook-contributors.png)
+
+## Content Curators
+
+Two [guiding principles](../index.md#guiding-princples) of the Handbook are that everyone can edit the Handbook, and that the Handbook is maintained by everyone. Sometimes, it can be difficult to know *where* to put the content you're looking to add. The @handbook-content-curators group in Slack is here to help. You can tag that group in the #handbook Slack channel for help with things like:
+1. Where should I put this new page or directory?
+1. Should I create a new page for this content, or embed in an existing page?

--- a/content/handbook/editing/handbook-content-best-practices.md
+++ b/content/handbook/editing/handbook-content-best-practices.md
@@ -1,0 +1,2 @@
+# Handbook Content Best Practices
+

--- a/content/handbook/editing/index.md
+++ b/content/handbook/editing/index.md
@@ -24,6 +24,7 @@ We don't expect everyone on the team to figure this out on their own. Other team
 - [Markdown Tips & Resources](markdown-resources.md)
 - [Reviewing & Approving Another Peron's Proposal](reviewing-a-proposal.md)
 - [Announcing Important Updates](announcing-handbook-updates.md)
+- [Handbook Content Best Practices](handbook-content-best-practices.md)
 
 ## Editing
 

--- a/content/handbook/index.md
+++ b/content/handbook/index.md
@@ -52,7 +52,8 @@ To be handbook-first, we must:
 - If you want to change a guideline or process, propose an edit to the handbook (by creating a pull request). Discuss and justify the change on the pull request.
   - Do this rather than discussing or drafting the changes in some other channel (Slack, Google Doc, etc.) first. If (for example) you start discussing a proposed change on Slack and then create a PR, you'll end up with half of the discussion on Slack and the other half on the PR, which results in confusion and duplication.
   - **Note:** In some cases, it might make sense to start with an [RFC](../communication/rfcs/index.md). In any case, before changes are implemented, they must be documented in the handbook.
-- Follow the [Sourcegraph content guidelines for consistent voice and style](../communication/content_guidelines/index.md).
+- Follow the [Sourcegraph content guidelines](../communication/content_guidelines/index.md) for consistent voice and style.
+- Follow the [Handbook Content Best Practices](editing/handbook-content-best-practices.md) for help with structuring your content, and deciding where it should live.
 
 ## Why do we use Git? Why not a wiki or Google Docs?
 


### PR DESCRIPTION
This is our first iteration of Handbook Content Best Practices. These will evolve over time, and this page is very open to feedback. This is intended to be a guideline for folks adding new content to the Handbook, and to introduce the concept of Handbook Content Curators (which is just me for now, as we pilot this idea).