### PR TITLE
Update Brand Team overview page.md

### DIFF
--- a/content/marketing/brand/index.md
+++ b/content/marketing/brand/index.md
@@ -15,15 +15,16 @@
 
 ## Function, Vision, Mission, and Values
 
-Built as a multidisciplinary in-house agency, the Sourcegraph Brand Team exists to elevate, activate and communicate the value of Sourcegraph to the world. We make this possible by serving as a strategic creative partner to cross-functional stakeholders, offering full-service creative support with a rapid, flexible, iterative process that stems from a deep understanding of our products, our processes, and our people.
+Built as a multidisciplinary in-house agency, the Sourcegraph Brand Team exists to drive awareness and affinity for our brand to our audience. We make this possible by serving as a strategic creative partner to cross-functional stakeholders, connecting brand vision to business strategy, and bringing our brand to life across every touchpoint at every level of our company. We also protect and evolve the Sourcegraph brand identity to ensure consistency, congruency, and recognizeability amongst our larger audience.
 
-In addition to increasing awareness and positive perception of the Sourcegraph brand, we strive to amplify the voices of our users and partners, by conceptualizing and producing best-in-class creative that leans heavily on storytelling and narrative to drive engagement and sharing. Our primary goal is to build and strengthen the connection between our brand and our audience as a means to increasing loyalty and retention by providing a better experience for our users.
+In addition to improving awareness and perception of our own brand, we strive to amplify the voices of our users and partners, by conceptualizing and producing best-in-class creative that leans heavily on storytelling and narrative to drive engagement and sharing. Our primary goal is to build and strengthen the connection between our brand and our audience, by providing an amazing, holistic brand experience for our users.
 
-We are: <br>
+We value: <br>
 
