### PR TITLE
Make table of contents always show h1 h2 h3

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -16,7 +16,9 @@ export function TableOfContents({
                 <React.Fragment key={node.id}>
                     <li>
                         <a href={node.id && `${hrefPrefix}#${node.id}`}>{node.value}</a>
-                        {node.children && <TableOfContents toc={node.children} hrefPrefix={hrefPrefix} />}
+                        {node.children && (
+                            <TableOfContents toc={node.children} hrefPrefix={hrefPrefix} className="active" />
+                        )}
                     </li>
                 </React.Fragment>
             ))}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -51,44 +51,6 @@ const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
 export default function Page({ page }: PageProps): JSX.Element {
     const markdownBodyReference = useRef<HTMLElement>(null)
     const tocReference = useRef<HTMLElement>(null)
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            entries => {
-                for (const entry of entries) {
-                    const tocLink = tocReference.current?.querySelector<HTMLAnchorElement>(
-                        `a[href="#${entry.target.querySelector(HEADING_SELECTOR)!.id}"]`
-                    )
-                    const listItem = tocLink?.parentElement
-                    if (entry.intersectionRatio > 0) {
-                        // Visible: Mark <li> item and all ancestors (<li>s, <ul>s) as active
-                        for (
-                            let parent = listItem;
-                            parent && parent !== tocReference.current;
-                            parent = parent.parentElement
-                        ) {
-                            parent.classList.add('active')
-                        }
-                    } else {
-                        // Not visible: Mark <li> item and all children as inactive
-                        listItem?.classList.toggle('active', false)
-                        for (const descendentItem of listItem?.querySelectorAll('ul, li') ?? []) {
-                            descendentItem.classList.remove('active')
-                        }
-                    }
-                }
-            },
-            {
-                // Header height
-                rootMargin: '-72px 0px 0px 0px',
-            }
-        )
-        const headings = markdownBodyReference.current?.querySelectorAll(HEADING_SELECTOR)
-        for (const heading of headings ?? []) {
-            const section = heading.parentElement!
-            observer.observe(section)
-        }
-        return () => observer.disconnect()
-    })
 
     const router = useRouter()
     if (!router.isFallback && !page?.slugPath) {

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -3,7 +3,7 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import ErrorPage from 'next/error'
 import { useRouter } from 'next/router'
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 
 import { EditSection } from '../components/EditSection'
 import { TableOfContents } from '../components/TableOfContents'
@@ -45,8 +45,6 @@ export interface PageWithMetadata extends LoadedPage {
 export interface PageProps {
     page: PageWithMetadata
 }
-
-const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
 
 export default function Page({ page }: PageProps): JSX.Element {
     const markdownBodyReference = useRef<HTMLElement>(null)

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -10,6 +10,7 @@
         flex: 1 1 calc(var(--width) * 0.15);
         max-width: 17rem;
         max-height: calc(100vh - var(--header-height) - var(--index-margin-top));
+        white-space: nowrap;
     }
 }
 
@@ -42,6 +43,7 @@
     padding-left: 0;
     margin-left: -0.5rem;
     margin-bottom: 0;
+    font-size: 0.9rem;
 
     &,
     & ul {


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/handbook/issues/901 (maybe)

This makes it so the full table of contents, including the h1 (`#`) page title, h2 (`##`) and h3 (`###`) headings, are always visible.

It makes the font size slightly smaller and never wraps the heading text so that it is more likely to fit on the page, but if there are lots and lots of headings it could result in scrolling on the right. That was possible before, but could be more likely now.

I think it still looks nice, and doesn't have the popping in and out which IMHO looks better. You can see it in action on any of the pages in the review app (https://deploy-preview-933--sourcegraph-handbook.netlify.app/)

In the future, if we want to get more clever, we could hide contributors in cases where the table of contents needs the space. But don't know at this point if that's even really necessary.

As a side effect this seems to fix the issue where pages "vibrate" on narrow screens.