### PR TITLE
Temporarily disable large files check action

### DIFF
--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,34 +1,34 @@
-name: Check that there are no large binary files
+# name: Check that there are no large binary files
 
-on:
-  pull_request:
-    types: [opened, synchronize]
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
 
-jobs:
-  large-files:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-        name: Checkout repository
-        with:
-          fetch-depth: 0 # We analyze Git history
+# jobs:
+#   large-files:
+#     runs-on: macos-11
+#     steps:
+#       - uses: actions/checkout@v2
+#         name: Checkout repository
+#         with:
+#           fetch-depth: 0 # We analyze Git history
 
-      - name: Check for large files
-        uses: Amadevus/pwsh-script@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            $global:ProgressPreference = 'SilentlyContinue'
-            $global:InformationPreference = 'Continue'
+#       - name: Check for large files
+#         uses: Amadevus/pwsh-script@v2
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           script: |
+#             $global:ProgressPreference = 'SilentlyContinue'
+#             $global:InformationPreference = 'Continue'
 
-            Set-StrictMode -Version 3.0
+#             Set-StrictMode -Version 3.0
 
-            Install-Module PowerGit -Force -ErrorAction Stop
-            Install-Module PSGitHub -Force -ErrorAction Stop
+#             Install-Module PowerGit -Force -ErrorAction Stop
+#             Install-Module PSGitHub -Force -ErrorAction Stop
 
-            $PSDefaultParameterValues['*:GitHub*'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
+#             $PSDefaultParameterValues['*:GitHub*'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
 
-            $baseRef = $github.base_ref
-            git branch $BaseRef "origin/$BaseRef"
-            ./src/scripts/check-large-files.ps1 -BaseRef $baseRef -PullRequestNumber $github.event.pull_request.number
+#             $baseRef = $github.base_ref
+#             git branch $BaseRef "origin/$BaseRef"
+#             ./src/scripts/check-large-files.ps1 -BaseRef $baseRef -PullRequestNumber $github.event.pull_request.number


### PR DESCRIPTION
Created an issue for us to come back to this: https://github.com/sourcegraph/handbook/issues/951