### PR TITLE
Fix career framework header

### DIFF
--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -191,7 +191,8 @@ const remarkSpecialNoteBlocks: Plugin<[], MdastRoot> = () =>
 const rehypeResponsiveTables: Plugin<[], HastRoot> = () => tree => {
     visit(tree, (node, index, parent) => {
         if (isElement(node, 'table')) {
-            parent!.children[index!] = h('div.table-responsive', node)
+            // Note: Matches breakpoint used for th.sticky CSS class
+            parent!.children[index!] = h('div.table-responsive-sm', node)
         }
     })
 }

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -398,11 +398,14 @@ kbd {
         overflow: auto;
     }
 
-    /* Can be applied to <th> table header cells */
-    .sticky {
-        position: sticky;
-        top: calc(var(--header-height) - 1px);
-        z-index: 2;
+    // Can be applied to <th> table header cells
+    // Only apply above small size, because on small we use scrolling table wrappers that conflict with sticky headers.
+    @include media-breakpoint-up(sm) {
+        th.sticky {
+            position: sticky;
+            top: calc(var(--header-height) - 1px);
+            z-index: 2;
+        }
     }
 
     table {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/handbook/issues/789

The sticky header code was conflicting with the newer scrolling table wrappers, making the headers look broken and overlap the first rows of the table.

Before:

<img width="987" alt="image" src="https://user-images.githubusercontent.com/10532611/149025288-1fc2aff1-6a6e-4fc7-be5e-78b7f57ffd8f.png">

After:

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/10532611/149025335-10f292e5-45fd-470f-bd01-ce7146df82b2.png">


Unfortunately we have to sacrifice either sticky headers or scrolling wrappers. I chose to let the table scroll on mobile (without sticky headers) while using sticky headers on desktop (but no scrolling).