### PR TITLE
adds go crash course to index.md

### DIFF
--- a/content/departments/support/process/enablement/index.md
+++ b/content/departments/support/process/enablement/index.md
@@ -13,6 +13,7 @@ This table correlates to our [technical competency matrix](https://docs.google.c
 | Code insights                   | Go here                                                                                                         |          |
 | Docker/docker-compose deploy    | Go here                                                                                                         |          |
 | Docker/docker-compose migration | [Go Here](docker-compose-migrations.md)                                                                         |          |
+| Go Programming Language         | [Go Here](https://go.dev/tour/welcome/1)                                                                        |          |
 | GraphQL                         | [Go here](https://docs.google.com/presentation/d/1qgid2A0D0ycNidRfzsl2YrmjKTPiG_W8HPoECdgXwLE/edit?usp=sharing) |          |
 | Kubernetes deploy               | Go here                                                                                                         |          |
 | Kubernetes migration            | [Go here](k8-migration.md)                                                                                      |          |


### PR DESCRIPTION
Completing the linked crash course on Go's official will bring AER's to a level 3 in the technical competence matrix.