### PR TITLE
Add more members to team info page

### DIFF
--- a/data/features.yml
+++ b/data/features.yml
@@ -2,7 +2,7 @@
 
 literal_search:
   title: Literal Search
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/reference/queries
   compatibility:
@@ -21,7 +21,7 @@ literal_search:
 
 regexp_search:
   title: Regular Expression Search
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/reference/queries
   compatibility:
@@ -40,7 +40,7 @@ regexp_search:
 
 structural_search:
   title: Structural Search
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/reference/queries
   compatibility:
@@ -59,7 +59,7 @@ structural_search:
 
 diff_commit_search:
   title: Diff/Commit Search
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/reference/queries
   compatibility:
@@ -78,7 +78,7 @@ diff_commit_search:
 
 code_monitoring:
   title: Code Monitoring
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_monitoring
   compatibility:
@@ -97,7 +97,7 @@ code_monitoring:
 
 code_monitoring_email_notifications:
   title: Code Monitoring E-mail Notifications
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_monitoring
   compatibility:
@@ -116,12 +116,12 @@ code_monitoring_email_notifications:
 
 code_monitoring_webhooks:
   title: Code Monitoring Webhooks
-  product_team: search
+  product_team: search_product
   maturity: not_implemented
 
 saved_searches:
   title: Saved Searches
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/explanations/features#saved-searches
   compatibility:
@@ -140,7 +140,7 @@ saved_searches:
 
 search_contexts:
   title: Search Contexts
-  product_team: search
+  product_team: search_product
   maturity: ga
   documentation_link: https://docs.sourcegraph.com/code_search/explanations/features#search-contexts
   compatibility:

--- a/data/product_orgs.yml
+++ b/data/product_orgs.yml
@@ -4,13 +4,16 @@ code_graph:
   title: Code Graph
   strategy_link: /company/strategy/code-graph/index.md
   pm: jason_yavorska
+  em: yink_teo
 
 cloud:
   title: Cloud
   strategy_link: /company/strategy/index.md#cloud
   pm: anna_mikhova
+  em: bill_creager
 
 enablement:
   title: Enablement
   strategy_link: /company/strategy/enablement/index.md
   pm: serina_clark
+  em: jean_du_plessis

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -1,12 +1,26 @@
 # yaml-language-server: $schema=../schema/product_teams.schema.json
 
-search:
-  title: Search
+search_product:
+  title: Search Product
   product_org: code_graph
-  strategy_link: /company/strategy/code-graph/search/index.md
+  strategy_link: /company/strategy/code-graph/search/search_product/index.md
   pm: ben_venker
+  em: felix_becker
+  design: rob_rhyne
+  pmm: alex_isken
   issue_labels:
     - team/search-product
+    - team/search
+
+search_core:
+  title: Search Core
+  product_org: code_graph
+  strategy_link: /company/strategy/code-graph/search/search_core/index.md
+  pm: loïc_guychard
+  em: jeff_warner
+  design: rob_rhyne
+  pmm: alex_isken
+  issue_labels:
     - team/search-core
     - team/search
 
@@ -15,6 +29,9 @@ code_intelligence:
   product_org: code_graph
   strategy_link: /company/strategy/code-graph/code-intelligence/index.md
   pm: maría_craig
+  em: owen_convey
+  design: sara_lee
+  pmm: victoria_yunger
   issue_labels:
     - team/code-intelligence
 
@@ -23,6 +40,9 @@ batch_changes:
   product_org: code_graph
   strategy_link: /company/strategy/code-graph/batch-changes/index.md
   pm: malo_marrec
+  em: chris_pine
+  design: rob_rhyne
+  pmm: alex_isken
   issue_labels:
     - team/batchers
 
@@ -31,6 +51,9 @@ code_insights:
   product_org: code_graph
   strategy_link: /company/strategy/code-graph/code-insights/index.md
   pm: joel_kwartler
+  em: felix_becker
+  design: alicja_suska
+  pmm: victoria_yunger
   issue_labels:
     - team/code-insights
 

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -14,7 +14,7 @@ function createRelativeProductLink(link) {
   if (link.startsWith('http')) {
     return link
   }
-  return `..${String(link)}`
+  return `../..${String(link)}`
 }
 
 export async function generateMaturityDefinitions() {
@@ -46,7 +46,7 @@ export async function generateFeatureMaturityLevels() {
       )}))\n`
     }
     if (productTeam.pm) {
-      const bioLink = `../company/team/index.md#${String(
+      const bioLink = `../../company/team/index.md#${String(
         teamMembers[productTeam.pm].name.toLowerCase().replace(/\s+/g, '-')
       )}`
       areaContent += `\nProduct Manager: [${String(teamMembers[productTeam.pm].name)}](${String(bioLink)})`
