### PR TITLE
Fix URL to locations.geojson

### DIFF
--- a/content/team/locations.md
+++ b/content/team/locations.md
@@ -3,7 +3,7 @@
 The [Sourcegraph team](index.md) is distributed around the world!
 
 <!-- https://docs.github.com/en/github/managing-files-in-a-repository/mapping-geojson-files-on-github#embedding-your-map-elsewhere -->
-<script src="https://embed.github.com/view/geojson/sourcegraph/handbook/main/content/company/team/locations.geojson"></script>
+<script src="https://embed.github.com/view/geojson/sourcegraph/handbook/main/content/team/locations.geojson"></script>
 
 ## Adding to the team locations map
 


### PR DESCRIPTION
For some reason, currently `locations.geojson` is referenced with an incorrect URL, which affects production.
<img width="1280" alt="Screenshot 2021-12-07 at 13 35 58" src="https://user-images.githubusercontent.com/2196347/145013681-f9bfb02a-3cd5-4eb8-8614-9c1938f70e01.png">

This PR fixes the bug.
<img width="1278" alt="Screenshot 2021-12-07 at 13 37 14" src="https://user-images.githubusercontent.com/2196347/145013803-44de2b9c-08a4-4e7c-9eaf-20f6ce3b87aa.png">

