### PR TITLE
Enablement additions, triage update, link to what we support

### DIFF
--- a/content/departments/support/index.md
+++ b/content/departments/support/index.md
@@ -11,7 +11,7 @@ Customer Support at Sourcegraph exists to resolve technical issues and answer te
 - Demonstrating profound compassion for the people with whom our paths cross and the problems/questions we help them solve, meeting them where they are
 - Only asking our customers and teammates things we can’t do or answer ourselves
 - Persistently working toward and/or seeking resolution that works equally for our customers and us (see [an open letter about root cause](process/enablement/root-cause.md) for inspiration)
-- Staying at least a step ahead (summarizing current status, giving clear next steps, and setting expectations in every communication)
+- Staying at least a step ahead (summarizing current status, giving clear next steps, and setting expectations in every communication) (see [an open letter about staying a step ahead](process/enablement/step-ahead.md)
 - Being flexible and open, maintaining a first principles thinking approach, and always confronting and growing past our biases
 - Outgrowing ourselves, the way we work, and continuously improving
 

--- a/content/departments/support/process/customer-support-triaging.md
+++ b/content/departments/support/process/customer-support-triaging.md
@@ -19,7 +19,7 @@ That said, there may be times when we have unusally large amount of work or more
 
   - Sometimes it may be an internal person and that would be correct, unless our teammate is posting on behalf of the customer and then we would want to change it to the customer.
   - When an application engineer is assigned to a customer, this step will also trigger that application engineer and their backup to appear as a follower (you don't see these auto populate until after you save the ticket (ie "submit as open").
-  - For the Hubspot form, we will also need to change the subject from "[Sourcegraph] Contact reconversion by submitting on HubSpot Form "Contact Us | Talk to a Dev" to something more useful for the person asking for help, like "Sourcegraph help request" -- that way they look at the email when a member of the team answers them.
+  - For the Hubspot form, we will need to email the person from our work Gmail account with a subject like "Sourcegraph inquiry" and support@sourcegraph.com in cc and let them know a member of the team will help them. We do this so that we can ensure the customer gets the email since Zendesk could block it.
 
 - **Step 3:** Identify if there is action for CS or not
 
@@ -36,6 +36,7 @@ That said, there may be times when we have unusally large amount of work or more
   - handle anything related to security for a customer with a CE
   - handle a feature request for a customer with a CE
   - provide guidance on how to think about using Sourcegraph/drive adoption (ie more proactive in nature guidance)
+  - for employment verifications, we can reply and send the requestor to [our Truework landing page](https://www.truework.com/verifications/sourcegraph-employment-verification/) where they can get what they need.
 
   If it's not clear, post in #customer-support-triage and brainstorm the best path.
 

--- a/content/departments/support/process/enablement/index.md
+++ b/content/departments/support/process/enablement/index.md
@@ -23,9 +23,9 @@ This table correlates to our [technical competency matrix](https://docs.google.c
 
 ## Docs
 
--
 - [Values enablement](support-values-enablement.md)
 - [Career roadmapping](../../career-growth/career-roadmap.md)
+- [Tips for considering how you want to shape your voice/style for our audience](shape-your-voice.md)
 - [How engineering and support learn from each other](eng-support-learn-from-eachother.md)
 - [Debugging tips](debugging-tips.md)
 - [Navigating the PGSQL Database](pgsql-guide.md)

--- a/content/departments/support/process/enablement/shape-your-voice.md
+++ b/content/departments/support/process/enablement/shape-your-voice.md
@@ -1,41 +1,50 @@
 # Tips for considering how you want to shape your voice/style for our audience
+
 As the application engineer responsible for your work (what cases you take, etc), it is up to you to exercise your agency and determine how to do the nuances of the job in a way that is authentic to you. As such, the purpose of this page is not to tell anyone how to communicate or prescribe exact steps, but rather to offer suggestions for consideration based on collective experiences and knowledge. The end goal is always for each member of our team to feel empowered to do the job of application engineer in a way that aligns with them individually.
 
 ## Who is our audience?
+
 No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../communication/content_guidelines.md), which can help you think about our audience from the perspective of what likely resonates most.
 
 ## Structure can go a long way
+
 We are all somewhere on a spectrum of preferring information to be delivered in a way that is straight to the point or gets into all of the context. Structure can help you meet both ends of the spectrum in a single post:
 
-It’s okay to skip the fluff. It’s okay to skip introducing yourself (everyone can see your title in Slack/email signature). It’s okay to keep the pleasantries brief -- a quick “hi” can go a long way. 
+It’s okay to skip the fluff. It’s okay to skip introducing yourself (everyone can see your title in Slack/email signature). It’s okay to keep the pleasantries brief -- a quick “hi” can go a long way.
 TL;DR can be powerful to help offer a cue of what you really want to be sure folks read
 Provide all the context AFTER you get to the point. This lets you meet both ends of the spectrum (those who crave context vs those who do not). You can make it feel natural with prefaces like “To share more context…,” “To explain in more detail....,” etc.
 Imagine whoever is reading what you write is busy and may not read more than the first few sentences … how can you structure everything you want to say so that if they don’t read everything, they will still get the most important things?
-It can make someone feel unheard if you neglect to answer a specific question they ask, even if you know the question isn’t relevant to resolving their issue. 
+It can make someone feel unheard if you neglect to answer a specific question they ask, even if you know the question isn’t relevant to resolving their issue.
 Using bold headers, bullet lists, etc can also help break up long text to help folks orient to everything in a way where they can more quickly understand why what you wrote is so long.
 
 ## Delivering hard news
+
 ### This is going to take longer than we both want
-Sometimes we have to prioritize work between customers, especially when we engage engineering for help. Try to orient your explanation to the customer in a way that is reassuring to them and doesn’t make them feel like the issue that matters to them doesn’t matter to us. A customer usually doesn’t care what else we have going on or how hard things are for us. They just want to know we care, we are on it, we are not going to ghost them, etc. It can help to tie the timeline to the issue. Something like... 
+
+Sometimes we have to prioritize work between customers, especially when we engage engineering for help. Try to orient your explanation to the customer in a way that is reassuring to them and doesn’t make them feel like the issue that matters to them doesn’t matter to us. A customer usually doesn’t care what else we have going on or how hard things are for us. They just want to know we care, we are on it, we are not going to ghost them, etc. It can help to tie the timeline to the issue. Something like...
 
 This issue is turning out to be a little unique so I want to engage my teammates who work in this part of our code base regularly. I’ll see what their workload is like right now and make sure we give this attention as soon as we can. I am hoping to have an update for you in a few days at the latest…
 
 ...can go a long way to setting expectations, with context as to why, and in a way that another developer can appreciate, all while making it clear you are driving the process.
 
 ### This is a feature request
-It can be very disappointing to have come to us with a question thinking something must be possible only to learn, nope … and developers know all too well that can mean we may never get to it. This disappointment can cause a lack of faith. This is why when a CE is assigned, we immediately bring in the CE to handle the conversation -- their super powers allow them to have these conversations in a way that prevents churn risk. For our customers without CE, the risk of churn is lower, but we still want them to feel heard without us accidentally committing another team to something they may or may not do. 
+
+It can be very disappointing to have come to us with a question thinking something must be possible only to learn, nope … and developers know all too well that can mean we may never get to it. This disappointment can cause a lack of faith. This is why when a CE is assigned, we immediately bring in the CE to handle the conversation -- their super powers allow them to have these conversations in a way that prevents churn risk. For our customers without CE, the risk of churn is lower, but we still want them to feel heard without us accidentally committing another team to something they may or may not do.
 You can help temper expectations with thoughtful adjective choice. “This is a great idea” might lead someone to believe we will do it. “This is an interesting idea” makes it a bit more clear there is a question for us to answer about whether we will do it or not.
 You can help set-up your product teammates for success by not saying things like “I am sure our team will want to do this…” and instead saying something like “My product teammates will consider this to see whether we can add it to our roadmap.”
-You can round it all out by filing a public issue the customer can have and engage on. That act alone makes it clear to the customer they have access to your teammates, too, and the process will be transparent. 
+You can round it all out by filing a public issue the customer can have and engage on. That act alone makes it clear to the customer they have access to your teammates, too, and the process will be transparent.
 It’s even okay to encourage the customer to share any additional thoughts they have on the feature request issue and that they can ask for an update if they ever wonder where our team is at with it.
 
 ### Saying no
+
 Sometimes we do need to say no. You can help folks work through their frustration by coupling a “no” with an invitation to react and imagining how they might feel. Something like “That is not currently possible. I imagine this is disappointing to learn. I can let my teammates responsible for this part of our code base know what thoughts you might have, if you want to share them.” This is very related to a feature request, but a little different if it’s something we have already said no to. Who knows, maybe sharing such details leads us to change our mind.
 
 ## Be the one to drive the conversation
-Honoring our guiding principle of staying at least a step ahead and never leaving the customer wondering what comes next can put you in control of the conversation. Usually customers only take over and get demanding when they feel like you don’t have next steps or it’s unclear to them what the next steps are. 
+
+Honoring our guiding principle of staying at least a step ahead and never leaving the customer wondering what comes next can put you in control of the conversation. Usually customers only take over and get demanding when they feel like you don’t have next steps or it’s unclear to them what the next steps are.
 
 ## Be the one to drive calls
+
 Showing up for the customer as the one driving a call can make calls go smoother and relieve a lot of the stress they can have. A few ways that can keep you the one driving:
 Before you get on the call, set expectations: make the customer share what they want to accomplish OR tell them what is possible. It’s even okay to say something like: "I might not be able to solve this on a call, but I should be able to get what I need so we can get to resolution faster."
 At the start of the call, restate those expectations that you put in writing before the call.
@@ -46,7 +55,9 @@ After the call, follow through on your next steps.
 Bonus: It often also goes better when you are the one to initiate the call vs waiting for a case to be going on so long the customer asks after 2-3 weeks and is already frustrated. And remember, it is 100% okay and encouraged to initiate a #rfh (request for help) with engineering via our usual workflow and in it, request that engineering join you on a call if you feel it will help you all resolve the customer’s issue faster.
 
 ## Understand you are the authority (even when you don’t feel you are)
-You have to know a lot as an application engineer and that can get into your head and make you feel like you are anything but an authority. Just try to remember that to the customer you are … you are Sourcegraph. Keeping yourself in the position by choosing your words to be reassuring of that fact helps the customer trust you even while you need time to figure things out. When you bring in others to help and you say something like “I want to talk to my teammates” or “I want to talk to my teammates who work in this part of the code every day” shows the customer you are on it and you will get what they need much more than “I need to talk to engineering” or “I need to talk to [engineering team name].” Our customers don’t know all of our team names and they shouldn’t have to. 
+
+You have to know a lot as an application engineer and that can get into your head and make you feel like you are anything but an authority. Just try to remember that to the customer you are … you are Sourcegraph. Keeping yourself in the position by choosing your words to be reassuring of that fact helps the customer trust you even while you need time to figure things out. When you bring in others to help and you say something like “I want to talk to my teammates” or “I want to talk to my teammates who work in this part of the code every day” shows the customer you are on it and you will get what they need much more than “I need to talk to engineering” or “I need to talk to [engineering team name].” Our customers don’t know all of our team names and they shouldn’t have to.
 
 ## “I think.../and…” or “I want to look into that more…” vs “I don’t know.”
-Sometimes the hardest part of the application engineer job is trusting how much you do know and projecting that confidence in a way that is reassuring to our customers, even when you have questions yourself. Saying “I don’t know” is honest, transparent, and likely feels natural. It can also trigger some folks to worry they won’t get the help they need. This isn’t our fault. This is the fault of many businesses who devalue their support teams and put them in awful positions to not be able to provide great support. Unfortunately, we sometimes have to take an extra step to prevent our customers from worrying we will be like just another bad support team. 
+
+Sometimes the hardest part of the application engineer job is trusting how much you do know and projecting that confidence in a way that is reassuring to our customers, even when you have questions yourself. Saying “I don’t know” is honest, transparent, and likely feels natural. It can also trigger some folks to worry they won’t get the help they need. This isn’t our fault. This is the fault of many businesses who devalue their support teams and put them in awful positions to not be able to provide great support. Unfortunately, we sometimes have to take an extra step to prevent our customers from worrying we will be like just another bad support team.

--- a/content/departments/support/process/enablement/shape-your-voice.md
+++ b/content/departments/support/process/enablement/shape-your-voice.md
@@ -4,7 +4,7 @@ As the application engineer responsible for your work (what cases you take, etc)
 
 ## Who is our audience?
 
-No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../company-info-and-process/communication/content_guidelines/index.md), which can help you think about our audience from the perspective of what likely resonates most.
+No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create our content guidelines (just search that here in the handbook and you'll find all their resources), which can help you think about our audience from the perspective of what likely resonates most.
 
 ## Structure can go a long way
 

--- a/content/departments/support/process/enablement/shape-your-voice.md
+++ b/content/departments/support/process/enablement/shape-your-voice.md
@@ -4,7 +4,7 @@ As the application engineer responsible for your work (what cases you take, etc)
 
 ## Who is our audience?
 
-No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../communication/content_guidelines.md), which can help you think about our audience from the perspective of what likely resonates most.
+No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../company-info-and-process/communication/content_guidelines.md), which can help you think about our audience from the perspective of what likely resonates most.
 
 ## Structure can go a long way
 

--- a/content/departments/support/process/enablement/shape-your-voice.md
+++ b/content/departments/support/process/enablement/shape-your-voice.md
@@ -4,7 +4,7 @@ As the application engineer responsible for your work (what cases you take, etc)
 
 ## Who is our audience?
 
-No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../company-info-and-process/communication/content_guidelines.md), which can help you think about our audience from the perspective of what likely resonates most.
+No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../company-info-and-process/communication/content_guidelines/index.md), which can help you think about our audience from the perspective of what likely resonates most.
 
 ## Structure can go a long way
 

