### PR TITLE
Remove white image background

### DIFF
--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -432,7 +432,6 @@ kbd {
     img {
         max-width: 100%;
         box-sizing: content-box;
-        background-color: #fff;
     }
 
     img[align='right'] {


### PR DESCRIPTION
This prevents transparent images from actually appearing transparent, which e.g. makes the logos in our brand guidelines look really bad or become unreadable in the case of the dark versions.

https://handbook.sourcegraph.com/departments/marketing/brand/brand_guidelines/logo