### PR TITLE
Document Batch Changes support process, update some messaging

### DIFF
--- a/content/product-engineering/engineering/code-graph/batch-changes/index.md
+++ b/content/product-engineering/engineering/code-graph/batch-changes/index.md
@@ -56,7 +56,7 @@ The Batch Changes team is the current owner of [src-cli](https://github.com/sour
 
 - [Malo Marrec](../../../../company/team/index.md#malo-marrec) ([Product Manager](../../../product/roles/index.md#product-manager))
 - [Rob Rhyne](../../../../company/team/index.md#rob-rhyne) ([Product Designer](../../../product/roles/index.md#product-designer))
-- [Chris Pine](../../../../company/team/index.md#chris-pine) ([Engineering Manager](../../roles.md#engineering-manager)) {#batch-changes-eng}
+- [Chris Pine](../../../../company/team/index.md#chris-pine) ([Engineering Manager](../../roles.md#engineering-manager))
   - [Thorsten Ball](../../../../company/team/index.md#thorsten-ball)
   - [Adam Harvey](../../../../company/team/index.md#adam-harvey)
   - [Erik Seliger](../../../../company/team/index.md#erik-seliger)
@@ -65,7 +65,7 @@ The Batch Changes team is the current owner of [src-cli](https://github.com/sour
 
 ## Growth plan
 
-We have no further plans to grow the team at this time.
+We are looking to add one [experienced full-stack engineer](https://boards.greenhouse.io/sourcegraph91/jobs/4179711004) to our team to help us grow our product in FY22 Q4.
 
 ## Onboarding
 

--- a/content/product-engineering/engineering/code-graph/batch-changes/index.md
+++ b/content/product-engineering/engineering/code-graph/batch-changes/index.md
@@ -9,7 +9,8 @@
 
 ## Contact
 
-- #batch-changes channel or @batchers on Slack.
+- For general questions or concerns, #batch-changes channel or @batchers on Slack.
+- For engineering support requests, customer questions, or anything else, @batcher-support on Slack.
 - @sourcegraph/batchers team or [team/batchers label](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fbatchers) on GitHub.
 
 ## Process
@@ -20,9 +21,10 @@
 
 - One Big Thing: Each sprint, each engineer gets one big thing to work on — one significant chunk of work scoped to be doable in a single sprint (leaving some slack in the sprint for customer support and other unexpected issues). When it is completed, engineers will pull P0 items from [our planning board](https://github.com/orgs/sourcegraph/projects/216) into the current sprint to work on (or P1 if there are no P0s).
 
-- Invariants and assumptions:
-  - Issues have the current milestone set if-and-only-if they are P0.
-  - An issue assigned to an engineer means that engineer is committing to finishing _in the current sprint_. Issues should be unassigned by default.
+- Support rotation: Each sprint, one engineer will assume the role of support engineer, serving as the primary point of contact for customer questions or issues with Batch Changes that are escalated by CE and CS. The support rotation schedule is laid out in our [team sync agenda doc](https://docs.google.com/document/d/1opVINuZ1PfNZCx3zJP3BwlXAEG5SYt8HIIdGab115j8/edit#), and customer GitHub issues on our team's radar are tracked on [our support board](https://github.com/orgs/sourcegraph/projects/218). Any engineer is always welcome to jump in on support requests, but it is the responsibility of the support engineer to ensure that issues that come in are not ignored or lost.
+  - At the beginning of a new sprint, the incoming support engineer should update the @batcher-support "user group" in Slack to remove the previous support engineer and add themselves.
+  - At the end of a sprint, the outgoing support engineer should use their discretion to decide whether to finish in-progress issues themselves or hand them off to the next support engineer. Either way, the outgoing engineer should review the state of the support board with the incoming engineer in order to ensure a smooth transition.
+  - Engineers may arrange for their teammates to cover them on days during their support rotation that they are unavailable due to PTO, holidays, etc.
 
 ## Sprint planning
 
@@ -40,9 +42,11 @@ Our two-week sprints start every other Wednesday. On the Tuesday before, we have
 
 ## Team Communication
 
-Our team has two Slack channels, one for everyone (#batch-changes) and one just for us (#batch-changes-internal). _Our default is to use the public channel._
+Our team has two Slack channels, one for everyone (#batch-changes) and one just for us (#batch-changes-internal). Both channels are public and able to be joined by anyone, but _our default is to use #batch-changes._
 
-The private channel is for communications that would be of no interest to someone not on the team. Things like (re-)scheduling of team meetings, vacation scheduling, reminders about tasks that need completing, etc. Keeping these out of the public channel raises the signal-to-noise ratio for folks interested in Batch Changes, but not interested in who will be 10 minutes late to our sync meeting today due to the fact that their cat knocked over a jar of pickles and now there's glass everywhere and everything smells like vinegar and now you wish you hadn't read this sentence to the end.
+The internal channel is for communications that would be of no interest to someone not on the team. Things like (re-)scheduling of team meetings, vacation scheduling, reminders about tasks that need completing, etc. Keeping these out of the public channel raises the signal-to-noise ratio for folks interested in Batch Changes, but not interested in who will be 10 minutes late to our sync meeting today due to the fact that their cat knocked over a jar of pickles and now there's glass everywhere and everything smells like vinegar and now you wish you hadn't read this sentence to the end.
+
+For bringing support questions or requests to the team, you can alert the engineer who is currently on support rotation using the @batcher-support alias.
 
 ## Stewardship of src-cli
 


### PR DESCRIPTION
We didn't have our support rotation process documented in our team processes, including the new support issues board we recently introduced, so I added a blurb to describe that. I also updated some of the messaging around communicating with our team, particularly about using @batcher-support, and removed two stated invariants that we are no longer following. 