### PR TITLE
Point at new org repo

### DIFF
--- a/content/departments/support/process/managing-cs-aws.md
+++ b/content/departments/support/process/managing-cs-aws.md
@@ -31,7 +31,7 @@ ssh -i .ssh/cse-aws.pem ec2-user@ec2-3-133-49-142.us-east-2.compute.amazonaws.co
 
 ## Upgrading CS-AWS
 
-Upgrading CS-AWS follows the [standard procedure](https://docs.sourcegraph.com/admin/install/docker-compose/operations#upgrade) for upgrading a compose instance. The EC2 instance points at a [fork of deploy-sourcegraph-docker](https://github.com/DaedalusG/deploy-sourcegraph-docker).
+Upgrading CS-AWS follows the [standard procedure](https://docs.sourcegraph.com/admin/install/docker-compose/operations#upgrade) for upgrading a compose instance. The EC2 instance points at a [fork of deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-cse-aws).
 
 **Note: When connection to the EC2 server via SSH your user does not have permissions to run many git commands, you'll need to run git commands with `sudo` or switch to the root user with `sudo su`**
 


### PR DESCRIPTION
I've moved the origin repo for cse-aws into a Sourcegraph org repo. The origin and upstream are correctly set inside the EC2 instance repo, and you should be able to clone this one and work straight from here. It's stock except for the caddy file. In the process of breaking things I may have messed up the gitconfig. So that may be a task for another day. I now have to provide a username and password (token) for most remote actions. 🤷  (ask me about my S3 debacle later lol) 