### PR TITLE
remove handbook office hours

### DIFF
--- a/content/handbook/index.md
+++ b/content/handbook/index.md
@@ -69,17 +69,6 @@ The handbook consists of Markdown files in the Git repository at github.com/sour
 
 Contact @handbook-support in the #handbook channel for help with the Handbook. @handbook-support is a volunteer-based group of Sourcegraph teammates that are passionate about the Handbook and eager to help. Join the @handbook-support group in Slack if you're interested in helping in this capacity.
 
-### Handbook Office Hours
-
-Handbook Office Hours are held by the Handbook Product Manager every Wednesday at 16:00 UTC. Look for weekly reminders in the #handbook-announce channel.
-
-Office Hours are open to all Sourcegraph teammates. Join for a few minutes, or the whole hour. Some of the things we cover:
-
-- Questions about making changes to the Handbook
-- Handbook Troubleshooting
-- Ideas for Handbook improvements
-- Discussion of Handbook process and features
-
 ### Handbook Hacking Hours
 
 Handbook Hacking Hours are held every Monday at 15:00 UTC, open to all Sourcegraph teammates to work on the Handbook website. We usually work through [Handbook Issues](https://github.com/sourcegraph/handbook/projects/1). The goal is to create some dedicated time to talk handbook, try things out, make it better, fail at things together, etc.


### PR DESCRIPTION
Due to low attendance, we are cancelling Handbook office hours going forward. If you need Handbook support, continue to reach out to the #handbook channel for help.