### PR TITLE
infra/ci: create /ci, add CI changelog

### DIFF
--- a/content/departments/product-engineering/engineering/enablement/dev-experience/index.md
+++ b/content/departments/product-engineering/engineering/enablement/dev-experience/index.md
@@ -23,8 +23,7 @@ The Dev Experience team, or DevX for short, is a team focused on improving the d
 - Continuous integration
   - [`sourcegraph/sourcegraph` Buildkite pipelines](https://docs.sourcegraph.com/dev/background-information/continuous_integration#buildkite-pipelines)
   - [Continuous integration playbook](../../process/incidents/playbooks/ci.md)
-  - [Buildkite agents](../../tools/infrastructure/index.md#buildkite-agents)
-  - [Sentry project](https://sentry.io/organizations/sourcegraph/issues/?project=6110304) for the CI pipeline.
+  - [Continuous integration infrastructure](../../tools/infrastructure/ci/index.md)
 - Tooling
   - [`sg` - the Sourcegraph developer tool](https://docs.sourcegraph.com/dev/background-information/sg)
     - [`sg` hack hour](#sg-hack-hour)

--- a/content/departments/product-engineering/engineering/tools/infrastructure/ci/changelog.md
+++ b/content/departments/product-engineering/engineering/tools/infrastructure/ci/changelog.md
@@ -1,0 +1,9 @@
+# Continuous integration changelog
+
+This page logs significant monthly changes to our [CI infrastructure](./index.md), and is primarily maintained by the [DevX team](../../../enablement/dev-experience/index.md).
+
+Also see the [DX newsletter](../../../enablement/dev-experience/newsletter.md) for some of this content, as well as other DX-related updates.
+
+## January 2022
+
+- 19th: Created CI changelog.

--- a/content/departments/product-engineering/engineering/tools/infrastructure/ci/index.md
+++ b/content/departments/product-engineering/engineering/tools/infrastructure/ci/index.md
@@ -1,0 +1,34 @@
+# Continuous integration infrastructure
+
+This page consolidates resources regarding our CI _infrastucture_, namely our [Buildkite agents fleet](#buildkite-agents).
+This infrastructure is maintained by the [DevX team](../../../enablement/dev-experience/index.md).
+
+Related resources:
+
+- [CI playbook](../../../process/incidents/playbooks/ci.md)
+- [CI changelog](./changelog.md)
+- [`sourcegraph/sourcegraph` CI pipelines](https://docs.sourcegraph.com/dev/background-information/continuous_integration)
+  - [`sourcegraph/sourcegraph` CI dashboard and logs](https://sourcegraph.grafana.net/d/iBBWbxFnk/ci?orgId=1)
+  - [Sentry project for CI pipelines](https://sentry.io/organizations/sourcegraph/issues/?project=6110304)
+
+## Buildkite agents
+
+We maintain a shared fleet of Buildkite agents for continuous integration across all repositories.
+
+- [Active agents](https://buildkite.com/organizations/sourcegraph/agents)
+- [Terraform and Kubernetes manifests](https://github.com/sourcegraph/infrastructure/tree/main/buildkite)
+- Images:
+  - [`buildkite-agent`](https://github.com/sourcegraph/infrastructure/tree/main/docker-images/buildkite-agent)
+  - [`buildkite-autoscaler`](https://github.com/sourcegraph/infrastructure/tree/main/docker-images/buildkite-autoscaler)
+  - [`buildkite-agent-metrics`](https://github.com/sourcegraph/infrastructure/tree/main/docker-images/buildkite-agent-metrics)
+- Specific resources:
+  - [Gain access to the CI cluster](../../../process/deployments/debugging/tutorial.md#ci-cluster)
+
+### Buildkite agent queues
+
+We have several different types of agents availables. We recommend explicitly declaring which type of agent you want your jobs to run on with the `agents: { queue: "standard" }` field in your pipeline configuration.
+
+The currently available queues:
+
+- `standard`: our default Buildkite agents, currently Docker-in-Docker agents running in Kubernetes
+- `baremetal`: special Buildkite agents running on standalone machines

--- a/content/departments/product-engineering/engineering/tools/infrastructure/index.md
+++ b/content/departments/product-engineering/engineering/tools/infrastructure/index.md
@@ -8,25 +8,9 @@ Internal deployments are documented in the [deployments](../../process/deploymen
 
 See [Google Cloud Platform](./gcp.md).
 
-## Buildkite agents
+## Continuous integration infrastructure
 
-We maintain a fleet of Buildkite agents for continuous integration across all repositories.
-
-- Owner: [Dev Experience](../../enablement/dev-experience/index.md)
-- URL: https://buildkite.com/organizations/sourcegraph/agents
-- Terraform and Kubernetes manifests: https://github.com/sourcegraph/infrastructure/tree/main/buildkite
-- Resources
-  - [CI playbook](../../process/incidents/playbooks/ci.md)
-  - [`sourcegraph/sourcegraph` CI pipelines](https://docs.sourcegraph.com/dev/background-information/continuous_integration#buildkite-pipelines)
-
-### Buildkite agent queues
-
-We have several different types of agents availables. We recommend explicitly declaring which type of agent you want your jobs to run on with the `agents: { queue: "standard" }` field in your pipeline configuration.
-
-The currently available queues:
-
-- `standard`: our default Buildkite agents, currently Docker-in-Docker agents running in Kubernetes
-- `baremetal`: special Buildkite agents running on standalone machines
+See [Continuous integration infrastructure](./ci/index.md).
 
 ## Code host testing instances
 


### PR DESCRIPTION
Migrates and consolidates CI infrastructure info into `/departments/product-engineering/engineering/tools/infrastructure/ci`, and sets up a CI changelog we can contribute to going forwards.