### PR TITLE
Add section about #dev- channels

### DIFF
--- a/content/product-engineering/engineering/index.md
+++ b/content/product-engineering/engineering/index.md
@@ -95,6 +95,7 @@ The current channels are:
 - #dev-frontend
 - #dev-databases
 - #dev-urandom
+- #prod-eng-announce 
 
 ## Misc.
 

--- a/content/product-engineering/engineering/index.md
+++ b/content/product-engineering/engineering/index.md
@@ -83,6 +83,19 @@ Sourcegraph has a lot of repositories!
 - [github.sgdev.org](https://github.sgdev.org) is a Github test instance.
 - [bitbucket.sgdev.org](https://bitbucket.sgdev.org) is a Bitbucket test instance.
 
+## Slack channels
+
+Slack channels for non-team-specific engineering interests typically start with a #dev- prefix
+
+The current channels are:
+
+- #dev-chat
+- #dev-ops
+- #dev-experience
+- #dev-frontend
+- #dev-databases
+- #dev-urandom
+
 ## Misc.
 
 This point lives here for now:

--- a/content/product-engineering/engineering/index.md
+++ b/content/product-engineering/engineering/index.md
@@ -95,7 +95,7 @@ The current channels are:
 - #dev-frontend
 - #dev-databases
 - #dev-urandom
-- #prod-eng-announce 
+- #prod-eng-announce
 
 ## Misc.
 


### PR DESCRIPTION
I noticed that we don't document our `#dev-` slack channels anywhere. This adds a small blurb on them. 

The `#dev-` prefix aids in discoverability.  