### PR TITLE
Spelling and style updates

### DIFF
--- a/content/departments/marketing/content/web_series.md
+++ b/content/departments/marketing/content/web_series.md
@@ -4,9 +4,9 @@
 
 ## Dev Tool Time
 
-Dev Tool Time is a bi-weekly web series livestreamed on [Twitch](https://www.twitch.tv/sourcegraph) where Sourcegraph engineers interview other devs in the community about their desk set up, favorite dev tools, productivity hacks, and more. Recordings are later available on our [YouTube account](https://www.youtube.com/watch?v=W7DHo90Boa4&list=PL6zLuuRVa1_iDEP4EicZ8972RgyccCRGF).
+Dev Tool Time is a bi-weekly web series live-streamed on [Twitch](https://www.twitch.tv/sourcegraph) where Sourcegraph engineers interview other devs in the community about their desk set up, favorite dev tools, productivity hacks, and more. Recordings are later available on our [YouTube account](https://www.youtube.com/watch?v=W7DHo90Boa4&list=PL6zLuuRVa1_iDEP4EicZ8972RgyccCRGF).
 
-This series aims to help new developers learn about existing tools but also update experienced developers who might not know about certain developer tools and workflows. While Sourcegraph may be mentioned, it will not be the main focus. This series is genuinely to inform developers about all the different tools out there and enhance developer awareness about the importance of having the right tools setup to increase coding efficiency.
+This series aims to help new developers learn about existing tools but also update experienced developers who might not know about certain developer tools and workflows. While Sourcegraph may be mentioned, it will not be the main focus. This series is genuinely to inform developers about all the different tools out there and enhance developer awareness about the importance of having the right tools set up to increase coding efficiency.
 
 ### What makes a great Dev Tool Time guest?
 
@@ -26,19 +26,19 @@ There will be a set structure that we apply to each event to create a consistent
 ##### Run of show
 
 - 10 minutes prior to start time: Hosts & guests enter green room
-- 1 minutes prior to start time: Moderator preps guest to go live (quiet the room, mute, etc.)
-- 30 seconds prior to start time: Moderator leads count down to going live and gives host signal to start
+- 1 minute prior to start time: Moderator preps guest to go live (quiet the room, mute, etc.)
+- 30 seconds prior to start time: Moderator leads countdown to going live and gives host signal to start
 - Host opens the show
 - Host leads intros, banter, background on guest
 - Guest shows hardware setup (guest shares photo of desk)
 - Guest dives into the tools, demos, live showcasing tools (guest shares their screen)
 - Moderator prepares and shares questions from chat throughout the show
-- Moderator signals 5 minute mark to wrap up show at 55 minute mark
+- Moderator signals 5-minute mark to wrap up show at 55-minute mark
 - Host leads outro, where to find more information, helpful links, teases next guest
 
 ### Program details
 
-- When: The second and fourth Wednesday of every month at 11:00am PT / 6:00 PM UTC
+- When: The second and fourth Wednesday of every month at 11:00 AM PT / 6:00 PM UTC
 - Where: [Twitch](https://www.twitch.tv/sourcegraph/)
 - Host: TJ DeVries, Thorsten Ball
 - Moderator: TBD
@@ -62,9 +62,9 @@ Thank you so much for wanting to share your dev environment with the world. To m
 
 #### Preparing for your episode
 
-- Episodes range in length from 30 minuntes to an hour
-- The show will be live streamed on Twitch using the restreamer.io platform, which offers several options for attendee participation. You can call in via restreamer. The restreamer link will be on your calendar invite 1 week prior to the live stream.
-- We’ll start off with you showing a photo of your desk (please be ready to share your screen) so you can talk about what setup has facilitated your work practices and environment. This is just an ice breaker so we’ll keep this segment short to about 5 minute but we’re also flexible if you want to invest more time into this.
+- Episodes range in length from 30 minutes to an hour
+- The show will be live-streamed on Twitch using the restreamer.io platform, which offers several options for attendee participation. You can call in via restreamer. The restreamer link will be on your calendar invite 1 week prior to the live-stream.
+- We’ll start off with you showing a photo of your desk (please be ready to share your screen) so you can talk about what setup has facilitated your work practices and environment. This is just an ice breaker so we’ll keep this segment short to about 5 minutes but we’re also flexible if you want to invest more time into this.
   Then we’ll go over to talk about the developer tools you love, diving into your developing processes, etc.
   You can focus on presenting your dev environment and dev tools. Our co-hosts will be forwarding you any questions that come up from the audience.
   The session will be recorded and will remain available on YouTube. We’ll make sure you get a link to the recording of your session which you can share and embed however you like.


### PR DESCRIPTION
count down to countdown
livestreamed to live-streamed
setup to set up
1 minutes to 1 minute
5-minute and 55-minute - added hyphens
Time capitalization consistency "am" to AM to match PM
minuntes to minutes