### PR TITLE
prettier workflow: Add .mjs to extensions to be formatted

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           # Take prettier version from package.json to stay in sync and support upgrades through Renovate
           prettier_version: ${{steps.prettier_version.outputs.prop}}
-          prettier_options: --write **/*.{js,css,scss,ts,tsx,md,html,yml,yaml,json}
+          prettier_options: --write **/*.{js,mjs,css,scss,ts,tsx,md,html,yml,yaml,json}
           commit_message: squash! Prettier
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_GITHUB_TOKEN }}


### PR DESCRIPTION
I'm reusing this workflow in [sourcegraph/interviews](https://github.com/sourcegraph/interviews), and I noticed that it doesn't format .mjs files. This PR fixes the problem.