-- Lean - small but efficient team that leverages vendors and contractors to scale support <br>
-- Agile - move fast, adapt, and change directions easily based on the market and goals <br>
-- Effective - strive for quantifiable results and outsized impact; everything has a “why”
+- Efficiency - We are a small but mighty team that leverages vendors and contractors to scale support <br>
+- Agility - We move fast, adapt, and can change directions easily based on the market and business goals <br>
+- Creativity - We don't settle for "status quo" and look for opportunities to surprise and delight our audience <br>
+- Measurement - We strive for quantifiable results and outsized impact; everything we do has a “why” behind it <br> 
 
 Projects are categorized on a 5-tier basis based on strategy, scope, and visibility. These tiers are broken down in more detail [here](./brand_and_creative_team_requests.md#project-tiers).
 
@@ -33,7 +34,7 @@ Projects are categorized on a 5-tier basis based on strategy, scope, and visibil
 - Tier 4 - Production design and brand management
 - Tier 5 - Self-serve and process-guided needs teammates can do on their own
 
-The Brand Team works closely with Product, Sales, Marketing, People, and Operations teams org-wide (among others), and is a key stakeholder in overall organizational messaging, strategy, and outbound engagement initiatives, as well as internally-facing messaging and branded programs or experiences.
+The Brand Team works closely with XFN teams at every level of the organization, and is a key stakeholder in overall company messaging, strategy, and engagement initiatives, as well as internally-facing messaging and branded programs or experiences.
 
 Our team acts as liaison or point-of-contact with external entities when producing branded content, sponsorships, or partnerships in accordance with [Sourcegraph’s Brand Guidelines](brand_guidelines/index.md).
 
@@ -43,43 +44,42 @@ Our company values can be found [here](../../company/values.md). Our Brand Creat
 
 Functional Areas: Design, illustration, animation, video production, copywriting, narrative, project management, brand strategy, market research, website development, and more.
 
-- Tommy Pesavento - Director of Brand / Creative Director
-- Fabiana Castellanos - Project Coordinator, Brand
-- Mustafa Ulker ~ a.k.a Moose - Senior Copywriter, Brand
+- Tommy Pesavento - Brand Director
+- Fabiana Castellanos - Project Manager, Brand
+- Mustafa Ulker ~ a.k.a Moose - Senior Creative Lead, Brand
 - Kristen Sundberg - Senior Manager, Social Media
 - Sruti Dhulipala - Senior Manager, Global Brand Strategy
 - Jessie Char - Senior Manager, Events & Experiences
-- Steph Zabala - Senior Brand Designer
+- Steph Zabala - Principal Designer, Brand
+- Brett Hayes – Senior Web Developer, Brand
 
 To be hired:
 
 - Brand Planner
+- Senior Brand Designer
 - Brand Designer
-- Production Designer
 - Creative Producer
 - Motion Designer/Animator
 - Multimedia Specialist
 - Copywriter, Brand
-- Digital Experience Manager
+- Digital Experience Manager/TPM
 - Web Designer (UX/UI)
-- Frontend Web Developer
-- CMS Admin
 - UX Researcher
 
 ## Capabilities
 
-We deliver agency-caliber campaigns, creative, production, and results in support of every team within the company to drive awareness, engagement, and adoption.
+We deliver agency-caliber creative and results in support of Sourcegraph business goals to drive awareness, engagement, and affinity for our brand.
 
-The Brand Team is nested in the Marketing department of Sourcegraph, serving as cross-functional brand and creative support for all internal teams and programs (i.e. People/HR, Product, Ops, Eng, etc.), as well as central brand communications, demand generation, content strategy and product marketing support. We sometimes partner with external agencies, freelancers, contractors, consultants, and other vendors as necessary to multiply our efforts or for when deep, subject-matter expertise is needed. This is called our [Preferred Vendor Network](./production_process.md#sourcegraph-preferred-vendor-network-aka-the-network), or simply The Network.
+The Brand Team is nested in the Marketing department of Sourcegraph, serving as cross-functional brand champion and creative partner for all internal teams and programs. With such a broad area of collaboration, we sometimes partner with external agencies, freelancers, contractors, consultants, and other vendors as necessary to multiply our efforts or for when deep, subject-matter expertise is needed. This is called our [Preferred Vendor Network](./production_process.md#sourcegraph-preferred-vendor-network-aka-the-network), or simply The Network.
 
-Our capabilities include:
+Connect with us if you have questions about any of the following. If we aren't able to support directly, we can at least serve as an advisory partner and connect you with a trusted vendor to help you get what you need:
 
 _Branding_
 
 - Brand management, brand identity design, logos, lockups, colors, etc.
 - Brand strategy, naming, positioning, packaging, narrative and market research
   - [See Naming Process Guide](naming_process_for_products_features_and_programs.md) for more information on naming features, products, programs and initiatives
-- Maintain and update [Sourcegraph Brand Guidelines](brand_guidelines/index.md) and brand assets
+- Ownership of the [Sourcegraph Brand Guidelines](brand_guidelines/index.md) and our brand asset library
 
 _Design_
 
@@ -102,20 +102,21 @@ _Website/Digital Experience_
 - Maintain and update website, incl. integrations, testing and SEO
 - Website design, page design, campaign and landing pages, microsites
 - Interactive design, incl. data visualization and infographics
-- Email design and development
-- Digital marketing stack and B guidance, strategy, and execution
+- Email design and copywriting
+- Digital creative strategy
 
 _Events_
 
 - Event planning, strategy and design
 - Booth, stage or environmental design and production
+- Experiential design and implementation, for URL and IRL events
 - Swag design and fulfillment planning. See our [Gifting Guidelines](./gifting_guidelines.md)
 
 _Copy_
 
 - Maintain and update brand style guide, voice and tone
 - Copywriting, editing and proofing for social media, ads, website, scripts, etc.
-- For blog posts, white papers, e-books, and other long-form serial content, please go to [Content Marketing](../content/index.md)
+- For blog posts, white papers, e-books, and other long-form serial content, please visit [Content Marketing](../content/index.md)
 
 ## Additional resources
 
@@ -124,16 +125,13 @@ _Copy_
 - [Benefits of Having an In-House Brand & Creative Team](sourcegraph_in-house_brand_team.md)
 - [Common challenges faced by in-house Brand & Creative teams](sourcegraph_in-house_brand_team.md)
 
-## Open Questions
+## Final thoughts
 
-This charter isn’t meant to have ALL the answers; rather, it’s meant to to be a living document that can change and adapt over time, while providing some frameworks and operational processes that help ensure smooth collaboration and successful partnering internally. A few of the top-of-mind questions that we still want to answer in the near term include:
+This handbook entry isn’t meant to have ALL the answers; rather, it’s meant to to be a living document that can change and adapt over time, while providing some frameworks and operational processes that help ensure smooth collaboration and successful partnering internally. Some of the typical questions that arise before starting a new project include:
 
-- How do we decide what to do in-house and when to bring agencies on board?
-- How do we determine the final decision-maker on creative and/or production techniques, assuming the content and message are approved by key internal stakeholders?
-- What percentage of work should we aim to complete in-house?
-- What is a realistic percentage of work that we need to ensure Brand team reviews, before leaving the house?
-- How do we measure success as a team/department within Marketing? Within Sourcegraph?
-- How do we ensure our work is laddering up to overarching Sourcegraph strategy and goals?
-- How can we prove the value of the service we provide to ensure earlier involvement?
-- How does our team think about creativity and the creative process?
-- Who are the final decision-makers for brand-level changes, updates, or launches?
+- Is it more efficient to handle the request in-house or bring an agency on board?
+- Using the RAID framework, who has final aproval of the requested work?
+- If our team doesn't directly produce a campaign or asset, what is the best process for Brand review?
+- How do we measure success/effectiveness of the requested project or asset?
+- How do we ensure this project is laddering up to overarching business strategy?
+- How involved do other teams/departments want to be in the creative process?

--- a/content/marketing/brand/index.md
+++ b/content/marketing/brand/index.md
@@ -24,7 +24,7 @@ We value: <br>
 - Efficiency - We are a small but mighty team that leverages vendors and contractors to scale support <br>
 - Agility - We move fast, adapt, and can change directions easily based on the market and business goals <br>
 - Creativity - We don't settle for "status quo" and look for opportunities to surprise and delight our audience <br>
-- Measurement - We strive for quantifiable results and outsized impact; everything we do has a “why” behind it <br> 
+- Measurement - We strive for quantifiable results and outsized impact; everything we do has a “why” behind it <br>
 
 Projects are categorized on a 5-tier basis based on strategy, scope, and visibility. These tiers are broken down in more detail [here](./brand_and_creative_team_requests.md#project-tiers).
 


### PR DESCRIPTION
Made some slight updates to the wording on the Brand team overview page in the handbook to simplify understanding how the team works and what we do, as well as added new team members and title updates based on some recent promotions.