@@ -95,7 +95,7 @@ export async function generateFeatureCodeHostCompatibilities() {
       )}))\n`
     }
     if (productTeam.pm) {
-      const bioLink = `../company/team/index.md#${String(
+      const bioLink = `../../company/team/index.md#${String(
         teamMembers[productTeam.pm].name.toLowerCase().replace(/\s+/g, '-')
       )}`
       areaContent += `\nProduct Manager: [${String(teamMembers[productTeam.pm].name)}](${String(bioLink)})`
@@ -190,32 +190,53 @@ export async function generateProductTeamsList() {
   const teamMembers = await readYamlFile('data/team.yml')
   let pageContent = ''
   for (const [productOrgName, productOrg] of Object.entries(productOrgs)) {
-    pageContent += `\n### ${String(productOrg.title)}\n\n`
+    pageContent += `\n### ${String(productOrg.title)} org\n\n`
     if (productOrg.strategy_link) {
       pageContent += `- [Strategy Page](${String(createRelativeProductLink(productOrg.strategy_link))})\n`
     }
     if (productOrg.strategy_link) {
-      const bioLink = `../company/team/index.md#${String(
+      const bioLink = `../../company/team/index.md#${String(
         teamMembers[productOrg.pm].name.toLowerCase().replace(/\s+/g, '-')
       )}`
       pageContent += `- Product Director: [${String(teamMembers[productOrg.pm].name)}](${String(bioLink)})\n`
+      pageContent += `- Engineering Director: [${String(teamMembers[productOrg.em].name)}](${String(bioLink)})\n`
     }
     for (const productTeam of Object.values(productTeams)) {
       if (productTeam.product_org === productOrgName) {
-        pageContent += `\n\n#### ${String(productTeam.title)}\n`
+        pageContent += `\n\n#### ${String(productTeam.title)} team\n`
         if (productTeam.strategy_link) {
           pageContent += `- [Strategy Page](${String(createRelativeProductLink(productTeam.strategy_link))})\n`
         }
         if (productTeam.pm) {
-          const bioLink = `../company/team/index.md#${String(
+          const bioLink = `../../company/team/index.md#${String(
             teamMembers[productTeam.pm].name.toLowerCase().replace(/\s+/g, '-')
           )}`
-          pageContent += `- Product Manager: [${String(teamMembers[productTeam.pm].name)}](${String(bioLink)})`
+          pageContent += `- Product Manager: [${String(teamMembers[productTeam.pm].name)}](${String(bioLink)})\n`
+        }
+        if (productTeam.em) {
+          const bioLink = `../../company/team/index.md#${String(
+            teamMembers[productTeam.em].name.toLowerCase().replace(/\s+/g, '-')
+          )}`
+          pageContent += `- Engineering Manager: [${String(teamMembers[productTeam.em].name)}](${String(bioLink)})\n`
+        }
+        if (productTeam.design) {
+          const bioLink = `../../company/team/index.md#${String(
+            teamMembers[productTeam.design].name.toLowerCase().replace(/\s+/g, '-')
+          )}`
+          pageContent += `- Product Designer: [${String(teamMembers[productTeam.design].name)}](${String(bioLink)})\n`
+        }
+        if (productTeam.pmm) {
+          const bioLink = `../../company/team/index.md#${String(
+            teamMembers[productTeam.pmm].name.toLowerCase().replace(/\s+/g, '-')
+          )}`
+          pageContent += `- Product Marketing Manager: [${String(teamMembers[productTeam.pmm].name)}](${String(
+            bioLink
+          )})\n`
         }
         if (productTeam.issue_labels) {
           for (let index = 0; index < productTeam.issue_labels.length; index++) {
             if (index === 0) {
-              pageContent += '\n- Issue labels: '
+              pageContent += '- Issue labels: '
             }
             if (index < productTeam.issue_labels.length - 1) {
               pageContent += `[${String(
@@ -233,5 +254,6 @@ export async function generateProductTeamsList() {
       }
     }
   }
+  console.log(pageContent)
   return pageContent
 }


### PR DESCRIPTION
This adds more members to the teams (design, pmm, em). 

It also fixes a bug with relative paths caused by the introduction of the `product-engineering` top-level heirarchy.