### PR TITLE
Update PM Interview Process index.md

### DIFF
--- a/content/departments/product-engineering/product/roles/interviews/product_manager/index.md
+++ b/content/departments/product-engineering/product/roles/interviews/product_manager/index.md
@@ -4,12 +4,13 @@ _Total interview time: 4.5 hours + ~1 hour project_
 
 1. [30 min] **[Initial screen](../initial_screen.md)**: Meet with our recruiting team to chat about Sourcegraph and what you are looking for in your next role.
 1. [30 min] **[Hiring manager screen](../hm_intro_call.md)**: We discuss your background & get to know you.
-1. [1 hr] **[Resume deep dive](../../../../../talent/process/types_of_interviews.md#resume-deep-dive)**: We go through your background in great detail with the hiring manager.
 1. [~ 1 hr] **[Async writing project](./pm_rfc_project.md)**: A writing project to see how you communicate and think about product problems, reviewed by two members from the [Product team](../../index.md#team)
+1. [1 hr] **Product interview**: Meet with a Product Manager and Product Designer to review your writing project and dive deep on how you work as a product manager.
 1. [2 hrs] **"Onsite" interview**
-   - [1 hr] **Product interview**: Meet with a Product Manager and Product Designer to review your writing project and dive deep on how you work as a product manager.
+   - [1 hr] **[Resume deep dive](../../../../../talent/process/types_of_interviews.md#resume-deep-dive)**: We go through your background in great detail with the hiring manager.
    - [30 min] **Engineering collaboration**: Meet with the Engineering Manager from the team you're interviewing for about how you collaborate and work within a team.
-   - [30 min] **[Values interview](../../../../../../company-info-and-process/values/index.md)** with someone from another Sourcegraph team (Marketing, Customer Support, BizOps)14. [30 min] **Final interview** with [Beyang Liu](../../../../../../team/index.md#beyang-liu), CTO
+   - [30 min] **[Values interview](../../../../../../company-info-and-process/values/index.md)** with someone from another Sourcegraph team (Marketing, Customer Support, BizOps)14. 
+   - [30 min] **Leadership interview** with [Beyang Liu](../../../../../../team/index.md#beyang-liu), CTO
 1. We make you a job offer!
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.

--- a/content/departments/product-engineering/product/roles/interviews/product_manager/index.md
+++ b/content/departments/product-engineering/product/roles/interviews/product_manager/index.md
@@ -9,7 +9,7 @@ _Total interview time: 4.5 hours + ~1 hour project_
 1. [2 hrs] **"Onsite" interview**
    - [1 hr] **[Resume deep dive](../../../../../talent/process/types_of_interviews.md#resume-deep-dive)**: We go through your background in great detail with the hiring manager.
    - [30 min] **Engineering collaboration**: Meet with the Engineering Manager from the team you're interviewing for about how you collaborate and work within a team.
-   - [30 min] **[Values interview](../../../../../../company-info-and-process/values/index.md)** with someone from another Sourcegraph team (Marketing, Customer Support, BizOps)14. 
+   - [30 min] **[Values interview](../../../../../../company-info-and-process/values/index.md)** with someone from another Sourcegraph team (Marketing, Customer Support, BizOps)14.
    - [30 min] **Leadership interview** with [Beyang Liu](../../../../../../team/index.md#beyang-liu), CTO
 1. We make you a job offer!
 


### PR DESCRIPTION
After reevaluating the  interview process, the team decided that to optimize for their time, especially given the lengthy nature of the virtual onsite, they would like switch around the steps of the process. They would like to move the RFC project and Product Manager Interview (RFC Review) after the manager intro call but before the resume deep dive.  They hope this will allow them to generate a better understanding of a candidate's technical abilities sooner rather than having to wait until the virtual onsite towards the end of the process to better understand the technical capabilities of the candidate.