--- a/content/departments/support/process/enablement/shape-your-voice.md
+++ b/content/departments/support/process/enablement/shape-your-voice.md
@@ -1,0 +1,52 @@
+# Tips for considering how you want to shape your voice/style for our audience
+As the application engineer responsible for your work (what cases you take, etc), it is up to you to exercise your agency and determine how to do the nuances of the job in a way that is authentic to you. As such, the purpose of this page is not to tell anyone how to communicate or prescribe exact steps, but rather to offer suggestions for consideration based on collective experiences and knowledge. The end goal is always for each member of our team to feel empowered to do the job of application engineer in a way that aligns with them individually.
+
+## Who is our audience?
+No audience is a monolith, which means it’s okay to start with a general idea and remember that there will never be a single way that will resonate with every single person who comprises our audience. Our audience is that of developers and we could make many wrong assumptions about what developers like/don’t like. The good news is, we have amazing partners in marketing and product/design who have put in tons of thought to create [these guidelines](../communication/content_guidelines.md), which can help you think about our audience from the perspective of what likely resonates most.
+
+## Structure can go a long way
+We are all somewhere on a spectrum of preferring information to be delivered in a way that is straight to the point or gets into all of the context. Structure can help you meet both ends of the spectrum in a single post:
+
+It’s okay to skip the fluff. It’s okay to skip introducing yourself (everyone can see your title in Slack/email signature). It’s okay to keep the pleasantries brief -- a quick “hi” can go a long way. 
+TL;DR can be powerful to help offer a cue of what you really want to be sure folks read
+Provide all the context AFTER you get to the point. This lets you meet both ends of the spectrum (those who crave context vs those who do not). You can make it feel natural with prefaces like “To share more context…,” “To explain in more detail....,” etc.
+Imagine whoever is reading what you write is busy and may not read more than the first few sentences … how can you structure everything you want to say so that if they don’t read everything, they will still get the most important things?
+It can make someone feel unheard if you neglect to answer a specific question they ask, even if you know the question isn’t relevant to resolving their issue. 
+Using bold headers, bullet lists, etc can also help break up long text to help folks orient to everything in a way where they can more quickly understand why what you wrote is so long.
+
+## Delivering hard news
+### This is going to take longer than we both want
+Sometimes we have to prioritize work between customers, especially when we engage engineering for help. Try to orient your explanation to the customer in a way that is reassuring to them and doesn’t make them feel like the issue that matters to them doesn’t matter to us. A customer usually doesn’t care what else we have going on or how hard things are for us. They just want to know we care, we are on it, we are not going to ghost them, etc. It can help to tie the timeline to the issue. Something like... 
+
+This issue is turning out to be a little unique so I want to engage my teammates who work in this part of our code base regularly. I’ll see what their workload is like right now and make sure we give this attention as soon as we can. I am hoping to have an update for you in a few days at the latest…
+
+...can go a long way to setting expectations, with context as to why, and in a way that another developer can appreciate, all while making it clear you are driving the process.
+
+### This is a feature request
+It can be very disappointing to have come to us with a question thinking something must be possible only to learn, nope … and developers know all too well that can mean we may never get to it. This disappointment can cause a lack of faith. This is why when a CE is assigned, we immediately bring in the CE to handle the conversation -- their super powers allow them to have these conversations in a way that prevents churn risk. For our customers without CE, the risk of churn is lower, but we still want them to feel heard without us accidentally committing another team to something they may or may not do. 
+You can help temper expectations with thoughtful adjective choice. “This is a great idea” might lead someone to believe we will do it. “This is an interesting idea” makes it a bit more clear there is a question for us to answer about whether we will do it or not.
+You can help set-up your product teammates for success by not saying things like “I am sure our team will want to do this…” and instead saying something like “My product teammates will consider this to see whether we can add it to our roadmap.”
+You can round it all out by filing a public issue the customer can have and engage on. That act alone makes it clear to the customer they have access to your teammates, too, and the process will be transparent. 
+It’s even okay to encourage the customer to share any additional thoughts they have on the feature request issue and that they can ask for an update if they ever wonder where our team is at with it.
+
+### Saying no
+Sometimes we do need to say no. You can help folks work through their frustration by coupling a “no” with an invitation to react and imagining how they might feel. Something like “That is not currently possible. I imagine this is disappointing to learn. I can let my teammates responsible for this part of our code base know what thoughts you might have, if you want to share them.” This is very related to a feature request, but a little different if it’s something we have already said no to. Who knows, maybe sharing such details leads us to change our mind.
+
+## Be the one to drive the conversation
+Honoring our guiding principle of staying at least a step ahead and never leaving the customer wondering what comes next can put you in control of the conversation. Usually customers only take over and get demanding when they feel like you don’t have next steps or it’s unclear to them what the next steps are. 
+
+## Be the one to drive calls
+Showing up for the customer as the one driving a call can make calls go smoother and relieve a lot of the stress they can have. A few ways that can keep you the one driving:
+Before you get on the call, set expectations: make the customer share what they want to accomplish OR tell them what is possible. It’s even okay to say something like: "I might not be able to solve this on a call, but I should be able to get what I need so we can get to resolution faster."
+At the start of the call, restate those expectations that you put in writing before the call.
+During the call, when something comes up that you don't know, usually with developers it goes better saying "Could be this, let me double check and confirm after the call." If someone responds to that unreasonably, they are likely having a bad day and probably treating you differently than they actually want to treat you.
+After the call, share a summary of what you did and what the next steps are.
+After the call, follow through on your next steps.
+
+Bonus: It often also goes better when you are the one to initiate the call vs waiting for a case to be going on so long the customer asks after 2-3 weeks and is already frustrated. And remember, it is 100% okay and encouraged to initiate a #rfh (request for help) with engineering via our usual workflow and in it, request that engineering join you on a call if you feel it will help you all resolve the customer’s issue faster.
+
+## Understand you are the authority (even when you don’t feel you are)
+You have to know a lot as an application engineer and that can get into your head and make you feel like you are anything but an authority. Just try to remember that to the customer you are … you are Sourcegraph. Keeping yourself in the position by choosing your words to be reassuring of that fact helps the customer trust you even while you need time to figure things out. When you bring in others to help and you say something like “I want to talk to my teammates” or “I want to talk to my teammates who work in this part of the code every day” shows the customer you are on it and you will get what they need much more than “I need to talk to engineering” or “I need to talk to [engineering team name].” Our customers don’t know all of our team names and they shouldn’t have to. 
+
+## “I think.../and…” or “I want to look into that more…” vs “I don’t know.”
+Sometimes the hardest part of the application engineer job is trusting how much you do know and projecting that confidence in a way that is reassuring to our customers, even when you have questions yourself. Saying “I don’t know” is honest, transparent, and likely feels natural. It can also trigger some folks to worry they won’t get the help they need. This isn’t our fault. This is the fault of many businesses who devalue their support teams and put them in awful positions to not be able to provide great support. Unfortunately, we sometimes have to take an extra step to prevent our customers from worrying we will be like just another bad support team. 

