### PR TITLE
update demo day to new schedule

### DIFF
--- a/content/product-engineering/demo-day.md
+++ b/content/product-engineering/demo-day.md
@@ -1,6 +1,6 @@
 # Demo day
 
-On the **second Tuesday of the month**, Product and Engineering team members present the latest features and improvements to Sourcegraph.
+Directly following the first Company Meeting of the month, Product and Engineering team members present the latest features and improvements to Sourcegraph.
 
 Demos should be short and easy to prepare for, so that as many team members as possible are able to participate. Demos are recorded for folks across the company, customers, and future team members to reference.
 

--- a/content/product-engineering/demo-day.md
+++ b/content/product-engineering/demo-day.md
@@ -1,6 +1,6 @@
 # Demo day
 
-On the **first Monday of the month** directly following [Company meeting](../communication/company_meeting.md), Product and Engineering team members present the latest features and improvements to Sourcegraph.
+On the **second Tuesday of the month**, Product and Engineering team members present the latest features and improvements to Sourcegraph.
 
 Demos should be short and easy to prepare for, so that as many team members as possible are able to participate. Demos are recorded for folks across the company, customers, and future team members to reference.
 


### PR DESCRIPTION
@kyfli I noticed the demo day page still said "first monday of the month directly following the company meeting" and did my best to update to what I _think_ is the current schedule, but wanted to get your approval before merging. Let me know if this looks accurate! 