### PR TITLE
Update devops and delivery team docs

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -1,6 +1,6 @@
 # Delivery team
 
-Delivery team is a part of the [DevOps](../devops/index.ms) team (part of the [Cloud](../index.md) org).
+Delivery team is a part of the [DevOps](../devops/index.md) team (part of the [Cloud](../index.md) org).
 
 ## Mission
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -1,6 +1,6 @@
 # Delivery team
 
-The Delivery team (part of the [Enablement](../index.md) org).
+Delivery team is a part of the [DevOps](../devops/index.ms) team (prt of the [Cloud](../index.md) org).
 
 ## Mission
 
@@ -8,10 +8,7 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 
 ## Members
 
-- [Jean du Plessis](../../../../../team/index.md#jean-du-plessis) ([Director of Engineering](../../roles/index.md#director-of-engineering)) and (acting [Engineering Manager](../../roles/index.md#engineering-manager))
-- [Dan Mckean](../../../../../team/index.md#dan-mckean) (acting [Product Manager](../../../product/roles/index.md#product-manager))
-- [Crystal Augustus](../../../../../team/index.md#crystal-augustus)
-- [Kevin Wojkovich](../../../../../team/index.md#kevin-wojkovich)
+{{generator:product_team.devops}}
 
 ## Strategy
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -1,6 +1,6 @@
 # Delivery team
 
-Delivery team is a part of the [DevOps](../devops/index.ms) team (prt of the [Cloud](../index.md) org).
+Delivery team is a part of the [DevOps](../devops/index.ms) team (part of the [Cloud](../index.md) org).
 
 ## Mission
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
@@ -91,4 +91,4 @@ Welcome to the Delivery team! This document will guide you through delivery-spec
 - Develop any new material required to help others level up and understand our product
 - Add to the teams planning and OKRs
 
-[GCP]: https://console.cloud.google.com
+[gcp]: https://console.cloud.google.com

--- a/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
@@ -91,4 +91,4 @@ Welcome to the Delivery team! This document will guide you through delivery-spec
 - Develop any new material required to help others level up and understand our product
 - Add to the teams planning and OKRs
 
-[gcp]: https://console.cloud.google.com
+[GCP]: https://console.cloud.google.com

--- a/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/onboarding.md
@@ -16,12 +16,13 @@ Welcome to the Delivery team! This document will guide you through delivery-spec
 
 #### Tasks
 
+> If you need access to any system, reach out to your peers in `#delivery-internal` on Slack.
+
 - Meet your onboarding buddy
 - Attend weekly sync meeting
 - Deploy your own SG instance using the following [install methods](https://docs.sourcegraph.com/admin/install):
   - [Docker Compose](https://docs.sourcegraph.com/admin/install/docker-compose): You should be able to install this locally on your Souregraph laptop. If for some reason you do not have the local resources, create a vm in your own [engineering project](../../tools/infrastructure/gcp.md#engineering-projects)
   - [Kubernetes](https://docs.sourcegraph.com/admin/install/kubernetes): To install this it is recommend you create a cluster in your own [engineering project](../../tools/infrastructure/gcp.md#engineering-projects).
-- Open and merge first GitHub pull request by adding yourself to [team page](../../../../../team/index.md) in Handbook
 - Read our [Delivery handbook pages](index.md)
 - Join the distribution Slack channels
   - #delivery
@@ -29,6 +30,8 @@ Welcome to the Delivery team! This document will guide you through delivery-spec
   - #dev-ops
   - #dev-chat
   - #dev-accounce
+- Make sure you are added to the [Delivery](https://github.com/orgs/sourcegraph/teams/delivery) team in Sourcegraph GitHub org.
+- Ask for access to the [Managed Instances](https://console.cloud.google.com/projectselector2/home/dashboard?folder=206339056180&orgonly=true&supportedpurview=project) project group on [GCP] in `#delivery-internal` channel.
 
 ### Week 2
 
@@ -87,3 +90,5 @@ Welcome to the Delivery team! This document will guide you through delivery-spec
 
 - Develop any new material required to help others level up and understand our product
 - Add to the teams planning and OKRs
+
+[GCP]: https://console.cloud.google.com

--- a/content/departments/product-engineering/engineering/cloud/delivery/processes.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/processes.md
@@ -51,8 +51,58 @@ We still work in 2 week cycles, and have the following ceremonies:
 3. Retro (biweekly)
    - A review of what we did for learing purposes
 
-### Issue tracking
+## Issue tracking
 
-<!-- TODO: We should copy the content of google docs over here once the content is finalized -->
+The [Delivery GitHub project](https://github.com/orgs/sourcegraph/projects/205) is the single source of truth. Our Kanban board on GitHub projects consists of the following columes
 
-The [Delivery GitHub project](https://github.com/orgs/sourcegraph/projects/205) is the single source of truth. You shoud go over this [doc](https://docs.google.com/document/d/1HBsAwXuuAVWMCl1_C2hNnKGmoOHGEmcpkQG_jQBSZeg/edit?usp=sharing) to understand how we use the board.
+- [Needs More Info](#needs-more-info)
+- [Icebox](#icebox)
+- [Blocked](#blocked)
+- [Backlog][#backlog]
+- [Up Next][#up-next]
+- [In Progress](#in-progress)
+- [Wating/In Review](#wating-in-review)
+- [Complete](#complete)
+
+### Needs More Info
+
+This is where we can place any tickets that we need to either gather more information on.
+
+Examples:
+- A customer ticket comes in but we need to have more information from the customer.
+- A ticket comes through from developers and we are unclear if this is really a Delivery issue.
+
+### Icebox
+
+This is where tickets that we really want to work on sometime in the future but have no plans for them at the moment.
+
+### Blocked
+
+These are for any tickets that we cannot move forward on. Either they rely on other work that needs to be done by other teams or it isn’t something that Delivery can get to at the moment.
+
+### Backlog
+
+> The items in here are ordered by importance. Top is the most important.
+
+These are items that we want to work on in the near future.
+
+### Up Next
+
+If you have completed the ticket that you are working on and need your next task, take it from here. These items have been looked over and are ready to be worked on.
+Note: The items in here are ordered by importance. Top is most important.
+
+### In Progress
+
+These are items that are currently being worked on. You should only have a maximum of 1 Item per person listed in here!
+
+### Waiting/In Review
+
+Items in here are either complete or are waiting on Customer/Internal feedback.
+
+Examples:
+- We have created a managed instance but we want to confirm the customer is able to log in.
+- We have completed work that needs to also be confirmed and worked on by other teams.
+
+### Complete
+
+All work on this ticket that needs to be done by the Delivery team has been successfully completed.

--- a/content/departments/product-engineering/engineering/cloud/delivery/processes.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/processes.md
@@ -69,6 +69,7 @@ The [Delivery GitHub project](https://github.com/orgs/sourcegraph/projects/205) 
 This is where we can place any tickets that we need to either gather more information on.
 
 Examples:
+
 - A customer ticket comes in but we need to have more information from the customer.
 - A ticket comes through from developers and we are unclear if this is really a Delivery issue.
 
@@ -100,6 +101,7 @@ These are items that are currently being worked on. You should only have a maxim
 Items in here are either complete or are waiting on Customer/Internal feedback.
 
 Examples:
+
 - We have created a managed instance but we want to confirm the customer is able to log in.
 - We have completed work that needs to also be confirmed and worked on by other teams.
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/processes.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/processes.md
@@ -32,6 +32,8 @@ Support requests related to our [areas of ownership](index.md#responsibilities) 
 
 ## How we work
 
+### Planning, sync, & retro
+
 We're currently working in a Kanban style. It suits the fact that support work often cannot wait for a new sprint, and so the idea of being able to plan what we be delivered in any period of time is unreliable.
 
 Kanban means we maintain a backlog of work we want to complete, prioritized in such a way that the team picks up the next highest priority thing.
@@ -48,3 +50,9 @@ We still work in 2 week cycles, and have the following ceremonies:
    - This happens on the weeks we don't have planning, and is a check in on the plans and anything new
 3. Retro (biweekly)
    - A review of what we did for learing purposes
+
+### Issue tracking
+
+<!-- TODO: We should copy the content of google docs over here once the content is finalized -->
+
+The [Delivery GitHub project](https://github.com/orgs/sourcegraph/projects/205) is the single source of truth. You shoud go over this [doc](https://docs.google.com/document/d/1HBsAwXuuAVWMCl1_C2hNnKGmoOHGEmcpkQG_jQBSZeg/edit?usp=sharing) to understand how we use the board.

--- a/content/departments/product-engineering/engineering/cloud/devops/index.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/index.md
@@ -5,7 +5,7 @@ Cloud DevOps team consists of two streams with different focus area.
 - DevOps
 - [Delivery]
 
-If you're looking DevOps stream documentation, stay on this page.
+If you're looking for DevOps stream documentation, stay on this page.
 If you're looking for [Delivery] specific documentation, visit this [page](../delivery/index.md).
 
 ## Vision

--- a/content/departments/product-engineering/engineering/cloud/devops/index.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/index.md
@@ -54,4 +54,4 @@ The best way to contact the cloud-devops team is in the #cloud-devops slack chan
 - Migrate our zonal cluster to a regional cluster and document the process
 - Complete assigned security tasks on behalf of security and provide evidence of completion
 
-[Delivery]: ../delivery/index.md
+[delivery]: ../delivery/index.md

--- a/content/departments/product-engineering/engineering/cloud/devops/index.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/index.md
@@ -1,5 +1,13 @@
 # Cloud DevOps Team
 
+Cloud DevOps team consists of two streams with different focus area.
+
+- DevOps
+- [Delivery]
+
+If you're looking DevOps stream documentation, stay on this page.
+If you're looking for [Delivery] specific documentation, visit this [page](../delivery/index.md).
+
 ## Vision
 
 The two primary pillars of the Cloud Team are Availability and Observability as defined in [RFC 498](https://docs.google.com/document/d/1FOuWZk6wdL7vOA09pb8ILyBYuQ8tEe5saAxebjKduBw/edit#heading=h.trqab8y0kufp)
@@ -45,3 +53,5 @@ The best way to contact the cloud-devops team is in the #cloud-devops slack chan
 - Standardize our monitoring, logging and error reporting systems
 - Migrate our zonal cluster to a regional cluster and document the process
 - Complete assigned security tasks on behalf of security and provide evidence of completion
+
+[Delivery]: ../delivery/index.md


### PR DESCRIPTION
Given the recent reorg, we should update the docs to make things less confusing.

### FAQ
#### Why not nest delivery docs under devops?

The handbook is already pretty nested, and the focus of delivery is still quite different from the cloud devops area, hence keeping them separate.

Close #1804 