### PR TITLE
Cloud SaaS team handbook team page update 

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/saas/index.md
+++ b/content/departments/product-engineering/engineering/cloud/saas/index.md
@@ -74,6 +74,8 @@ The list below contains features and services that already exist, and the Cloud 
   - [Milan Freml](../../../../../team/index.md#milan-freml) (he/him)
   - [Rafal Gajdulewicz](../../../../../team/index.md#rafal-gajdulewicz) (he/him)
   - P. R. (he/him) - starting 2022.01
+  - P-J L. (he/him) - starting 2022.01
+  - M. V. (she/her) - starting 2022.02
 
 We’re hiring! [Check out our open roles](https://boards.greenhouse.io/sourcegraph91/jobs/4101082004).
 

--- a/content/departments/product-engineering/engineering/cloud/saas/index.md
+++ b/content/departments/product-engineering/engineering/cloud/saas/index.md
@@ -104,7 +104,7 @@ We are committed to sending a monthly newsletter to the entire Product and Engin
 ### How to contact the team and ask for help
 
 - For cloud users with urgent help requests reach out to our support team at [support@sourcegraph.com](mailto:support@sourcegraph.com).
-- For emergencies and incidents, alert the team using Slack command `/genie alert [message] for Cloud SaaS Team`.
+- For emergencies and incidents, alert the team using Slack command `/genie alert [message] for cloud-saas`.
 - For internal Sourcegraph teammates, join us in [#cloud-saas](https://sourcegraph.slack.com/archives/cloud-saas) to ask questions or request help from our team.
 - For cloud users with feature requests, please reach out to our product manager, Ryan, at [ryphil@sourcegraph.com](mailto:ryphil@sourcegraph.com) and include `Cloud Feature Request:` in your subject line.
 

--- a/data/team.yml
+++ b/data/team.yml
@@ -981,7 +981,7 @@ carly_jones:
 rafal_leszczynski:
   name: Rafal Leszczynski
   pronouns: he/him
-  role: Engineering Manager, Core Application
+  role: Engineering Manager, Cloud SaaS
   location: Jelonek (Poznan), Poland 🇵🇱
   github: RafLeszczynski
   email: rafal@sourcegraph.com


### PR DESCRIPTION
 - add new hires
 - fix the slack command to page the team
 - update raf's description on the SG team page 