### PR TITLE
Restore large files check

### DIFF
--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,34 +1,34 @@
-# name: Check that there are no large binary files
+name: Check that there are no large binary files
 
-# on:
-#   pull_request:
-#     types: [opened, synchronize]
+on:
+  pull_request:
+    types: [opened, synchronize]
 
-# jobs:
-#   large-files:
-#     runs-on: macos-11
-#     steps:
-#       - uses: actions/checkout@v2
-#         name: Checkout repository
-#         with:
-#           fetch-depth: 0 # We analyze Git history
+jobs:
+  large-files:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout repository
+        with:
+          fetch-depth: 0 # We analyze Git history
 
-#       - name: Check for large files
-#         uses: Amadevus/pwsh-script@v2
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         with:
-#           script: |
-#             $global:ProgressPreference = 'SilentlyContinue'
-#             $global:InformationPreference = 'Continue'
+      - name: Check for large files
+        uses: Amadevus/pwsh-script@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            $global:ProgressPreference = 'SilentlyContinue'
+            $global:InformationPreference = 'Continue'
 
-#             Set-StrictMode -Version 3.0
+            Set-StrictMode -Version 3.0
 
-#             Install-Module PowerGit -Force -ErrorAction Stop
-#             Install-Module PSGitHub -Force -ErrorAction Stop
+            Install-Module PowerGit -Force -ErrorAction Stop
+            Install-Module PSGitHub -Force -ErrorAction Stop
 
-#             $PSDefaultParameterValues['*:GitHub*'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
+            $PSDefaultParameterValues['*:GitHub*'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
 
-#             $baseRef = $github.base_ref
-#             git branch $BaseRef "origin/$BaseRef"
-#             ./src/scripts/check-large-files.ps1 -BaseRef $baseRef -PullRequestNumber $github.event.pull_request.number
+            $baseRef = $github.base_ref
+            git branch $BaseRef "origin/$BaseRef"
+            ./src/scripts/check-large-files.ps1 -BaseRef $baseRef -PullRequestNumber $github.event.pull_request.number

--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,0 +1,34 @@
+# name: Check that there are no large binary files
+
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
+
+# jobs:
+#   large-files:
+#     runs-on: macos-11
+#     steps:
+#       - uses: actions/checkout@v2
+#         name: Checkout repository
+#         with:
+#           fetch-depth: 0 # We analyze Git history
+
+#       - name: Check for large files
+#         uses: Amadevus/pwsh-script@v2
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           script: |
+#             $global:ProgressPreference = 'SilentlyContinue'
+#             $global:InformationPreference = 'Continue'
+
+#             Set-StrictMode -Version 3.0
+
+#             Install-Module PowerGit -Force -ErrorAction Stop
+#             Install-Module PSGitHub -Force -ErrorAction Stop
+
+#             $PSDefaultParameterValues['*:GitHub*'] = ConvertTo-SecureString -String $env:GITHUB_TOKEN -AsPlainText -Force
+
+#             $baseRef = $github.base_ref
+#             git branch $BaseRef "origin/$BaseRef"
+#             ./src/scripts/check-large-files.ps1 -BaseRef $baseRef -PullRequestNumber $github.event.pull_request.number

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -27,7 +27,12 @@ $largeChanges =
   # Filter for binary blobs larger than the limit
   Where-Object {
     $blob = $repo.Lookup($_.Oid)
-    Write-Information "$($_.Path) $($blob.Size) $($blob.IsBinary)"
+    $message = "$($_.Path) Size=$($blob.Size)B IsBinary=$($blob.IsBinary)"
+    if ($blob.IsBinary) {
+      Write-Warning $message
+    } else {
+      Write-Information $message
+    }
     $blob.Size -gt $limit -and $blob.IsBinary
   }
 

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -17,7 +17,7 @@ $base = Get-GitCommit $BaseRef
 
 $largeChanges =
   # Get all commits between HEAD and the base ref
-  Get-GitCommit -Since HEAD -Until $base.Sha |
+  Get-GitCommit -Since HEAD -Until $base.Sha -NoMerges |
   # Compare commit to the parent
   ForEach-Object { Compare-GitTree -ReferenceRevision ($_.Parents | Select-Object -First 1).Sha -DifferenceRevision $_.Sha } |
   # Flatten changes collection

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -43,9 +43,9 @@ if ($largeChanges) {
     $message += "`nIf the images you want to add are _diagrams_, _infographics_, or other image types containing **text**, please consider exporting them as [SVG](https://blog.hubspot.com/website/what-is-an-svg-file) instead, which are **allowed** to be added to the repository, more accessible and higher quality.`n`n"
   }
 
-  # TODO: Add link to "Editing the handbook" page once that contains more instructions.
-
   $message += "`n" +
+    "You can find more information on the handbook page [Adding images or video to the handbook](https://handbook.sourcegraph.com/handbook/editing/handbook-images-video).`n" +
+    "`n" +
     "This branch will need to be **rebased** with the binary file completely removed, otherwise the file will still be present in the repository history. @sourcegraph/handbook-support will be happy to help with this.`n" +
     "`n" +
     "The following large binary files $still need to be removed:`n" +

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -37,7 +37,7 @@ $largeChanges =
   Where-Object {
     $blob = $repo.Lookup($_.Oid)
     $message = "{0} Size={1:N0}B IsBinary={2}" -f $_.Path, $blob.Size, $blob.IsBinary
-    if ($blob.IsBinary) {
+    if ($blob.Size -gt $limit -and $blob.IsBinary) {
       Write-Warning $message
     } else {
       Write-Information $message

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -22,8 +22,8 @@ $largeChanges =
   ForEach-Object { Compare-GitTree -ReferenceRevision ($_.Parents | Select-Object -First 1).Sha -DifferenceRevision $_.Sha } |
   # Flatten changes collection
   ForEach-Object { $_ } |
-  # Ignore deleted files and files outside the content/ folder
-  Where-Object { $_.Status -ne 'Deleted' -and $_.Path -like 'content/*' } |
+  # Ignore deleted files, renamed/moved files and files outside the content/ folder
+  Where-Object { $_.Status -notin 'Deleted','Renamed' -and $_.Path -like 'content/*' } |
   # Filter for binary blobs larger than the limit
   Where-Object {
     $blob = $repo.Lookup($_.Oid)

--- a/src/scripts/check-large-files.ps1
+++ b/src/scripts/check-large-files.ps1
@@ -36,7 +36,7 @@ $largeChanges =
   # Filter for binary blobs larger than the limit
   Where-Object {
     $blob = $repo.Lookup($_.Oid)
-    $message = "$($_.Path) Size=$($blob.Size)B IsBinary=$($blob.IsBinary)"
+    $message = "{0} Size={1:N0}B IsBinary={2}" -f $_.Path, $blob.Size, $blob.IsBinary
     if ($blob.IsBinary) {
       Write-Warning $message
     } else {


### PR DESCRIPTION
- Revert temporary removal of large files checks
- Ignore moved/renamed files (this is what caused failures on Nick's branch)
- For merge commits, consider only changes present compared to all parent commits. This prevents branches failing when merging in `main` if there were large binary files touched between latest `main` and the base of the branch. Before, it would consider those changes part of the branch too, now it will ignore those. (this is what caused failures on other branches after Nick merged)
- Some improvements in reporting and formatting.