### PR TITLE
Update Batch Changes positioning page to be more actionable

### DIFF
--- a/content/company/strategy/code-graph/batch-changes/index.md
+++ b/content/company/strategy/code-graph/batch-changes/index.md
@@ -4,11 +4,12 @@ Batch Changes is a tool to find code that needs to be changed and change it at s
 
 ## Quick links
 
-- [Code Graph overall strategy](../../../../product-engineering/engineering/code-graph/batch-changes/index.md)
-- [Batch Changes team page](../../../../product-engineering/engineering/code-graph/batch-changes)
-- [Planning board](https://github.com/orgs/sourcegraph/projects/216)
+- [Code Graph overall strategy](../../../../product-engineering/engineering/code-graph/index.md)
+- [Batch Changes positioning and messaging](../../../../marketing/product-marketing/batch_changes_positioning.md)
 - [Demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw)
 - [Batch Changes documentation](https://docs.sourcegraph.com/batch_changes)
+- [Batch Changes team page](../../../../product-engineering/engineering/code-graph/batch-changes)
+- [Planning board](https://github.com/orgs/sourcegraph/projects/216)
 
 ## Vision
 

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -3,7 +3,6 @@
 ## Overview
 
 - **Product name:** Batch Changes (formerly known as Campaigns)
-- **Marketing launch date:** 2021-03-24
 - **Access and pricing:** Paid add-on for Enterprise customers; all customers can try the product (limit: 5 changesets)
 
 ## Positioning and value drivers

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -36,19 +36,21 @@ When developers need to make changes across multiple repositories or workspaces:
 There are many ways to get value out of Batch Changes, but here are the two approaches that are the most successfull:
 
 ### Playbook 1
+
 - User persona: a platform team that is responsible for a framework or platform. Sample teams: Java platform team, client platform team, frontend platform team.
 - Painpoint: When shipping new internal library versions with breaking changes, getting other teams to upgrade takes a lot of time and effort.
 - Use case: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
 - Sponsor: developer experience team
 
 ### Playbook 2
+
 - User persona: an infrastructure team, sometimes also responsible for developer experience
 - Painpoint: Infrastructure or configuration files have a lot of repetitive / boilerplate code that is very time-consuming to change.
 - Use case: ship updates to configuration across many repositories.
-   - Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
-   - Update infrastructure-as-code (eg. Terraform) files across many repositories
+  - Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
+  - Update infrastructure-as-code (eg. Terraform) files across many repositories
 
-### Other use cases 
+### Other use cases
 
 - **Refactoring:** Use language-aware tooling of your choice to perform complex refactors like updating an API and its function calls or replacing libraries entirely.
 - **Security:** When problems occur with critical security updates, every hour that goes by increases risk. Batch Changes enables you to find any place where vulnerabilities exist and then refactor code to replace insecure functions, update vulnerable packages, or modify container configurations across hundreds of repositories.

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -37,16 +37,16 @@ There are many ways to get value out of Batch Changes, but here are the two appr
 
 ### Playbook 1
 
-- User persona: a platform team that is responsible for a framework or platform. Sample teams: Java platform team, client platform team, frontend platform team.
-- Painpoint: When shipping new internal library versions with breaking changes, getting other teams to upgrade takes a lot of time and effort.
-- Use case: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
-- Sponsor: developer experience team
+- **User persona**: a platform team that is responsible for a framework or platform. Sample teams: Java platform team, client platform team, frontend platform team.
+- **Painpoint**: When shipping new internal library versions with breaking changes, getting other teams to upgrade takes a lot of time and effort.
+- **Use case**: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
+- **Sponsor**: developer experience team
 
 ### Playbook 2
 
-- User persona: an infrastructure team, sometimes also responsible for developer experience
-- Painpoint: Infrastructure or configuration files have a lot of repetitive / boilerplate code that is very time-consuming to change.
-- Use case: ship updates to configuration across many repositories.
+- **User persona**: an infrastructure team, sometimes also responsible for developer experience
+- **Painpoint**: Infrastructure or configuration files have a lot of repetitive / boilerplate code that is very time-consuming to change.
+- **Use case**: ship updates to configuration across many repositories.
   - Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
   - Update infrastructure-as-code (eg. Terraform) files across many repositories
 

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -72,9 +72,8 @@ If the developer does not know, default to:
 
 ## Resources
 
-- [Batch Changes strategy page]
+- [Batch Changes strategy page](../../company/strategy/code-graph/batch-changes)
 - [Docs](https://docs.sourcegraph.com/batch_changes)
-- [Landing page](https://about.sourcegraph.com/batch-changes)
 - [Demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw)
 - [Blog post](https://about.sourcegraph.com/blog/introducing-batch-changes/)
 - (private) AE training [recording](https://drive.google.com/file/d/10oeyEvKNKk4RdyJUtvc-rXcgcmGhSrc2/view?usp=sharing) [slides](https://docs.google.com/presentation/d/1N50kk1N712lvsWI_BrGB4WH8LHnOVYrkxqvRS9WubuA/edit#slide=id.g7d2aea8729_0_0)

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -39,18 +39,18 @@ There are many ways to get value out of Batch Changes, but here are the two appr
 
 - **User persona**: a platform team that is responsible for a framework or platform. Sample teams: Java platform team, client platform team, frontend platform team.
 - **Painpoint**: When shipping new internal library versions with breaking changes, getting other teams to upgrade takes a lot of time and effort.
-- **Use case**: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
+- **Product use case**: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
 - **Sponsor**: developer experience team
 
 ### Playbook 2
 
 - **User persona**: an infrastructure team, sometimes also responsible for developer experience
 - **Painpoint**: Infrastructure or configuration files have a lot of repetitive / boilerplate code that is very time-consuming to change.
-- **Use case**: ship updates to configuration across many repositories.
+- **Product use case**: ship updates to configuration across many repositories.
   - Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
   - Update infrastructure-as-code (eg. Terraform) files across many repositories
 
-### Other use cases
+### Other product use cases
 
 - **Refactoring:** Use language-aware tooling of your choice to perform complex refactors like updating an API and its function calls or replacing libraries entirely.
 - **Security:** When problems occur with critical security updates, every hour that goes by increases risk. Batch Changes enables you to find any place where vulnerabilities exist and then refactor code to replace insecure functions, update vulnerable packages, or modify container configurations across hundreds of repositories.

--- a/content/marketing/product-marketing/batch_changes_positioning.md
+++ b/content/marketing/product-marketing/batch_changes_positioning.md
@@ -11,21 +11,19 @@
 
 Sourcegraph Batch Changes enables developers to automate and manage large-scale code changes across all of their repositories and code hosts.
 
-### Value driver: Accelerate developer velocity
+### Value driver: Developer velocity
 
 #### Pains
 
 When developers need to make changes across multiple repositories or workspaces:
 
-- Asking each repository owner to make changes duplicates effort and lengthens time required
+- Asking each repository owner to make changes takes a lot of time and effort
 - Tracking changes to many repositories requires spreadsheets and manual labor
-- When problems occur with critical security updates, every hour that goes by increases risk
-- Internal library authors need to enable and sometimes force upgrades.
+- Automating applying changes with one-off scripts is brittle
 
 #### Benefits
 
-- Can reduce the time it takes to make large-scale code changes by 80%
-- Improve code quality throughout the org by reducing the risk of bugs or bad code making it to production
+- Reduce the time it takes to make large-scale code changes by up to 80%
 - Turn control back to the developer making the change. Instead of asking for help, they can automate the change and ask for review.
 
 #### Customer proof points
@@ -33,20 +31,27 @@ When developers need to make changes across multiple repositories or workspaces:
 - [Workiva reduces the time it takes to make large-scale code changes by 80%](https://about.sourcegraph.com/case-studies/workiva-automates-large-scale-code-changes)
 - [Indeed keeps code up to date and accelerates development velocity](https://about.sourcegraph.com/case-studies/indeed-accelerates-development-velocity)
 
-## Personas
+## Go-to-market playbook
 
-- **Engineering leadership:** Efficiency gains; accelerate developer velocity
-- **Infrastructure, platform and framework teams:** Getting other teams to make changes is really hard and time consuming
-- **Site reliability engineers:** Deploy & maintain services across hundreds of repos
-- **Security engineers:** Faster updates = less risk
-- **Engineers with microservice architectures** in general: Managing 10s to 100s of repos efficiently requires automation
+There are many ways to get value out of Batch Changes, but here are the two approaches that are the most successfull:
 
-## Use cases
+### Playbook 1
+- User persona: a platform team that is responsible for a framework or platform. Sample teams: Java platform team, client platform team, frontend platform team.
+- Painpoint: When shipping new internal library versions with breaking changes, getting other teams to upgrade takes a lot of time and effort.
+- Use case: When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
+- Sponsor: developer experience team
 
-- **Security:** When problems occur with critical security updates, every hour that goes by increases risk. Batch Changes enables you to find any place where vulnerabilities exist and then refactor code to replace insecure functions, update vulnerable packages, or modify container configurations across hundreds of repositories.
-- **Configuration:** Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
+### Playbook 2
+- User persona: an infrastructure team, sometimes also responsible for developer experience
+- Painpoint: Infrastructure or configuration files have a lot of repetitive / boilerplate code that is very time-consuming to change.
+- Use case: ship updates to configuration across many repositories.
+   - Quickly edit every CI, build, and other configuration files to make changes such as altering steps, migrating versions or changing base images.
+   - Update infrastructure-as-code (eg. Terraform) files across many repositories
+
+### Other use cases 
+
 - **Refactoring:** Use language-aware tooling of your choice to perform complex refactors like updating an API and its function calls or replacing libraries entirely.
-- **Ship Breaking changes:** When updating boilerplate code, internal libraries, or frameworks across a company, use Batch Changes to rollout the upgrade to all consumer repositories.
+- **Security:** When problems occur with critical security updates, every hour that goes by increases risk. Batch Changes enables you to find any place where vulnerabilities exist and then refactor code to replace insecure functions, update vulnerable packages, or modify container configurations across hundreds of repositories.
 
 ## Discovery
 
@@ -61,9 +66,11 @@ If the developer does not know, default to:
 
 - Tell me about a time you were asked to merge a change from a framework library?
 - Tell me about a time you were blocked because an internal library wasn’t updated?
+- Tell me about a time you were tracking pull requests in a spreadsheet?
 
 ## Resources
 
+- [Batch Changes strategy page]
 - [Docs](https://docs.sourcegraph.com/batch_changes)
 - [Landing page](https://about.sourcegraph.com/batch-changes)
 - [Demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw)


### PR DESCRIPTION
We have learnt a lot since launch. We have now narrowed down some repeatable sales and use cases patterns. There are others we are still discovering and testing out (eg. security), but we should focus on what works, while discovering more.

This PR brings those learning to this page. I took the angle of making it more tactical ("what could a sales team mate use effectively"). The strategic positioning source of truth is in the batch changes [strategy page](https://handbook.sourcegraph.com/company/strategy/code-graph/batch-changes) (PRs welcome there).

I also tightened up some of the wording to align with what we use in practice.