### PR TITLE
Remove vision breakout

### DIFF
--- a/content/company/strategy/code-graph/index.md
+++ b/content/company/strategy/code-graph/index.md
@@ -1,24 +1,12 @@
 # Code Graph strategy
 
-We have teams working on [Search](./search/index.md), [Code Insights](./code-insights/index.md), [Code Intelligence](./code-intelligence/index.md), and [Batch Changes](./batch-changes/index.md); this page describes the overarching mission and strategy that ties them together, but each linked team also provides a more detailed strategy page with what they are working on next and why. There is also a whole-company [Sourcegraph strategy](../index.md) available.
+We have teams working on [Search](./search/index.md), [Code Insights](./code-insights/index.md), [Code Intelligence](./code-intelligence/index.md), and [Batch Changes](./batch-changes/index.md); this page describes the mission and strategy that ties them together, but each linked page provides a more detailed strategy for that team including what they are working on next and why. There is also a whole-company [Sourcegraph strategy](../index.md) available to which all of this is aligned.
 
 ## Mission
 
-We want to make finding, understanding, and editing code easier, regardless of how much you have, how complex it is, where you store it, or even how technical you are.
-
-## Vision
-
-### One year vision
-
-> We want to ensure that we are solving the most critical problems for our enterprise users, focusing on retaining existing and acquiring new enterprise customers. By providing as much value as possible to them, we can grow the business while solving the hardest scaling and complexity problems for everyone.
-
-### Three year vision
-
-> We imagine a much more connected experience, not just in terms of the kinds of searching that you're able to do, but in how we can offer suggestions for interesting searches and what you can do with the results. Expanding on capabilities we've introduced recently, such as semantic search, insights, and batch changes, we will offer an unparalleled solution for searching and making decisions across branches, repositories, and even code hosts, beyond even what's possible today.
-
-### Ten year vision
-
-> We want to make using Sourcegraph to understand and modify code so easy that anyone can do it, including people not traditionally considered developers. We want to [democratize coding](../index.md#ten-year-vision) by making it so that everyone in the company can engage with the organization's code, safely making changes to implement their department's priorities and interests, without need for an intermediary to do it for them.
+- Make finding, understanding, and editing code easier, regardless of how complex it is, where you store it, or how technical you are.
+- Build connected experiences that tie together insights, searching, and making changes into a natural work flow.
+- Make onboarding into and understanding a new code base easy for both experts and new developers.
 
 ## Principles
 
@@ -43,9 +31,7 @@ If we achieve these points, we can make it easy for developers to get things don
 
 ## Themes & Goals
 
-We are focused on several themes to help make our one year vision a reality. They are not listed in priority order. To see how these play into what any particular product team is delivering, take a look at the individual team strategy pages linked at the [top of this page](#code-graph).
-
-We also set our goals around these themes, you can see current FY22-Q4 goals as a bullet list in each theme. The team listed after each goal is the primary team responsible for implementing the goal, but in the end we achieve these together and will support each other as needed to make them reality. The current status can be found at our [high-level OKR and roadmap tracker](https://github.com/orgs/sourcegraph/projects/214/views/11) (internal only) or on the [slides version of the same content](https://docs.google.com/presentation/d/1DgY3k684Jn3diCe4GPPcrGt9iaD9-vyndiiJwEoELyE/edit?usp=sharing) (also internal only).
+We are focused on several themes that bridge all of our teams to help make our one year vision a reality. We also set our goals around these themes, so you can see current FY22-Q4 goals as a bullet list in each theme. The team listed after each goal is the primary team responsible for implementing the goal, but in the end we achieve these together and will support each other as needed to make them reality. The current status can be found at our [high-level OKR and roadmap tracker](https://github.com/orgs/sourcegraph/projects/214/views/11) (internal only) or on the [slides version of the same content](https://docs.google.com/presentation/d/1DgY3k684Jn3diCe4GPPcrGt9iaD9-vyndiiJwEoELyE/edit?usp=sharing) (also internal only). Note that none of these goals or themes are listed in priority order. 
 
 ### Make the power of our features easier to find and use
 

--- a/content/company/strategy/code-graph/index.md
+++ b/content/company/strategy/code-graph/index.md
@@ -31,7 +31,7 @@ If we achieve these points, we can make it easy for developers to get things don
 
 ## Themes & Goals
 
-We are focused on several themes that bridge all of our teams to help make our one year vision a reality. We also set our goals around these themes, so you can see current FY22-Q4 goals as a bullet list in each theme. The team listed after each goal is the primary team responsible for implementing the goal, but in the end we achieve these together and will support each other as needed to make them reality. The current status can be found at our [high-level OKR and roadmap tracker](https://github.com/orgs/sourcegraph/projects/214/views/11) (internal only) or on the [slides version of the same content](https://docs.google.com/presentation/d/1DgY3k684Jn3diCe4GPPcrGt9iaD9-vyndiiJwEoELyE/edit?usp=sharing) (also internal only). Note that none of these goals or themes are listed in priority order. 
+We are focused on several themes that bridge all of our teams to help make our one year vision a reality. We also set our goals around these themes, so you can see current FY22-Q4 goals as a bullet list in each theme. The team listed after each goal is the primary team responsible for implementing the goal, but in the end we achieve these together and will support each other as needed to make them reality. The current status can be found at our [high-level OKR and roadmap tracker](https://github.com/orgs/sourcegraph/projects/214/views/11) (internal only) or on the [slides version of the same content](https://docs.google.com/presentation/d/1DgY3k684Jn3diCe4GPPcrGt9iaD9-vyndiiJwEoELyE/edit?usp=sharing) (also internal only). Note that none of these goals or themes are listed in priority order.
 
 ### Make the power of our features easier to find and use
 

--- a/content/engineering/cloud/devops/index.md
+++ b/content/engineering/cloud/devops/index.md
@@ -21,7 +21,7 @@ The Cloud DevOps team is responsible for the infrastructure used to host Sourceg
 
 ## How to contact the team and ask for help
 
-The best way to contact the cloud-devops team is in the #cloud-devops slack channel. 
+The best way to contact the cloud-devops team is in the #cloud-devops slack channel.
 
 ## Goals
 


### PR DESCRIPTION
I think we can summarize the mission + vision with these three bullets instead of everything we had there. By keeping things minimal here we avoid duplicating content either at a higher or lower level.

Since this is only a structural change I'm going ahead with merging.