--- a/content/departments/support/process/enablement/step-ahead.md
+++ b/content/departments/support/process/enablement/step-ahead.md
@@ -1,0 +1,31 @@
+# An open letter about staying a step ahead
+
+Dear Application Engineer,
+
+You are here because you are trying to stay a step ahead and you are realizing … wow, this feels hard. It is hard! And like all of life’s wonderful complexities, it is possible to process it and metabolize it until it clicks and makes such deep sense it suddenly feels easy.
+
+Let’s do that!
+
+- Staying a step ahead means our customers know what you are thinking, what you are intending, what you are wondering.
+- Staying a step ahead means you are leading and our customers are following.
+- Staying a step ahead means our customers feel a deep truth that they are in good hands with you.
+
+Not tangible enough, right? Right!
+
+- Staying a step ahead means summarizing the current status, giving clear next steps, and setting expectations in every communication.
+- Staying a step ahead means our customers don't even feel compelled to escalate because they can feel your progress so frequently it never even occurs to them to do so.
+- Staying a step ahead means communicating in a deeply nuanced way that leaves our customers feeling reassured.
+
+Still not quite tangible enough, right? Right!
+
+- Staying a step ahead means sharing the details to the point where you wonder if you are oversharing, but it won’t feel that way to them because you share the most important details first and then you share all of the context they will also appreciate
+- Staying a step ahead means you hold the truth tight that you are responsible and you freely speak in “I” or “we” so that are customers understand you are the one making this happen (regardless if you need to bring in others, which is always okay to do)
+- Staying a step ahead means you accept the reality that when an issue isn’t resolved in a week, our customers start to get nervous, start to lose faith … and you do something about it. You get ahead of it. You move through our workflow at a quick clip, you help your engineering teammates understand they need to join you on a call, you stay thoughtfully persistent and thoughtfully relentless.
+- Staying a step ahead means you often ask your teammates for help AND then engage engineering within a day or two (it’s okay to move that quick if you need to).
+- Staying a step ahead means if you don’t feel like you are going to resolve an issue within a week, you bring in engineering on day 3 or 4, not week 2.
+- Staying a step ahead means if you are working with engineering and you are not getting it or you don’t feel you can yet help the customer, you ask your engineering teammate to Zoom with you (they will and you will get what you need to help the customer faster!)
+- Staying a step ahead means if you reach a week and the issue isn’t resolved, a call with the customer is probably the best next step to making sure the issue doesn’t drag on for another week or another and it’s okay to ask engineering to join you on those calls and find a time that works for everyone to do the call.
+
+Couple this with the list for how you, as an application engineer, know if you are being successful and you will be unstoppable. This is why it matters to only have 5 active cases -- we are going for quality here, folks, and quality takes time and space. To be responsive, reliable, and consistent, you cannot be stretched too thin. If ever you feel overwhelmed or like you cannot show up to honor the depth of what it means to stay a step ahead, simply post in #customer-support-internal these simple words “I am trying to do too much to do it all with quality. I need help.” Your teammates will have your back, your leadership team will support you -- we will all work together to ensure every member of the team is set-up for success so we can all stay a step ahead.
+
+This is how we stay a step ahead.

