### PR TITLE
Merge ownership update on release post script

### DIFF
--- a/content/marketing/product-marketing/release_post_process.md
+++ b/content/marketing/product-marketing/release_post_process.md
@@ -15,7 +15,7 @@ Product marketing is responsible for creating the monthly release post in collab
 
 You can tell when the release is cut by following along in #progress.
 
-- The marketing release post owner runs the script to generate the changelog (being sure to replace the version number in the command), and merges it into the release template at the end of the release post ([loom guide](https://www.loom.com/share/59da6bc1784a48e9b6af4d9e620ee4df)): `go run ./bin/generate_changelog_items.go -versions 3.28 -i ../sourcegraph/CHANGELOG.md`.
+- The marketing release post owner runs the command to generate the changelog (being sure to replace the version number in the command), and then pastes the output at the end of the release post ([loom guide](https://www.loom.com/share/59da6bc1784a48e9b6af4d9e620ee4df)): `go run ./bin/generate_changelog_items.go -versions 3.28 -i ../sourcegraph/CHANGELOG.md`.
   - Make sure that you get the latest in the Sourcegraph repo before running this command. If your repo is in a different location than `../sourcegraph`, you'll need to update the commandline above.
   - If for some reason the version number isn't added yet and you need to capture the "Unreleased" then passing it the literal string match for the "Unreleased" heading, usually `Unreleased`, in place of a version number works)
 - Once this is done, inform the team in the #release-post channel.

--- a/content/marketing/product-marketing/release_post_process.md
+++ b/content/marketing/product-marketing/release_post_process.md
@@ -15,7 +15,7 @@ Product marketing is responsible for creating the monthly release post in collab
 
 You can tell when the release is cut by following along in #progress.
 
-- VP Product runs the command to generate changelog (being sure to replace the version number in the command), then pastes the output at the end of the release post: `go run ./bin/generate_changelog_items.go -versions 3.28 -i ../sourcegraph/CHANGELOG.md`.
+- The marketing release post owner runs the script to generate the changelog (being sure to replace the version number in the command), and merges it into the release template at the end of the release post ([loom guide](https://www.loom.com/share/59da6bc1784a48e9b6af4d9e620ee4df)): `go run ./bin/generate_changelog_items.go -versions 3.28 -i ../sourcegraph/CHANGELOG.md`.
   - Make sure that you get the latest in the Sourcegraph repo before running this command. If your repo is in a different location than `../sourcegraph`, you'll need to update the commandline above.
   - If for some reason the version number isn't added yet and you need to capture the "Unreleased" then passing it the literal string match for the "Unreleased" heading, usually `Unreleased`, in place of a version number works)
 - Once this is done, inform the team in the #release-post channel.


### PR DESCRIPTION
[Originally proposed and agreed upon here](https://github.com/sourcegraph/about/pull/4733/files), my fault for losing track of it in the hackathon planning and then handbook migration busy-ness. 