### PR TITLE
Clarify tracker update expectations

### DIFF
--- a/content/product-engineering/engineering/vpe/index.md
+++ b/content/product-engineering/engineering/vpe/index.md
@@ -8,3 +8,8 @@ This page documents the team that reports to the VP of Engineering.
   - [Bill Creager](../../../company/team/index.md#bill-creager), [Director of Engineering](../roles.md#director-of-engineering), Cloud
   - [Jean du Plessis](../../../company/team/index.md#jean-du-plessis), [Director of Engineering](../roles.md#engineering-manager), Enablement
   - [Yink Teo](../../../company/team/index.md#yink-teo), [Director of Engineering](../roles.md#director-of-engineering), [Code Graph](../code-graph/index.md)
+  - [Michal Sennett](../../../company/team/index.md#michal-sennett), Strategic Project Manager
+
+## VPE team sync
+
+Team meets 8-9am PT every Wednesday to discuss [agenda items](https://docs.google.com/document/d/1tM8HEKY7_RcBKKIlMZnYXTiVwPAoAFGFzouaEMuGOpk/edit) and review the [engineering tracker](https://github.com/orgs/sourcegraph/projects/214/views/16).

--- a/content/product-engineering/planning-process.md
+++ b/content/product-engineering/planning-process.md
@@ -68,27 +68,12 @@ There are a few ways we track plans and celebrate progress at Sourcegraph.
 
 ### GitHub project tracker
 
-The [GitHub project tracker](https://github.com/orgs/sourcegraph/projects/214) is **the source of truth** for key results in product and engineering. There are a few tabs.
+The [GitHub project tracker](https://github.com/orgs/sourcegraph/projects/214) is **the source of truth** for key results in product and engineering.
+
+There are a few tabs:
 
 - The **Department KRs** tab tracks the top level product and engineering key results that the VPs and Directors review every week at the [VP team sync](#vp-team-sync). Updates are tracked and communicated in the [OKR slides](#okr-slides).
 - The **Org KRs** tab tracks all the org level key results. VPs and Directors review this monthly, or as-needed when something is escalated by a Director.
-
-  - For each KR, the assignee is responsible for posting an update to the issue at the end of each week. The update should include:
-
-    ```markdown
-    # Wins
-
-    <!-- What outcomes have we accomplished since the last update? -->
-
-    # Risks
-
-    <!-- What might prevent us from making the progress we want to make? -->
-
-    # Next steps
-
-    <!-- What are the next outcomes that the team is working toward? -->
-    ```
-
 - The **Team Deliverables** tab tracks the next big roadmap items that each team is delivering in service of their KRs.
   - When teams are in the state where they have a clear KR, but don't yet have a clear roadmap to achieving that KR, the KR is included in this view. Once a roadmap item added, the KR is removed.
   - Teams should include any big current and future roadmap items that the team has line of sight to.
@@ -122,7 +107,7 @@ Slides:
 
 These are due each Friday by 19:00 UTC.
 
-- Owners update their sections and connected issues in the [GitHub project tracker](#github-project-tracker)
+- Teams ensure that the [GitHub project tracker](#github-project-tracker) and connected issues are up-to-date.
 - Directors update the [OKR slides](#okr-slides)
 
 ### Monthly team updates

--- a/content/product-engineering/planning-process.md
+++ b/content/product-engineering/planning-process.md
@@ -70,39 +70,38 @@ There are a few ways we track plans and celebrate progress at Sourcegraph.
 
 The [GitHub project tracker](https://github.com/orgs/sourcegraph/projects/214) is **the source of truth** for key results in product and engineering. There are a few tabs.
 
-- The **Department KRs** tab tracks the top level product and engineering key results that the VPs and Directors review every week at the [VP team sync](#vp-team-sync).
-- The **Org KRs** tab tracks all the org level key results (excluding those that are tracked at the department level). VPs and Directors review this monthly, or as-needed when something is escalated by a Director.
+- The **Department KRs** tab tracks the top level product and engineering key results that the VPs and Directors review every week at the [VP team sync](#vp-team-sync). Updates are tracked and communicated in the [OKR slides](#okr-slides).
+- The **Org KRs** tab tracks all the org level key results. VPs and Directors review this monthly, or as-needed when something is escalated by a Director.
+
+  - For each KR, the assignee is responsible for posting an update to the issue at the end of each week. The update should include:
+
+    ```markdown
+    # Wins
+
+    <!-- What outcomes have we accomplished since the last update? -->
+
+    # Risks
+
+    <!-- What might prevent us from making the progress we want to make? -->
+
+    # Next steps
+
+    <!-- What are the next outcomes that the team is working toward? -->
+    ```
+
 - The **Team Deliverables** tab tracks the next big roadmap items that each team is delivering in service of their KRs.
   - When teams are in the state where they have a clear KR, but don't yet have a clear roadmap to achieving that KR, the KR is included in this view. Once a roadmap item added, the KR is removed.
-  - Teams should include as many future roadmap items beyond the quarter as that team has line of sight to.
+  - Teams should include any big current and future roadmap items that the team has line of sight to.
   - Roadmap items have a target date that is our best estimate of when the item will be delivered. This date is used for multiple purposes:
     - A diagnostic tool to help us identify teams that might need help.
     - A cross-functional communication tool so Sales/CE/CS/Marketing can plan ahead to help us drive usage of the things we are delivering.
   - This tab is reviewed ad hoc by VPs.
-- The **Engineering** tab tracks results that are relevant only to engineering or engineering leadership. This is reviewed every week in the [VPE team sync](team.md#vpe-team-sync).
 - The **All** tab simply shows all items in the tracker for reference.
-- Each org (Cloud, Enablement, Code graph) has a tab that tracks the results that the directors for that org care about. Directors own how they use their tab with their org.
+- Orgs and teams may create their own tabs and documented expectations in their own section of the handbook.
 
-Expectations:
+All items in the tracker should be linked to a GitHub issue so that we can assign owners, see a history of updates (useful audit log if we need to change KRs), and so there is an place for the team to post updates.
 
-- Each tab on this tracker is reviewed and updated on a weekly basis by the relevant team.
-- Each item in the tracker is linked to a GitHub issue.
-  - Customer names and business metrics can't be mentioned on public issues, so by default, all issues should be created in [sourcegraph/product-engineering-tracker](https://github.com/sourcegraph/product-engineering-tracker).
-- For each issue linked to from the tracker, the assignee is responsible for posting an update to the issue at the end of each week. The update should include:
-
-  ```markdown
-  # Wins
-
-  <!-- What outcomes have we accomplished since the last update? -->
-
-  # Risks
-
-  <!-- What might prevent us from making the progress we want to make? -->
-
-  # Next steps
-
-  <!-- What are the next outcomes that the team is working toward? -->
-  ```
+Customer names and business metrics can't be mentioned on public issues, so by default, all issues should be created in [sourcegraph/product-engineering-tracker](https://github.com/sourcegraph/product-engineering-tracker).
 
 ### OKR slides
 


### PR DESCRIPTION
Previous documentation asked for an explicit weekly update for each issue in the tracker. There are a lot of issues in the tracker, some of which might not have a meaningful update each week.

This PR documents that we just expect issues have up-to-date information on a weekly basis and directors can set more specific expectations for their orgs as desired.