### PR TITLE
Add  pages without backlinks to dashboard

### DIFF
--- a/src/pages/meta.tsx
+++ b/src/pages/meta.tsx
@@ -58,12 +58,23 @@ interface IndexProps {
     tree: DirectoryNode<ParsedPage>
 }
 export default function Index({ allPages, tree }: IndexProps): JSX.Element {
+    const pagesWithoutBacklinks = allPages.filter(page => page.backlinks.length === 0)
     return (
         <div className="container">
             <section id="content">
                 <h1>Handbook Dashboard</h1>
                 <h2>Statistics</h2>
                 <p>The handbook contains {allPages.length} pages.</p>
+
+                <h2>Pages without backlinks: {pagesWithoutBacklinks.length}</h2>
+                <ul>
+                    {pagesWithoutBacklinks.map(p => (
+                        <li>
+                            <a href={`/${p.slugPath}`}>{p.title}</a> ({p.path})
+                        </li>
+                    ))}
+                </ul>
+
                 <h2>Tree view</h2>
                 <ul>
                     <DirectoryItem node={tree} />

--- a/src/pages/meta.tsx
+++ b/src/pages/meta.tsx
@@ -68,9 +68,9 @@ export default function Index({ allPages, tree }: IndexProps): JSX.Element {
 
                 <h2>Pages without backlinks: {pagesWithoutBacklinks.length}</h2>
                 <ul>
-                    {pagesWithoutBacklinks.map(p => (
-                        <li>
-                            <a href={`/${p.slugPath}`}>{p.title}</a> ({p.path})
+                    {pagesWithoutBacklinks.map(page => (
+                        <li key={page.path}>
+                            <a href={`/${page.slugPath}`}>{page.title}</a> ({page.path})
                         </li>
                     ))}
                 </ul>


### PR DESCRIPTION
Show the list of pages that don't have backlinks.

This is a debug measure to help identify pages that aren't linked to anywhere, while we are working on having this be a check in the PR checks.