--- a/content/departments/support/process/support-workflow.md
+++ b/content/departments/support/process/support-workflow.md
@@ -41,7 +41,7 @@ Things happen pretty much in this order...and at every step, our decisions and a
    2. If we collectively don't know the answer, then we engage engineering following the steps outlined [here](engaging-other-teams.md).
    3. A few additional tips...
       - If ever an issue seems a bit bigger than helping a customer fix something that isn't working correctly or explaining how something works (for example, the customer needs to make a decision about doing something one way or another), then it's a good idea to loop in the CE and see if they want to offer any additional ideas/thoughts to the customer to help them from a strategic perspective.
-      - Try to make sure that what you are helping a customer with is fully supported. You can check this by referring to the resources found [here](../departments/product-engineering/product#feature-matrices).
+      - Try to make sure that what you are helping a customer with is fully supported. You can check this by referring to the resources found [here](../../product-engineering/product#feature-matrices).
       - For features tagged beta or experimental in our docs, it’s okay to err on the side of engaging engineering sooner rather than later (since we don't yet know if we will want to release these, we keep our docs light in case we opt to remove the feature after all).
 
 9. **The application engineer resolves the issue.** We don't consider something resolved unless the customer does/would. Resolution happens in a few ways. Only when one of these is true do we designate a case "closed" in Zendesk -- and if we were working in Slack, we leave that channel.

--- a/content/departments/support/process/support-workflow.md
+++ b/content/departments/support/process/support-workflow.md
@@ -39,9 +39,10 @@ Things happen pretty much in this order...and at every step, our decisions and a
 
    1. Ask our teammates in our #customer-support-internal Slack channel.
    2. If we collectively don't know the answer, then we engage engineering following the steps outlined [here](engaging-other-teams.md).
-   3. If ever an issue seems a bit bigger than helping a customer fix something that isn't working correctly or explaining how something works (for example, the customer needs to make a decision about doing something one way or another), then it's a good idea to loop in the CE and see if they want to offer any additional ideas/thoughts to the customer to help them from a strategic perspective.
-
-For features tagged beta or experimental in our docs, it’s okay to err on the side of engaging engineering sooner rather than later (since we don't yet know if we will want to release these, we keep our docs light in case we opt to remove the feature after all).
+   3. A few additional tips...
+	   - If ever an issue seems a bit bigger than helping a customer fix something that isn't working correctly or explaining how something works (for example, the customer needs to make a decision about doing something one way or another), then it's a good idea to loop in the CE and see if they want to offer any additional ideas/thoughts to the customer to help them from a strategic perspective. 
+	   - Try to make sure that what you are helping a customer with is fully supported. You can check this by referring to the resources found [here](../departments/product-engineering/product#feature-matrices).
+	   - For features tagged beta or experimental in our docs, it’s okay to err on the side of engaging engineering sooner rather than later (since we don't yet know if we will want to release these, we keep our docs light in case we opt to remove the feature after all).
 
 9. **The application engineer resolves the issue.** We don't consider something resolved unless the customer does/would. Resolution happens in a few ways. Only when one of these is true do we designate a case "closed" in Zendesk -- and if we were working in Slack, we leave that channel.
 

--- a/content/departments/support/process/support-workflow.md
+++ b/content/departments/support/process/support-workflow.md
@@ -40,9 +40,9 @@ Things happen pretty much in this order...and at every step, our decisions and a
    1. Ask our teammates in our #customer-support-internal Slack channel.
    2. If we collectively don't know the answer, then we engage engineering following the steps outlined [here](engaging-other-teams.md).
    3. A few additional tips...
-	   - If ever an issue seems a bit bigger than helping a customer fix something that isn't working correctly or explaining how something works (for example, the customer needs to make a decision about doing something one way or another), then it's a good idea to loop in the CE and see if they want to offer any additional ideas/thoughts to the customer to help them from a strategic perspective. 
-	   - Try to make sure that what you are helping a customer with is fully supported. You can check this by referring to the resources found [here](../departments/product-engineering/product#feature-matrices).
-	   - For features tagged beta or experimental in our docs, it’s okay to err on the side of engaging engineering sooner rather than later (since we don't yet know if we will want to release these, we keep our docs light in case we opt to remove the feature after all).
+      - If ever an issue seems a bit bigger than helping a customer fix something that isn't working correctly or explaining how something works (for example, the customer needs to make a decision about doing something one way or another), then it's a good idea to loop in the CE and see if they want to offer any additional ideas/thoughts to the customer to help them from a strategic perspective.
+      - Try to make sure that what you are helping a customer with is fully supported. You can check this by referring to the resources found [here](../departments/product-engineering/product#feature-matrices).
+      - For features tagged beta or experimental in our docs, it’s okay to err on the side of engaging engineering sooner rather than later (since we don't yet know if we will want to release these, we keep our docs light in case we opt to remove the feature after all).
 
 9. **The application engineer resolves the issue.** We don't consider something resolved unless the customer does/would. Resolution happens in a few ways. Only when one of these is true do we designate a case "closed" in Zendesk -- and if we were working in Slack, we leave that channel.
 


### PR DESCRIPTION
Added new enablemement pages: 1) clarify what staying a step ahead mens and 2) tips for how to communicate with devs as an audience.

Also made two changes to triage: 1) change in how we handle Hubspot forms and 2) link to Truework page for employement verification requests

And added links in workflow to our product pages to help us understand if we support something or its more of a feature request