### PR TITLE
Add script that checks for backlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sourcegraph-handbook",
   "private": true,
+  "type": "module",
   "description": "Our company handbook repository",
   "scripts": {
     "dev": "yarn run next",
@@ -17,6 +18,7 @@
     "eslint": "eslint 'src/**/*.?(m)[jt]s?(x)'",
     "test": "echo \"it works fine on my computer\" && exit 1",
     "copy-assets": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node src/scripts/copy-assets.ts",
+    "check-backlinks": "node --loader ts-node/esm --experimental-specifier-resolution=node src/scripts/check-backlinks.ts",
     "validate-data": "find data -name *.yml | sed -E \"s/data\\/(.*).yml/\\1/\" | xargs -I '{}' ajv -d data/{}.yml -s schema/{}.schema.json --errors=text"
   },
   "repository": {

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -254,6 +254,5 @@ export async function generateProductTeamsList() {
       }
     }
   }
-  console.log(pageContent)
   return pageContent
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -59,6 +59,11 @@ interface IndexProps {
 }
 export default function Index({ allPages, tree }: IndexProps): JSX.Element {
     const pagesWithoutBacklinks = allPages.filter(page => page.backlinks.length === 0)
+
+    if (pagesWithoutBacklinks.length > 0) {
+        throw new Error(`Pages without backlinks:\n${pagesWithoutBacklinks.map(page => `- ${page.slugPath}: ${page.title || 'Untitled'}\n`).join()}`)
+    }
+
     const pagesWithoutTitle = allPages.filter(page => !page.title)
 
     return (

--- a/src/scripts/check-backlinks.ts
+++ b/src/scripts/check-backlinks.ts
@@ -1,0 +1,26 @@
+import { buildBacklinks, loadAllPages, parsePage } from "../lib/api";
+
+async function checkbackLinks() {
+    console.log('Loading all pages...');
+    const allPages = await loadAllPages()
+
+    console.log('Parsing all pages...')
+    const parsedPages = await Promise.all(allPages.map(page => parsePage(page)))
+
+    // Populates the `backlinks` field of each page.
+    console.log('Populating all backlinks...')
+    buildBacklinks(parsedPages)
+
+    const pagesWithoutBacklinks = parsedPages.filter(page => page.backlinks.length === 0)
+
+    if (pagesWithoutBacklinks.length > 0) {
+        throw new Error(`Pages without backlinks:\n${pagesWithoutBacklinks.map(page => `- ${page.slugPath}: ${page.title || 'Untitled'}\n`).join()}`)
+    }
+}
+
+checkbackLinks().catch(error => {
+    console.error(error.message)
+    process.exit(1)
+})
+
+


### PR DESCRIPTION
**Reason for this change**

- We want to be able to enforce all pages having at least one backlink (in other words, no orphan pages)

**Why not `check-links.mjs` script:**

- This is a different script than `check-links.mjs` because this allows us to use the same link parsing logic as the main build script. This takes into account things like section links (heading ids in hash fragments) and generated pages, which `check-links.mjs` cannot currently do. This also avoids code duplication.

**Work remaining**

There's a problem with running the script because the script and its dependencies are written in TS, and some of our npm dependencies introduce an additional challenge because they are defined as native ES modules and therefore don't compile to `commonjs`. The `commonjs` target would be the easiest way of compiling for the script to be runnable by `node` (via `ts-node` or `node --loader ts-node/register`

Adding `type: "module"` to `package.json` is needed in order to make node run the script (and its dependencies) as ES modules. This needs to be combined with `ts-node` being configured to emit ES modules and not `commonjs`. However, `type: "module"` breaks the main build step, because NextJS doesn't expect it. It's necessary for this script, though, because `ts-node` emits regular JS and not `mjs` which would be an alternative to setting `type: "module"`

Alternative: make `ts-node` emit `commonjs` instead of ES modules. However, this breaks because some packages are natively ES modules, like the `toc` plugin. So it doesn't work with `commonjs`.

So this PR is stuck while we look for a combination of configuration options that works.