### PR TITLE
Update managed instance upgrade list

### DIFF
--- a/content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md
+++ b/content/departments/product-engineering/engineering/process/releases/upgrade_managed_issue_template.md
@@ -39,7 +39,6 @@ Make sure to upgrade internal instances before customer instances.
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8288
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8282
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/8285
-- [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/2512
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/581
 - [ ] Upgrade instance for https://github.com/sourcegraph/accounts/issues/6857
 - [ ] Upgrade instance for https://github.com/sourcegraph/customer/issues/605


### PR DESCRIPTION
Followup to https://github.com/sourcegraph/customer/issues/603 - this instance has been shut down and can be removed from the upgrade list.