### PR TITLE
prettier workflow: Use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -50,4 +50,4 @@ jobs:
           prettier_options: --write **/*.{js,mjs,css,scss,ts,tsx,md,html,yml,yaml,json}
           commit_message: squash! Prettier
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switch the prettier workflow to use the default GITHUB_TOKEN (automatically available to all workflows) rather than a repository-specific token.

This allows the script to be copied as-is and reused in other Sourcegraph repos. With the current version, that's not possible because it relies on a [repository-level secret](https://github.com/sourcegraph/handbook/settings/secrets/actions), which means that you'd have to add a secret with the same name to every repository where you want to reuse this.