### PR TITLE
Update managed instance account ref

### DIFF
--- a/content/product-engineering/engineering/releases/upgrade_managed_issue_template.md
+++ b/content/product-engineering/engineering/releases/upgrade_managed_issue_template.md
@@ -36,7 +36,7 @@ Make sure to upgrade internal instances before customer instances.
 - [ ] Upgrade second instance for https://github.com/sourcegraph/accounts/issues/542
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/5041
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/547
-- [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8286
+- [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8288
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/1503
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8282
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8285


### PR DESCRIPTION
The initial account was manually created without a corresponding SF ref.