### PR TITLE
Team names

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -3,6 +3,7 @@
 quinn_slack:
   name: Quinn Slack
   role: '[CEO](../../ceo/index.md), Cofounder, Board of Directors'
+  team:
   location: Mill Valley, CA, USA 🇺🇸
   email: sqs@sourcegraph.com
   links: '[slack.org](https://slack.org), [@sqs](https://twitter.com/sqs), [LinkedIn](https://www.linkedin.com/in/quinnslack)'
@@ -12,6 +13,7 @@ quinn_slack:
 beyang_liu:
   name: Beyang Liu
   role: CTO, Cofounder, Board of Directors
+  team:
   location: San Francisco, CA, USA 🇺🇸
   email: beyang@sourcegraph.com
   links: '[@beyang](https://twitter.com/beyang), [LinkedIn](https://www.linkedin.com/in/beyang-liu)'
@@ -21,6 +23,7 @@ christina_forney:
   name: Christina Forney
   pronouns: she/her
   role: VP Product
+  team:
   manager_role_slug: vp_product
   location: Woodside, CA, USA 🇺🇸
   github: christinaforney
@@ -32,6 +35,7 @@ christina_forney:
 stephen_gutekanst:
   name: Stephen Gutekanst
   role: Internal Contributor / Software Engineer
+  team:
   reports_to: director_engineering
   location: Phoenix, AZ, USA 🇺🇸
   email: stephen@sourcegraph.com
@@ -43,6 +47,7 @@ ryan_slade:
   name: Ryan Slade
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: software_engineering_manager
   location: Valencia, Spain 🇪🇸
   email: rslade@sourcegraph.com
@@ -53,6 +58,7 @@ ryan_slade:
 rijnard_van_tonder:
   name: Rijnard van Tonder
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search
   location: Las Vegas, NV, USA 🇺🇸
   email: rijnard@sourcegraph.com
@@ -65,6 +71,7 @@ eric_fritz:
   name: Eric Fritz
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Milwaukee, WI, USA 🇺🇸
   github: efritz
@@ -76,6 +83,7 @@ eric_fritz:
 eric_brody-moore:
   name: Eric Brody-Moore
   role: Business Operations Manager
+  team:
   reports_to: vp_operations
   manager_role_slug: business_operations_manager
   location: Nashville, TN, USA 🇺🇸
@@ -87,6 +95,7 @@ eric_brody-moore:
 keegan_carruthers-smith:
   name: Keegan Carruthers-Smith
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search_core
   location: Cape Town, South Africa 🇿🇦
   github: keegancsmith
@@ -97,6 +106,7 @@ keegan_carruthers-smith:
 joe_chen:
   name: Joe Chen
   role: Software Engineer
+  team:
   reports_to: engineering_manager_cloud_saas
   location: Boston, MA, USA 🇺🇸
   github: unknwon
@@ -109,6 +119,7 @@ vanesa_ortiz:
   pronouns: she/her
   pronunciation: '/[ˈvanɛsa ɔɹˈtiz](http://ipa-reader.xyz/?text=%5B%CB%88van%C9%9Bsa%20%C9%94%C9%B9%CB%88tiz%5D&voice=Penelope)/'
   role: Community Advocate
+  team:
   reports_to: director_community
   location: San Francisco, CA, USA 🇺🇸
   github: vanesa
@@ -120,6 +131,7 @@ noemi_mercado:
   name: Noemi Mercado
   pronouns: she/her
   role: People Operations Manager
+  team:
   reports_to: vp_people
   manager_role_slug: people_operations_manager
   location: San Francisco, CA (Ramaytush Ohlone land)
@@ -133,6 +145,7 @@ nick_snyder:
   name: Nick Snyder
   pronouns: he/him
   role: VP Engineering
+  team:
   manager_role_slug: vp_engineering
   location: Belmont, CA, USA 🇺🇸
   github: GitHub
@@ -145,6 +158,7 @@ thorsten_ball:
   name: Thorsten Ball
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Aschaffenburg, Bavaria, Germany 🇩🇪
   github: mrnugget
@@ -155,6 +169,7 @@ thorsten_ball:
 loïc_guychard:
   name: Loïc Guychard
   role: Engineering manager, search
+  team:
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_search
   location: Brest, Brittany, France 🇫🇷
@@ -167,6 +182,7 @@ dan_adler:
   name: Dan Adler
   pronouns: he/him
   role: VP Operations
+  team:
   manager_role_slug: vp_operations
   location: San Francisco, CA, USA 🇺🇸
   github: dadlerj
@@ -177,6 +193,7 @@ dan_adler:
 tomás_senart:
   name: Tomás Senart
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search_core
   location: Lisbon, Portugal 🇵🇹 / Berlin, Germany 🇩🇪
   github: tsenart
@@ -188,6 +205,7 @@ tomás_senart:
 geoffrey_gilmore:
   name: Geoffrey Gilmore
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search_core
   location: San Francisco, CA, USA 🇺🇸
   github: ggilmore
@@ -197,6 +215,7 @@ geoffrey_gilmore:
 farhan_attamimi:
   name: Farhan Attamimi
   role: Senior Data Operations Analyst
+  team:
   reports_to: vp_operations
   location: Singapore 🇸🇬
   github: attfarhan
@@ -206,6 +225,7 @@ farhan_attamimi:
 erik_seliger:
   name: Erik Seliger
   role: Software Engineer
+  team:
   reports_to: engineering_manager_batch_changes
   location: Bremen, Germany 🇩🇪
   github: eseliger
@@ -217,6 +237,7 @@ kai_passo:
   name: Kai Passo
   pronouns: he/him
   role: Account Executive
+  team:
   reports_to: regional_director_sales_east
   location: Atlanta, GA, USA 🇺🇸
   github: kpsource
@@ -227,6 +248,7 @@ rob_rhyne:
   name: Rob Rhyne
   reports_to: director_design
   role: Senior Product Designer, Batch Changes and Search
+  team:
   location: Wilmington, NC, USA 🇺🇸
   email: rob@sourcegraph.com
   links: '[@robrhyne](https://twitter.com/robrhyne), [LinkedIn](https://www.linkedin.com/in/rrhyne)'
@@ -234,7 +256,8 @@ rob_rhyne:
 
 felix_becker:
   name: Felix Becker
-  role: Engineering Manager, Code Insights
+  role: Engineering Manager
+  team: Code Insights
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_code_insights
   location: ~~Bremen, Germany 🇩🇪~~ San Francisco, California 🇺🇸
@@ -247,6 +270,7 @@ asdine_el_hrychy:
   name: Asdine El Hrychy
   pronunciation: First name is pronounced _as-deen_, last name _el-ree-tchee_
   role: Software Engineer
+  team:
   reports_to: software_engineering_manager
   location: Ajaccio, France 🇫🇷/ Dubai, UAE 🇦🇪
   github: asdine
@@ -256,6 +280,7 @@ asdine_el_hrychy:
 dave_try:
   name: Dave Try
   role: Software Engineer
+  team:
   reports_to: engineering_manager_developer_experience
   location: Ibague, Colombia 🇨🇴/ Sydney, Australia 🇦🇺
   github: davejrt
@@ -266,6 +291,7 @@ dax_mcdonald:
   name: Dax McDonald
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_devops
   location: Phoenix, AZ, USA 🇺🇸
   github: daxmc99
@@ -276,6 +302,7 @@ dax_mcdonald:
 robert_lin:
   name: Robert Lin
   role: Software Engineer
+  team:
   reports_to: engineering_manager_developer_experience
   location: Burnaby, Canada 🇨🇦
   pronouns: he/him
@@ -287,6 +314,7 @@ robert_lin:
 marek_zaluski:
   name: Marek Zaluski
   role: 'Software Engineer, Engineering Education Lead'
+  team:
   reports_to: engineering_manager_developer_experience
   location: Ottawa, Canada 🇨🇦
   github: marekweb
@@ -298,6 +326,7 @@ adam_harvey:
   name: Adam Harvey
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_batch_changes
   location: Vancouver, Canada 🇨🇦
   github: LawnGnome
@@ -310,6 +339,7 @@ mark_muldez:
   name: Mark "Markie" Muldez
   pronouns: he/him
   role: Sales Development
+  team:
   reports_to: head_sales_development
   location: Tampa, FL 🌴 🇺🇸
   email: mark@sourcegraph.com
@@ -320,6 +350,7 @@ christine_lovett:
   name: Christine Lovett
   pronouns: she/her
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Baltimore MD, USA 🇺🇸
   github: christinelovett
@@ -333,6 +364,7 @@ alicja_suska:
   pronouns: she/her
   pronunciation: /aˈlʲit͡s.ja/
   role: Product Designer, Frontend Platform, Growth and Integrations, and Code Insights
+  team:
   location: Poznań, Poland 🇵🇱
   github: AlicjaSuska
   email: alicja@sourcegraph.com
@@ -343,6 +375,7 @@ stefan_hengl:
   name: Stefan Hengl
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search_core
   location: Berlin, Germany 🇩🇪
   github: stefanhengl
@@ -354,6 +387,7 @@ quinn_keast:
   reports_to: director_design
   pronouns: he/him
   role: Product Designer, Cloud SaaS and Search
+  team:
   location: Berlin, Germany 🇩🇪
   github: quinnkeast
   email: qkeast@sourcegraph.com
@@ -364,6 +398,7 @@ juliana_peña:
   name: Juliana Peña
   pronouns: she/her
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search
   location: Redmond, WA, USA 🇺🇸
   github: limitedmage
@@ -376,6 +411,7 @@ tharuntej_kandala:
   name: Tharuntej Kandala
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_growth
   location: Jacksonville, FL, USA 🇺🇸
   github: tjkandala
@@ -387,6 +423,7 @@ chris_pine:
   name: Chris Pine
   pronouns: he/she/they/Chris
   role: Engineering Manager, Batch Changes
+  team:
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_batch_changes
   location: Portland, OR, USA 🇺🇸
@@ -399,6 +436,7 @@ chris_pine:
 gregg_stone:
   name: Gregg Stone
   role: VP of Sales
+  team:
   manager_role_slug: vp_sales
   location: San Francisco, CA
 
@@ -410,6 +448,7 @@ noah_santschi-cooney:
   name: Noah Santschi-Cooney
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Wexford, Ireland 🇮🇪
   pronunciation: '/[noʊə santʃi kuːnɪ](http://ipa-reader.xyz/?text=no%CA%8A%C9%99%20sant%CA%83i%20ku%CB%90n%C9%AA&voice=Amy)/'
@@ -421,6 +460,7 @@ noah_santschi-cooney:
 bill_kolman:
   name: Bill Kolman
   role: Account Executive
+  team:
   reports_to: regional_director_sales_east
   location: New York, New York
   email: Bill@sourcegraph.com
@@ -431,6 +471,7 @@ owen_brennan:
   name: Owen Brennan
   pronouns: he/him
   role: Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: Boise, Idaho, USA
 
@@ -443,6 +484,7 @@ maría_craig:
   reports_to: product_director_code_graph
   pronouns: she/her
   role: Product Manager, Code Intelligence
+  team:
   location: Barcelona, Spain 🇪🇸 / Buenos Aires, Argentina 🇦🇷
   github: macraig
   email: maria@sourcegraph.com
@@ -453,6 +495,7 @@ maría_craig:
 chris_surdi:
   name: Chris Surdi
   role: Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: San Francisco, Ca, USA, 🇺🇸
   email: chris.surdi@sourcegraph.co
@@ -463,6 +506,7 @@ joel_kwartler:
   reports_to: product_director_code_graph
   pronouns: he/him
   role: Product Manager, Code Insights
+  team:
   location: Los Angeles, CA, USA 🇺🇸
   pronunciation: '[ʤoʊl kwɔrtlɜr](http://ipa-reader.xyz/?text=%CA%A4o%CA%8Al%20kw%C9%94rtl%C9%9Cr&voice=Joey)'
   github: Joelkw
@@ -474,6 +518,7 @@ joe_kirscher:
   name: Joe Kirscher
   pronouns: he/him
   role: Strategy & Operations Manager
+  team:
   reports_to: vp_sales
   manager_role_slug: strategy_operations_manager
   location: Mountain View, CA, USA 🇺🇸
@@ -484,6 +529,7 @@ kacie_jenkins:
   name: Kacie Jenkins
   pronouns: she/her
   role: VP of Marketing
+  team:
   manager_role_slug: vp_marketing
   location: Sea Ranch, CA, USA 🇺🇸
   email: kacie@sourcegraph.com
@@ -494,6 +540,7 @@ jonah_dueck:
   name: Jonah Dueck
   pronouns: he/him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Seattle, WA, USA 🇺🇸
   github: justdueck
@@ -505,6 +552,7 @@ jean_du_plessis:
   name: Jean du Plessis
   pronouns: he/him
   role: Engineering Manager, Web
+  team:
   reports_to: vp_engineering
   manager_role_slug: engineering_manager_web
   location: Cape Town, South Africa 🇿🇦
@@ -518,6 +566,7 @@ owen_convey:
   name: Owen Convey
   pronouns: he/him
   role: Engineering Manager
+  team:
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_code_intelligence
   location: Barcelona, Spain 🇪🇸
@@ -530,6 +579,7 @@ virginia_ulrich:
   name: Virginia Ulrich
   pronouns: she/they
   role: Director of Customer Support
+  team:
   manager_role_slug: director_customer_support
   location: Portland, Oregon, United States 🇺🇸
   github: virginiaulrich
@@ -542,6 +592,7 @@ scott_campbell:
   name: Scott Campbell
   pronouns: he/him
   role: Regional Director of Sales, East
+  team:
   reports_to: vp_sales
   manager_role_slug: regional_director_sales_east
   location: Asheville, North Carolina, United States 🇺🇸
@@ -555,6 +606,7 @@ tommy_o_donnell:
   name: Tommy O Donnell
   pronouns: he/him
   role: Manager, Financial Planning & Analysis
+  team:
   reports_to: vp_operations
   manager_role_slug: manager_financial_planning
   location: Tralee, County Kerry, Ireland 🇮🇪
@@ -567,6 +619,7 @@ cecily_black:
   name: Cecily Black
   pronouns: she/her
   role: People Operations Coordinator
+  team:
   reports_to: people_operations_manager
   location: San Jose, California, United States 🇺🇸
   github: CecilyBee
@@ -578,6 +631,7 @@ mike_mclaughlin:
   name: Mike McLaughlin
   pronouns: he/him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Chicago, IL, USA 🇺🇸
   github: mike-r-mclaughlin
@@ -589,6 +643,7 @@ rok_novosel:
   name: Rok Novosel
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search
   location: Trebnje, Slovenia 🇸🇮
   github: novoselrok
@@ -600,6 +655,7 @@ andré_eleuterio:
   name: André Eleuterio
   pronouns: he/him
   role: Security Engineer
+  team:
   reports_to: security_engineering_manager
   location: Curitiba, Brazil 🇧🇷
   github: andreeleuterio
@@ -611,6 +667,7 @@ emily_chapman:
   name: Emily Chapman
   pronouns: she/her
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Portland, OR, USA, 🇺🇸
   github: emchap
@@ -623,6 +680,7 @@ erica_lindberg:
   name: Erica Lindberg
   pronouns: she/her
   role: Director of Content Strategy
+  team:
   reports_to: vp_marketing
   manager_role_slug: director_content_strategy
   location: Nederland, CO, USA 🇺🇸
@@ -635,6 +693,7 @@ camden_cheek:
   name: Camden Cheek
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_search
   location: Monument, Colorado, USA 🇺🇸
   github: camdencheek
@@ -646,6 +705,7 @@ andy_schumeister:
   name: Andy Schumeister
   pronouns: he/him
   role: Director of Product Marketing
+  team:
   reports_to: vp_marketing
   manager_role_slug: director_product_marketing
   location: Minneapolis, MN, USA 🇺🇸
@@ -658,6 +718,7 @@ tom_ross:
   name: Tom Ross
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_frontend_platform
   location: York, North Yorkshire, UK 🇬🇧
   github: umpox
@@ -669,6 +730,7 @@ greg_bastis:
   name: Greg Bastis
   pronouns: he/him
   role: VP Sales, Western Region
+  team:
   reports_to: vp_sales
   manager_role_slug: vp_sales_western_region
   location: San Francisco, CA, USA
@@ -681,6 +743,7 @@ seth_hoover:
   name: Seth Hoover
   pronouns: he/him
   role: Senior Salesforce Administrator
+  team:
   reports_to: strategy_operations_manager
   location: Menifee, CA, USA 🇺🇸
   github: seth-sourcegraph
@@ -692,6 +755,7 @@ seth_hoover:
   name: Ólafur Páll Geirsson
   pronouns: he/him
   role: Software Engineer, Code Intelligence
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Drøbak, Norway 🇳🇴
   github: olafurpg
@@ -704,6 +768,7 @@ malo_marrec:
   reports_to: product_director_code_graph
   pronouns: he/him
   role: Product Manager, Batch Changes
+  team:
   location: Paris, France 🇫🇷
   email: malo@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/malo-marrec)'
@@ -713,6 +778,7 @@ inés_roitman:
   name: Inés Roitman
   pronouns: she/her
   role: Onboarding and Training Manager
+  team:
   reports_to: vp_people
   location: Buenos Aires, Argentina 🇦🇷 / Barcelona, Spain 🇪🇸
   github: InesRoitman
@@ -725,6 +791,7 @@ james_clifford:
   name: James Clifford
   pronouns: he/him
   role: Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: San Francisco, CA, USA 🇺🇸
   github: jclifford1
@@ -735,6 +802,7 @@ james_clifford:
 tj_devries:
   name: TJ DeVries
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Rockford, MI, USA 🇺🇸
   github: tjdevries
@@ -746,6 +814,7 @@ tj_devries:
 manuel_ucles:
   name: Manuel Ucles
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Phoenix, AZ, USA 🇺🇸
   github: mucles
@@ -758,6 +827,7 @@ kylie_fligstein:
   reports_to: vp_product
   pronouns: she/her
   role: Executive Business Partner to VP of Product
+  team:
   location: Oakland, CA, USA 🇺🇸
   github: kyfli
   email: kylie@sourcegraph.com
@@ -768,6 +838,7 @@ caitlin_moran:
   name: Caitlin Moran
   pronouns: she/her
   role: Enterprise Account Executive
+  team:
   reports_to: regional_director_sales_east
   location: Brooklyn, NY USA 🇺🇸
   github: Caitlinsourcegraph
@@ -779,6 +850,7 @@ murat_sutunc:
   name: Murat Sutunc
   pronouns: he/him
   role: Engineering Manager, Growth and Integrations
+  team:
   reports_to: director_engineering
   manager_role_slug: engineering_manager_growth
   location: Redwood City, CA, USA 🇺🇸
@@ -792,6 +864,7 @@ jon_kishpaugh:
   name: Jon Kishpaugh
   pronouns: he/him
   role: Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: San Francisco, CA, USA
   github: JonKish
@@ -802,6 +875,7 @@ jon_kishpaugh:
 dudley_nostrand:
   name: Dudley Nostrand
   role: Senior Manager, Value Engineering & Sales Enablement
+  team:
   reports_to: vp_sales
   manager_role_slug: senior_manager_value_engineering
   location: Hamilton, Massachusetts, USA
@@ -814,6 +888,7 @@ tammy_zhu:
   name: Tammy Zhu
   pronouns: she/her
   role: Director of Legal
+  team:
   reports_to: vp_operations
   manager_role_slug: director_legal
   location: San Francisco, CA, USA 🇺🇸
@@ -824,6 +899,7 @@ warren_gifford:
   name: Warren Gifford
   pronouns: he/him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: Portland, OR, USA 🇺🇸
   github: DaedalusG
@@ -835,6 +911,7 @@ valery_bugakov:
   name: Valery Bugakov
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_frontend_platform
   location: St. Petersburg, Russia 🇷🇺
   github: valerybugakov
@@ -847,6 +924,7 @@ giselle_northy:
   name: Giselle Northy
   pronouns: she/her
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Sherwood, OR, USA 🇺🇸
   github: northyg
@@ -859,6 +937,7 @@ vova_kulikov:
   name: Vova Kulikov
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_insights
   location: St. Petersburg, Russia 🇷🇺
   github: vovakulikov
@@ -871,6 +950,7 @@ alex_fogg:
   name: Alex Fogg
   pronouns: he/him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Philadelphia, PA, USA 🇺🇸
   github: alexfogg
@@ -881,6 +961,7 @@ alex_fogg:
 adeola_akinsiku:
   name: Adeola Akinsiku
   role: Application Engineer
+  team:
   reports_to: engineering_manager_batch_changes
   location: Atlanta, GA, USA 🇺🇸
   github: adeola-ak
@@ -892,6 +973,7 @@ patrick_dubroy:
   name: Patrick Dubroy
   pronouns: he/him
   role: Engineering Manager, Frontend platform
+  team:
   reports_to: engineering_manager_web
   manager_role_slug: engineering_manager_frontend_platform
   location: Munich, Germany 🇩🇪
@@ -904,6 +986,7 @@ beatrix_woo:
   name: Beatrix Woo
   pronouns: she/her
   role: Application Engineer
+  team:
   reports_to: engineering_manager_growth
   location: San Diego, CA, USA 🇺🇸 / Hong Kong 🇭🇰
   github: abeatrix
@@ -915,6 +998,7 @@ beatrix_woo:
 stompy_mwendwa:
   name: Stompy Mwendwa
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Nairobi, Kenya 🇰🇪
   github: airamare01
@@ -926,6 +1010,7 @@ stompy_mwendwa:
 sam_cregg:
   name: Sam Cregg
   role: Sales Development Rep
+  team:
   reports_to: head_sales_development
   location: Boston, MA, USA USA
   email: samcregg@sourcegraph.com
@@ -936,6 +1021,7 @@ indradhanush_gupta:
   name: Indradhanush Gupta
   pronouns: he/him
   role: Software Engineer, Core Application
+  team:
   reports_to: software_engineering_manager
   location: Kolkata, India, 🇮🇳
   github: indradhanush
@@ -948,6 +1034,7 @@ sarah_reece:
   name: Sarah Reece
   pronouns: she/her
   role: Director, Demand Generation
+  team:
   reports_to: vp_marketing
   manager_role_slug: director_demand_generation
   location: Winston Salem, NC, USA
@@ -960,6 +1047,7 @@ steph_hay:
   name: Steph Hay
   pronouns: she/her
   role: Senior Business Operations Analyst
+  team:
   reports_to: vp_operations
   location: Los Angeles, CA, USA 🇺🇸
   github: stephmhay
@@ -971,6 +1059,7 @@ kelsey_brown:
   name: Kelsey Brown
   pronouns: she/her
   role: Senior Business Operations Analyst
+  team:
   reports_to: vp_operations
   location: Arlington, VA, USA 🇺🇸
   github: kelsey-brown
@@ -981,6 +1070,7 @@ kelsey_brown:
 bill_creager:
   name: Bill Creager
   role: Director of Engineering
+  team:
   reports_to: vp_engineering
   manager_role_slug: director_engineering
   location: Buda, TX USA 🇺🇸
@@ -992,6 +1082,7 @@ samson_goddy:
   name: Samson Goddy
   pronouns: he/him
   role: Director of Community
+  team:
   reports_to: vp_marketing
   manager_role_slug: director_community
   location: Port Harcourt, Nigeria 🇳🇬
@@ -1004,6 +1095,7 @@ fabiana_castellanos:
   name: Fabiana Castellanos
   pronouns: she/her
   role: Project Coordinator, Brand
+  team:
   reports_to: director_demand_generation
   location: Oceanside, CA USA 🇺🇸
   github: fabicastp
@@ -1015,6 +1107,7 @@ kendrick_morris:
   name: Kendrick Morris
   pronouns: he/him
   role: Finance and Operations Analyst
+  team:
   reports_to: manager_financial_planning
   location: San Francisco, CA USA 🇺🇸
   github: kmorris50
@@ -1026,6 +1119,7 @@ christy_haragan:
   name: Christy Haragan
   pronouns: she/her
   role: Director of Customer Engineering - International
+  team:
   reports_to: vp_customer_engineering
   manager_role_slug: director_customer_engineering_international
   location: London, UK 🇬🇧
@@ -1038,6 +1132,7 @@ rebecca_dodd:
   name: Rebecca Dodd
   pronouns: she/her
   role: Senior Managing Editor
+  team:
   reports_to: director_content_strategy
   manager_role_slug: senior_managing_editor
   location: Bristol, UK 🇬🇧
@@ -1050,6 +1145,7 @@ carly_jones:
   name: Carly Jones
   pronouns: she/her
   role: VP, Talent
+  team:
   location: Denver, CO USA 🇺🇸
   github: carlyj0nes
   description: Carly is a Denver native who went to college in Vermont (Middlebury), lived in Washington, DC for 5 years, and has since returned home to Colorado. Prior to Sourcegraph, she gained experience leading talent teams at high growth startups and is passionate about all things talent acquisition. When not working, you can find Carly tackling a DIY project, practicing her golf game, spending time outdoors, and traveling.
@@ -1058,6 +1154,7 @@ rafal_leszczynski:
   name: Rafal Leszczynski
   pronouns: he/him
   role: Engineering Manager, Cloud SaaS
+  team:
   reports_to: director_engineering
   manager_role_slug: engineering_manager_cloud_saas
   location: Jelonek (Poznan), Poland 🇵🇱
@@ -1070,6 +1167,7 @@ kelli_rockwell:
   name: Kelli Rockwell
   pronouns: she/her
   role: Software Engineer, Batch Changes
+  team:
   reports_to: engineering_manager_batch_changes
   location: Seattle, WA, USA 🇺🇸
   github: courier-new
@@ -1083,6 +1181,7 @@ dan_mckean:
   reports_to: product_director_enablement
   pronouns: he/him
   role: Product Manager, Repo Management & Delivery
+  team:
   location: Shaftesbury (Dorset), UK 🇬🇧
   github: dan-mckean
   email: dan.mckean@sourcegraph.com
@@ -1093,6 +1192,7 @@ cassie_melani:
   name: Cassie Melani
   pronouns: she/her
   role: Teammate Success Manager
+  team:
   reports_to: vp_people
   location: Seattle, Washington, USA 🇺🇸🌲
   email: cassie@sourcegraph.com
@@ -1103,6 +1203,7 @@ rebecca_rissinger:
   name: Rebecca Rissinger
   pronouns: she/her
   role: Manager, Marketing Operations
+  team:
   reports_to: director_demand_generation
   manager_role_slug: manager_marketing_operations
   location: Red Bank, New Jersey, USA
@@ -1116,6 +1217,7 @@ ryan_phillips:
   reports_to: product_director_cloud
   pronouns: He/Him
   role: Product Manager, Cloud
+  team:
   location: San Francisco, CA, USA 🇺🇸
   github: Ryphil
   email: ryphil@sourcegraph.com
@@ -1126,6 +1228,7 @@ jake_sorensen:
   name: Jake Sorensen
   pronouns: He/Him
   role: Programs Lead, Demand Gen Campaigns
+  team:
   reports_to: director_demand_generation
   location: Los Angeles, CA, USA 🇺🇸
   github: jakevsen
@@ -1136,7 +1239,8 @@ jake_sorensen:
 coury_clark:
   name: Coury Clark
   pronouns: He/Him
-  role: Software Engineer, Code Insights
+  role: Software Engineer
+  team: Code WINSIGHTS
   reports_to: engineering_manager_code_insights
   location: Phoenix, AZ, USA
   email: coury@sourcegraph.com
@@ -1147,6 +1251,7 @@ aimee_menne:
   name: Aimee Menne
   pronouns: she/her
   role: VP of Customer Engineering
+  team:
   manager_role_slug: vp_customer_engineering
   location: Denver, CO USA 🇺🇸
   github: amenne
@@ -1158,6 +1263,7 @@ nicholas_gage:
   name: Nicholas Gage
   pronouns: he/him
   role: Head of Sales Development
+  team:
   reports_to: vp_sales
   manager_role_slug: head_sales_development
   location: Oakland, CA USA
@@ -1170,6 +1276,7 @@ devon_coords:
   name: Devon Coords
   pronouns: She/Her
   role: Senior Technical Recruiter, Team Lead
+  team:
   location: White Plains, NY USA 🇺🇸
   github: devoncoords
   email: devon@sourcegraph.com
@@ -1180,6 +1287,7 @@ trevor_houghton:
   name: Trevor Houghton
   pronouns: he/him
   role: Recruiting Operations Specialist
+  team:
   location: Austin, TX, USA 🇺🇸
   github: TrevorHoughton
   email: trevor@sourcegraph.com
@@ -1190,6 +1298,7 @@ prosper_otemuyiwa:
   name: Prosper Otemuyiwa
   pronouns: he/him
   role: Staff Developer Evangelist
+  team:
   reports_to: director_community
   location: Lagos, Nigeria 🇳🇬
   github: unicodeveloper
@@ -1201,6 +1310,7 @@ kevin_quigley:
   name: Kevin Quigley
   pronouns: he/him
   role: Sales Development Rep
+  team:
   reports_to: head_sales_development
   location: Atlanta, GA, USA 🇺🇸
   github: kevin-quigley
@@ -1212,6 +1322,7 @@ brady_herrmann:
   name: Brady Herrmann
   pronouns: he/him
   role: Enterprise Account Executive
+  team:
   reports_to: regional_director_sales_east
   location: Chicago, IL, USA 🇺🇸
   github: brherrma
@@ -1223,6 +1334,7 @@ rashad_bartholomew:
   name: Rashad Bartholomew
   pronouns: he/him
   role: Senior Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: Oakland, CA, USA 🇺🇸
   github: gigswift
@@ -1234,6 +1346,7 @@ nicky_van_maanen:
   name: Nicky Van Maanen
   pronouns: she/her
   role: Tech Ops Manager
+  team:
   reports_to: vp_operations
   manager_role_slug: tech_ops_manager
   location: Costa Mesa, California, USA 🇺🇸
@@ -1246,6 +1359,7 @@ debbie_johnstone:
   name: Debbie Johnstone
   pronouns: she/her
   role: VP of People
+  team:
   reports_to: vp_operations
   manager_role_slug: vp_people
   location: Amsterdam, Netherlands 🇳🇱
@@ -1258,6 +1372,7 @@ nate_maynard:
   name: Nate Maynard
   pronouns: He/Him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Denver, Colorado, USA 🇺🇸
 
@@ -1269,6 +1384,7 @@ jenny_bergen:
   name: Jenny Bergen
   pronouns: she/her
   role: Manager, Content Marketing
+  team:
   reports_to: director_content_strategy
   manager_role_slug: manager_content_marketing
   location: Denver, Colorado, USA 🇺🇸
@@ -1281,6 +1397,7 @@ kelsey_nagel:
   name: Kelsey Nagel
   pronouns: she/her
   role: Corporate Recruiter
+  team:
   location: Minneapolis, MN USA
   github: kelseynagel
   description: "Kelsey is a North Dakota native living in Minneapolis with her husband and two dogs, Crew and Nash. She is an avid Recruiter, bringing 5 years of talent acquisition experience in high growth companies before joining Sourcegraph. When not working, you'll find Kelsey travelling, spending time on lakes in Minnesota summers, and trying new Sushi restaurants."
@@ -1289,6 +1406,7 @@ gabe_torres:
   name: Gabe Torres
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: Los Angeles, CA, USA 🇺🇸
   github: gabtorre
@@ -1300,6 +1418,7 @@ suki_randhawa:
   name: Suki Randhawa
   pronouns: He/Him
   role: Enterprise Account Executive
+  team:
   reports_to: head_international_sales
   location: London, UK 🇬🇧
   github: suki-randhawa1
@@ -1311,6 +1430,7 @@ amber_furbush:
   name: Amber Furbush
   pronouns: She/her
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Commerce City, CO, US
   github: amberfurbush0317
@@ -1322,6 +1442,7 @@ ben_gordon:
   name: Ben Gordon
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Chicago IL, USA 🇺🇸
   github: benjaminwgordon
@@ -1333,6 +1454,7 @@ donavon_ellison:
   name: Donavon Ellison
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Acworth, GA USA
   github: donavonelli
@@ -1344,6 +1466,7 @@ jason_harris:
   name: Jason Harris
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Los Angeles, CA USA
   github: jasonhawkharris
@@ -1355,6 +1478,7 @@ michael_bali:
   name: Michael Bali
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: Lagos, Nigeria 🇳🇬
   github: topebali
@@ -1366,6 +1490,7 @@ alex_jean-baptiste:
   name: Alex Jean-Baptiste
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_2
   location: Atlanta, Georgia USA 🇺🇸
   github: alexAtSourcegraph
@@ -1378,6 +1503,7 @@ kelvin_lee:
   name: Kelvin Lee
   pronouns: He/Him
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: (Northern) California, USA 🇺🇸
   email: kelvin@sourcegraph.com
@@ -1388,6 +1514,7 @@ mariam_adedeji:
   name: Mariam Adedeji
   pronouns: She/Her
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: Lagos, Nigeria 🇳🇬
   github: rhiam
@@ -1399,6 +1526,7 @@ alex_isken:
   name: Alex Isken
   pronouns: He/Him
   role: Product Marketing Manager
+  team:
   reports_to: director_product_marketing
   location: Milwaukee, WI, USA 🇺🇸
   github: iskyOS
@@ -1410,6 +1538,7 @@ katy_juell:
   name: Katy Juell
   pronouns: She/Her
   role: Full Stack Engineer
+  team:
   reports_to: engineering_manager_content_platform
   location: Greenwich, CT, USA 🇺🇸
   github: katjuell
@@ -1421,6 +1550,7 @@ bill_caplan:
   name: Bill Caplan
   pronouns: He/Him
   role: Senior Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Raleigh, NC USA 🇺🇸
   github: billCaplan
@@ -1432,6 +1562,7 @@ marija_petrovic:
   name: Marija Petrovic
   pronouns: She/Her
   role: Team Lead, Senior Sales Recruiter
+  team:
   location: Naples, FL USA 🇺🇸
   github: marija.petrovic214
   email: marija.petrovic@sourcegraph.com
@@ -1442,6 +1573,7 @@ shawn_king:
   name: Shawn King
   pronouns: He/Him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Rochester, MN USA 🇺🇸
   github: shawnplusplus
@@ -1452,6 +1584,7 @@ kristen_sundberg:
   name: Kristen Sundberg
   pronouns: She/Her
   role: Senior Social Media Manager
+  team:
   reports_to: director_global_communications
   location: Boston, MA USA 🇺🇸
   github: kristen-sundberg
@@ -1463,6 +1596,7 @@ amie_rotherham:
   name: Amie Rotherham
   pronouns: She/Her
   role: Director of Global Communications
+  team:
   reports_to: vp_marketing
   manager_role_slug: director_global_communications
   location: Toronto, Canada 🇨🇦
@@ -1475,6 +1609,7 @@ max_wiederholt:
   name: Max Wiederholt
   pronouns: He/Him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Mountain View, CA, USA 🇺🇸
   github: maaaaaaaax
@@ -1486,6 +1621,7 @@ justin_boyson:
   name: Justin Boyson
   pronouns: He/Him
   role: Frontend Engineer
+  team:
   reports_to: engineering_manager_code_insights
   location: Austin, TX, USA 🇺🇸
   github: unclejustin
@@ -1497,6 +1633,7 @@ victoria_yunger:
   name: Victoria Yunger
   pronouns: She/Her
   role: Product Marketing Lead, Enterprise
+  team:
   reports_to: director_product_marketing
   location: San Francisco, CA, USA 🇺🇸
   github: thisisvic
@@ -1508,6 +1645,7 @@ luke_taylor:
   name: Luke Taylor
   pronouns: He/Him
   role: Enterprise Account Executive
+  team:
   reports_to: head_international_sales
   location: Amsterdam, The Netherlands
   github: iamluketaylor
@@ -1519,6 +1657,7 @@ anna_mikhova:
   name: Anna Mikhova
   reports_to: vp_product
   role: Director of Product, Cloud
+  team:
   manager_role_slug: product_director_cloud
   location: Salt Lake City, UT, USA 🇺🇸
   github: anna-mikhova
@@ -1530,6 +1669,7 @@ rami_hamdan:
   name: Rami Hamdan
   pronouns: they/them
   role: Senior Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Albuquerque, NM from Palestine 🇵🇸
   github: ZrnH
@@ -1540,6 +1680,7 @@ yink_teo:
   name: Yink Teo
   pronouns: he/him
   role: Director of Engineering, Global Code Graph
+  team:
   reports_to: vp_engineering
   manager_role_slug: director_engineering_global_code_graph
   location: San Francisco, CA USA 🇺🇸
@@ -1552,6 +1693,7 @@ milan_freml:
   name: Milan Freml
   pronouns: He/Him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_cloud_saas
   location: Ružomberok, Žilinský, Slovakia 🇸🇰
   github: kopancek
@@ -1564,6 +1706,7 @@ david_rohnow:
   name: David Rohnow
   pronouns: he/him
   role: Sr. Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: San Diego, CA USA 🇺🇸
   github: zrnh
@@ -1575,6 +1718,7 @@ scott_bailey:
   name: Scott Bailey
   pronouns: he/him
   role: Technical Content Marketing Manager
+  team:
   reports_to: manager_content_marketing
   location: Raleigh, NC, USA 🇺🇸
   github: csbailey5t
@@ -1586,6 +1730,7 @@ ellie_dawson:
   name: Ellie Dawson
   pronouns: she/her
   role: Sales Development Representative
+  team:
   reports_to: head_sales_development
   location: Cincinnati, OH, USA
   github: elliedawson
@@ -1597,6 +1742,7 @@ elzanne_wentzel:
   name: Elzanne Wentzel
   pronouns: she/her
   role: Customer Engineer
+  team:
   reports_to: director_customer_engineering_international
   location: Amsterdam, The Netherlands 🇳🇱
   github: elzannewentzel
@@ -1608,6 +1754,7 @@ ajay_sridhar:
   name: Ajay Sridhar
   pronouns: He/Him
   role: Senior Customer Engineer
+  team:
   reports_to: director_customer_engineering_international
   location: London, UK 🇬🇧
   github: ajaynz
@@ -1619,6 +1766,7 @@ leo_abreu:
   name: Leo Abreu
   pronouns: he/him
   role: Senior Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Matthews, NC, USA 🇺🇸
   github: leo-abreu
@@ -1631,6 +1779,7 @@ erzhan_torokulov:
   name: Erzhan Torokulov
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_growth
   location: St. Petersburg, Russia 🇷🇺
   github: erzhtor
@@ -1643,6 +1792,7 @@ nick_moore:
   name: Nick Moore
   pronouns: he/him/his
   role: Content Editor
+  team:
   reports_to: senior_managing_editor
   location: Weymouth, Massachusettes, United States 🇺🇸
   github: nickmyyz
@@ -1654,6 +1804,7 @@ erica_freckelton:
   name: Erica Freckelton
   pronouns: she/her
   role: Senior Digital Marketing Manager
+  team:
   reports_to: director_demand_generation
   location: San Diego, California, United States 🇺🇸
   github: efreckelton
@@ -1666,6 +1817,7 @@ serina_clark:
   reports_to: vp_product
   pronouns: her/she/hers
   role: Director of Product, Enablement
+  team:
   manager_role_slug: product_director_enablement
   location: Erie, Colorado, United States 🇺🇸
   github: serinadawn
@@ -1678,6 +1830,7 @@ dan_ryan:
   name: Dan Ryan
   pronouns: he/him
   role: Senior Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Lehi, UT, United States 🇺🇸
   github: danryan621
@@ -1690,6 +1843,7 @@ mary_belzer:
   reports_to: product_director_enablement
   pronouns: she/her
   role: Product Manager, Content Platform
+  team:
   location: Denver, Colorado, United States 🇺🇸
   github: marybelzer
   email: mary.belzer@sourcegraph.com
@@ -1699,6 +1853,7 @@ mary_belzer:
 brannon_rouse:
   name: Brannon Rouse
   role: Sales Development Representative
+  team:
   reports_to: head_sales_development
   location: Birmingham, AL, United States 🇺🇸
   github: Brannon-Rouse
@@ -1710,6 +1865,7 @@ greg_bouton:
   name: Greg Bouton
   pronouns: he/him/his
   role: Senior Email & Automation Marketing Manager
+  team:
   reports_to: manager_marketing_operations
   location: S. Hamilton, MA, United States 🇺🇸
   github: GregBouton
@@ -1720,6 +1876,7 @@ greg_bouton:
 nonso_obiano:
   name: Nonso Obiano
   role: Customer Support Manager
+  team:
   reports_to: director_customer_support
   manager_role_slug: customer_support_manager_2
   location: Lagos, Nigeria 🇳🇬
@@ -1731,6 +1888,7 @@ nonso_obiano:
 brielle_collins:
   name: Brielle Collins
   role: Customer Support Manager
+  team:
   reports_to: director_customer_support
   manager_role_slug: customer_support_manager_1
   location: Chicago, Illinois 🇺🇸
@@ -1743,6 +1901,7 @@ jason_yavorska:
   reports_to: vp_product
   pronouns: he/him
   role: Product Director, Code Graph
+  team:
   manager_role_slug: product_director_code_graph
   location: Leiden, NL 🇳🇱 and part of the year in Odessa, UA 🇺🇦
   github: jyavorska
@@ -1754,6 +1913,7 @@ diego_comas:
   name: Diego Comas
   pronouns: he/him/his
   role: Security Engineering Manager
+  team:
   reports_to: director_engineering
   manager_role_slug: security_engineering_manager
   location: Barcelona, Spain 🇪🇸
@@ -1766,6 +1926,7 @@ andrew_hsu:
   name: Andrew Hsu
   pronouns: he/him
   role: Customer Engineer
+  team:
   reports_to: vp_customer_engineering
   location: Los Angeles, California, United States 🇺🇸
   github: superhsu
@@ -1777,6 +1938,7 @@ jh_chabran:
   name: JH Chabran
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_developer_experience
   pronunciation: 'Name Pronunciation: [/ʒiaʃ/](https://www.name-coach.com/jh-chabran)'
   location: Lyon, France 🇫🇷
@@ -1787,6 +1949,7 @@ jh_chabran:
 chris_wendt:
   name: Chris Wendt
   role: Software Engineer on Code Intelligence
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Boulder, CO 🇺🇸
   github: chrismwendt
@@ -1798,6 +1961,7 @@ mohammad_umer_alam:
   name: Mohammad Umer Alam
   pronouns: he/him
   role: Security Engineer
+  team:
   reports_to: security_engineering_manager
   location: Staten Island, NY 🇺🇸
   github: mohammadualam
@@ -1809,6 +1973,7 @@ grace_bohl:
   name: Grace Bohl
   pronouns: she/her
   role: Corporate Recruiter
+  team:
   location: Denver, CO 🇺🇸
   github: gracebohl
   email: you@sourcegraph.com
@@ -1817,6 +1982,7 @@ grace_bohl:
 cesar_jimenez:
   name: Cesar Jimenez
   role: Senior Software Engineer on Code Intelligence
+  team:
   reports_to: engineering_manager_code_intelligence
   location: Seattle, WA 🇺🇸
   github: numbers88s
@@ -1828,6 +1994,7 @@ trey_sizemore:
   name: Trey Sizemore
   pronouns: he/him
   role: Enablement Manager
+  team:
   reports_to: senior_manager_value_engineering
   location: Various, USA 🇺🇸
   github: hjsizemore
@@ -1838,6 +2005,7 @@ trey_sizemore:
 cristina_birkel:
   name: Cristina Birkel
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_insights
   location: Cleveland, OH, United States 🇺🇸
   github: CristinaBirkel
@@ -1850,6 +2018,7 @@ sara_lee:
   reports_to: director_design
   pronouns: she/her
   role: Product Designer, Code Intel and Growth and Integrations
+  team:
   location: Chapel Hill, NC, United States 🇺🇸
   github: jjinnii
   email: sara.lee@sourcegraph.com
@@ -1860,6 +2029,7 @@ ben_venker:
   name: Ben Venker
   reports_to: product_director_code_graph
   role: Product Manager, Search Product
+  team:
   location: St. Louis, MO, United States 🇺🇸
   github: benvenker
   email: ben.venker@sourcegraph.com
@@ -1869,6 +2039,7 @@ win_yu:
   name: Win Yu
   pronouns: he/his
   role: Technical Talent Sourcer
+  team:
   location: Yangon, Burma
   github: wysg
   email: win.yu@sourcegraph.com
@@ -1878,6 +2049,7 @@ win_yu:
 sam_jones:
   name: Sam Jones
   role: Senior Corporate & Commercial Counsel
+  team:
   reports_to: director_legal
   location: Oakland, CA, United States 🇺🇸
   github: srj427
@@ -1888,6 +2060,7 @@ stephanie_zabala:
   name: Stephanie Zabala
   pronouns: she/her
   role: Principal Designer, Brand
+  team:
   location: Brooklyn, NY, United States 🇺🇸
   github: stephzabala
   email: steph.zabala@sourcegraph.com
@@ -1897,6 +2070,7 @@ crystal_augustus:
   name: Crystal Augustus
   pronouns: she/her
   role: Software Engineer, Delivery
+  team:
   reports_to: engineering_manager_devops
   location: Ashland, MA, United States 🇺🇸
   github: caugustus-sourcegraph
@@ -1908,6 +2082,7 @@ kemper_hamilton:
   name: Kemper Hamilton
   pronouns: she/her
   role: Recruiting Operations Specialist
+  team:
   location: Austin, TX, United States 🇺🇸
   github: kemperhamilton
   email: kemper.hamilton@sourcegraph.com
@@ -1919,6 +2094,7 @@ marisa_kanemoto:
   reports_to: director_design
   pronouns: she/her
   role: Product Designer, Search
+  team:
   location: Berkeley, California, United States 🇺🇸
   github: marisak
   email: marisa.kanemoto@sourcegraph.com
@@ -1929,6 +2105,7 @@ bob_roudebush:
   name: Bob Roudebush
   pronouns: he/him
   role: Customer Engineering Director - Americas
+  team:
   reports_to: vp_customer_engineering
   manager_role_slug: director_customer_engineering_americas
   location: Indianapolis, Indiana, United States 🇺🇸
@@ -1942,6 +2119,7 @@ nancy_shah:
   name: Nancy Shah
   pronouns: she/her
   role: Senior Customer Engineer - East Americas
+  team:
   reports_to: director_customer_engineering_americas
   location: Oakton, VA, United States 🇺🇸
   github: nancy4dev
@@ -1954,6 +2132,7 @@ michal_sennett:
   name: Michal Sennett
   pronouns: she/her
   role: Strategic Projects Manager, Engineering
+  team:
   location: Dallas, TX, USA 🇺🇸
   github: msennett22
   email: michal.sennett@sourcegraph.com
@@ -1963,6 +2142,7 @@ keely_aguayo:
   name: Keely Aguayo
   pronouns: she/her
   role: Payroll Manager
+  team:
   reports_to: financial_controller
   location: New Orleans, LA, USA 🇺🇸
   github: keelyaguayo
@@ -1973,6 +2153,7 @@ erika_heidi:
   name: Erika Heidi
   pronouns: she/her
   role: Senior Developer Advocate, Community
+  team:
   reports_to: director_community
   location: The Hague, Netherlands 🇳🇱
   github: erikaheidi
@@ -1983,6 +2164,7 @@ erika_heidi:
 frey_andersson:
   name: Frey Andersson
   role: Technical Recruiter
+  team:
   location: Tokyo, Japan 🇯🇵
   github: LordFriccoFro
   email: frey.andersson@sourcegraph.com
@@ -1993,6 +2175,7 @@ simon_waterer:
   name: Simon Waterer
   pronouns: he/him
   role: Senior Customer Engineer
+  team:
   reports_to: director_customer_engineering_international
   location: London, United Kingdom 🏴󠁧󠁢󠁥󠁮󠁧󠁿
   github: simoncwaterer
@@ -2004,6 +2187,7 @@ adam_greenhalgh:
   name: Adam Greenhalgh
   pronouns: he/him
   role: Marketing Operations Analyst
+  team:
   reports_to: manager_marketing_operations
   location: Salt Lake City, Utah, United States
   github: Adammaxla
@@ -2014,6 +2198,7 @@ david_sandy:
   name: David Sandy
   pronouns: he/him
   role: Security Engineer
+  team:
   reports_to: security_engineering_manager
   location: St. Paul, MN, US 🇺🇸
   github: david-sandy
@@ -2024,6 +2209,7 @@ devon_thompson:
   name: DeVon Thompson
   pronouns: she/her
   role: Customer Engineer
+  team:
   reports_to: director_customer_engineering_americas
   location: Baltimore, MD, US 🇺🇸
   github: Deethompson
@@ -2035,6 +2221,7 @@ taylor_sperry:
   reports_to: product_director_enablement
   pronouns: she/her
   role: Technical Product Manager, Frontend Platform & Dev Experience
+  team:
   location: Denver, CO, USA 🇺🇸
   github: taylorsperry
   email: taylor.sperry@sourcegraph.com
@@ -2045,6 +2232,7 @@ rafal_gajdulewicz:
   name: Rafal Gajdulewicz
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_cloud_saas
   location: Warsaw, Poland 🇵🇱
   github: rafax
@@ -2056,6 +2244,7 @@ lauren_chapman:
   name: Lauren Chapman
   pronouns: she/her
   role: Security Engineer
+  team:
   reports_to: security_engineering_manager
   location: New Brunswick, Canada 🇨🇦
   github: deflncha
@@ -2067,6 +2256,7 @@ jordan_plahn:
   name: Jordan Plahn
   pronouns: he/him
   role: Engineering Manager
+  team:
   reports_to: engineering_manager_web
   manager_role_slug: software_engineering_manager
   location: Seattle, WA, USA 🇺🇸
@@ -2079,6 +2269,7 @@ varun_gandhi:
   name: Varun Gandhi
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_code_intelligence
   location: 'Berkeley, CA, USA / Mumbai, India'
   github: varungandhi-src
@@ -2090,6 +2281,7 @@ erin_laio:
   name: Erin Laio
   pronouns: she/her
   role: Senior Executive Business Partner
+  team:
   location: Andover, MA, USA
   github: erinlaio
   email: erin.laio@sourcegraph.com
@@ -2100,6 +2292,7 @@ jeff_warner:
   name: Jeff Warner
   pronouns: he/him
   role: Engineering Manager for Search Core
+  team:
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_search_core
   github: jjeffwarner
@@ -2110,6 +2303,7 @@ jeff_warner:
 carter_jaenichen:
   name: Carter Jaenichen
   role: Sales Development Representative
+  team:
   reports_to: head_sales_development
   location: Orange County, CA, USA 🇺🇸
   github: carterjaenichen
@@ -2120,6 +2314,7 @@ carter_jaenichen:
 amber_smokowski:
   name: Amber Smokowski
   role: Executive Business Partner, Sales and Marketing
+  team:
   reports_to: vp_marketing
   location: From Longmont, CO, USA currently in Austin, TX, USA
   github: ambersmo
@@ -2129,6 +2324,7 @@ amber_smokowski:
 jagna_feierabend:
   name: Jagna Feierabend
   role: Sales Development Representative (EMEA)
+  team:
   reports_to: head_sales_development
   location: London, United Kingdom
   github: jfeierabend
@@ -2142,6 +2338,7 @@ dan_diemer:
   github: dhdiemer
   pronouns: he/him
   role: Senior Customer Engineer
+  team:
   reports_to: director_customer_engineering_americas
   location: Whitefish, MT
   links: '[Spotify](https://open.spotify.com/artist/4dhuJYDtoPxqQCkzAxXXfd), [LinkedIn](https://www.linkedin.com/in/dhdiemer/)'
@@ -2154,6 +2351,7 @@ carson_hopkins:
   github: hopkinscl
   pronouns: she/her
   role: Senior Customer Engineer
+  team:
   reports_to: director_customer_engineering_americas
   location: Brooklyn, NY, USA 🇺🇸
   description: Carson grew up in rural Virginia and now lives in New York City with her wife. She’s a startup and remote work veteran who enjoys buying more books than she can possibly read, drinking coffee, and showering her cat with affection that is occasionally reciprocated. She’s also a big fan of national parks, dinner parties, sweatpants, and obscure desserts.
@@ -2164,6 +2362,7 @@ kevin_wojkovich:
   github: kevinwojo
   pronouns: he/him
   role: Software Engineer, Delivery
+  team:
   reports_to: engineering_manager_devops
   location: Chicago, IL, USA 🇺🇸
   description: Kevin lives in the Rogers Park neigborhood in Chicago, IL. He's worked within the DevOps and Infrastructure space across many industries including crytpocurrency, finance, retail, and law enforcement. When not working, Kevin enjoys biking, going to the gym, cooking, bread-making, and watching cartoons.
@@ -2173,6 +2372,7 @@ brett_hayes:
   email: brett.hayes@sourcegraph.com
   github: bretthayes
   role: Software Engineer
+  team:
   reports_to: engineering_manager_content_platform
   location: Ontario, Canada 🇨🇦
   description: Brett sparked his interest in design and programming when he first discovered modding map skins and projectiles to do weird things in the game of Halo. This became the catalyst to his self-taught career in software and web development. He started consulting after graduating high school and has had the pleasure of working for a handful of startups as well as Co-founding a few of his own. He's worked in many industries such as retail, edtech, fintech, and automotive and brings over a decade of experience in software and web development to Sourcegraph. Being creative at heart with an analytical mind, Brett has a knack for his craft and is passionate about design and web technologies. Away from his mechanical keyboard, you can find him photographing candid moments, snowboarding with his wife, tinkering with his network rack, playing or writing music, or wrenching on his car.
@@ -2183,6 +2383,7 @@ olivia_simpson:
   links: '[LinkedIn](https://www.linkedin.com/in/olivia-simpson-9a8a1835/)'
   github: olivia488
   role: Program Manager, Demand Generation Campaigns
+  team:
   reports_to: director_demand_generation
   location: New York, NY, USA
   description: Olivia is originally from Park Ridge, IL, but now lives in Manhattan with her fluffy corgi. Prior to joining Sourcegraph, Olivia held different roles at high-growth startups, where she discovered a passion for demand generation marketing. In her free time, she enjoys walking her dog in Central Park, meeting up with friends, and finding fun new Peloton rides to try!
@@ -2193,6 +2394,7 @@ amy_johnson:
   links: '[LinkedIn](https://www.linkedin.com/in/amy-johnson-2367a4137/)'
   github: amyjohnsonSG
   role: Accountant
+  team:
   reports_to: financial_controller
   location: Trabuco Canyon, CA, USA
   description: Amy lives in Southern California with her husband and mini australian shepherd. When she isn't knee deep in spreadsheets, she enjoys hiking, camping, and snowboarding.
@@ -2200,12 +2402,14 @@ amy_johnson:
 director_design:
   name: Christina Forney
   role: (Interim) Director of Design
+  team:
   reports_to: vp_product
   manager_role_slug: director_design
 
 engineering_manager_content_platform:
   name: Jean du Plessis
   role: (Interim) Engineering Manager, Content Platform
+  team:
   reports_to: engineering_manager_web
   manager_role_slug: engineering_manager_content_platform
 
@@ -2215,6 +2419,7 @@ Daniel_Gwyn:
   links: '[LinkdIn](https://www.linkedin.com/in/daniel-gwyn-6b9ab6161/)'
   github: danieltgwyn
   role: Sales Dev Rep
+  team:
   reports_to: head_sales_development
   location: Raleigh, NC, USA
 
@@ -2224,6 +2429,7 @@ molly_weitzel:
   links: '[LinkedIn](https://www.linkedin.com/in/mollyweitzel/)'
   github: mollylogue
   role: Software Engineer
+  team:
   reports_to: software_engineering_manager
   location: Boulder, CO, USA
   description: Molly lives in Boulder, CO with her husband Matthew. In her free time she enjoys outdoor activities such as rock climbing, running, hiking, and skiing.
@@ -2232,6 +2438,7 @@ alex_ostrikov:
   name: Alexander Ostrikov
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: software_engineering_manager
   location: St. Petersburg, Russia 🇷🇺
   github: sashaostrikov
@@ -2243,6 +2450,7 @@ dominique_cole:
   name: Dominique "Dom" Cole
   pronouns: he/him
   role: Technical Recruiter
+  team:
   location: Austin, TX, USA 🇺🇸
   email: dom.cole@sourcegraph.com
   github: domcole
@@ -2253,6 +2461,7 @@ jonathan_ayers:
   name: Jonathan Ayers
   pronouns: he/him
   role: Senior People Partner
+  team:
   reports_to: vp_people
   location: Seattle, WA, USA 🇺🇸
   email: jonathan.ayers@sourcegraph.com
@@ -2264,6 +2473,7 @@ veronica_bueno:
   name: Veronica Bueno
   pronouns: she/her
   role: Technical Recruiter
+  team:
   location: Austin, TX, USA 🇺🇸
   email: veronica.bueno@sourcegraph.com
   github: vernbueno
@@ -2274,6 +2484,7 @@ jennifer_mitchell:
   name: Jennifer Mitchell
   pronouns: she/her
   role: Engineering Manager - DevOps
+  team:
   reports_to: director_engineering
   manager_role_slug: engineering_manager_devops
   location: Hutto, TX, USA 🇺🇸
@@ -2286,6 +2497,7 @@ Nate_Freng:
   name: Nate Freng
   pronouns: he/him
   role: Tech Ops Engineer
+  team:
   reports_to: tech_ops_manager
   location: Fargo, ND, USA 🇺🇸
   email: nate.freng@sourcegraph.com
@@ -2299,6 +2511,7 @@ greg_seador:
   github: gseador
   pronouns: he/him
   role: Manager, Customer Engineering
+  team:
   reports_to: director_customer_engineering_americas
   location: Austin, TX, USA 🇺🇸
   description: Greg lives in Austin, TX. In his free time he's usually out golfing, trying a new restaurant, adding to his burger spreadsheet, tackling a home improvement project, or listening to a podcast.
@@ -2310,6 +2523,7 @@ oleg_gromov:
   links: '[gromov.com](https://gromov.com), [@oleggromov](https://twitter.com/oleggromov), [LinkedIn](https://www.linkedin.com/in/oleggromov/), [where is Rostov-on-Don](https://goo.gl/maps/Dv8suXbopw6zQ2fm9)'
   github: oleggromov
   role: Software Engineer
+  team:
   reports_to: engineering_manager_frontend_platform
   location: Rostov-on-Don, Russia 🇷🇺
   description: "Oleg is a software engineer who is experienced in hands-on development and people management. He dedicates his attention to front-end development, although also enjoys full-stack work from product and design to dev-ops and analytics. He is originally from Rostov-on-Don, and after living in the US, Sweden, and UK he's back to his hometown. Supposedly not for long 😅 In his free time, Oleg enjoys playing and listening to rock music, spending time with his son and wife, and playing chess with friends."
@@ -2318,6 +2532,7 @@ filip_haftek:
   name: Filip Haftek
   pronouns: he/him
   role: Software Engineer DevOps
+  team:
   reports_to: engineering_manager_devops
   location: Kraków, Poland 🇵🇱
   github: filiphaftek
@@ -2329,6 +2544,7 @@ cory_dobson:
   name: Cory Dobson
   pronouns: he/him
   role: Enterprise Account Executive - Sales
+  team:
   reports_to: vp_sales_western_region
   location: Portland, OR, USA 🇺🇸
   github: corydobson
@@ -2340,6 +2556,7 @@ isuru_fonseka:
   name: Isuru Fonseka
   pronouns: he/him
   role: Senior Customer Engineer
+  team:
   reports_to: director_customer_engineering_international
   location: Sydney, Australia 🇦🇺
   github: Isuru-F
@@ -2350,6 +2567,7 @@ isuru_fonseka:
 daniel_dides:
   name: Daniel Dides
   role: Cloud DevOps
+  team:
   reports_to: engineering_manager_devops
   location: Flint, TX, USA 🇺🇸
   email: daniel.dides@sourcegraph.com
@@ -2360,6 +2578,7 @@ daniel_dides:
 nicolas_hernandez:
   name: Nick Hernandez
   role: Enterprise Account Executive - Sales
+  team:
   reports_to: regional_director_sales_east
   location: New York City, NY, USA 🇺🇸
   email: nick.hernandez@sourcegraph.com
@@ -2370,6 +2589,7 @@ nicolas_hernandez:
 rohan_gupta:
   name: Rohan Gupta
   role: Sales Development Representative - (USA)
+  team:
   reports_to: head_sales_development
   location: Austin, TX, USA 🇺🇸
   pronouns: he/him
@@ -2381,6 +2601,7 @@ rohan_gupta:
 david_veszelovszki:
   name: David Veszelovszki
   role: Software Engineer
+  team:
   reports_to: director_engineering
   location: Budapest, Hungary 🇭🇺
   pronouns: he/him
@@ -2395,6 +2616,7 @@ riana_shahid:
   github: r-shahid
   pronouns: she/her
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: New York City, NY, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/rianashahid/)'
@@ -2405,6 +2627,7 @@ rob_dapaah:
   email: rob.dapaah@sourcegraph.com
   github: rdapaah
   role: Senior Advisor, Value Engineering
+  team:
   reports_to: senior_manager_value_engineering
   location: Hauppauge, NY, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/robdap/)'
@@ -2416,6 +2639,7 @@ ashwin_Thakur:
   pronouns: he/him
   github: ashwint98
   role: Sales Development Representative (EMEA)
+  team:
   reports_to: head_sales_development
   location: London, UK
   links: '[LinkedIn](https://www.linkedin.com/in/ashwin-thakur/)'
@@ -2426,6 +2650,7 @@ casi_neff:
   email: casi.neff@sourcegraph.com
   github: casineff
   role: Sales Development Representative (East)
+  team:
   reports_to: head_sales_development
   location: Indianapolis, IN, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/casi-neff-5a5787142/)'
@@ -2435,6 +2660,7 @@ philipp_spiess:
   name: Philipp Spiess
   pronouns: he/him
   role: Full-Stack Engineer, Growth and Integrations
+  team:
   reports_to: engineering_manager_growth
   location: Vienna, AT 🇦🇹
   pronunciation: '[ˈʃpiːs](http://ipa-reader.xyz/?text=%CB%88%CA%83pi%CB%90s&voice=Marlene)'
@@ -2446,18 +2672,21 @@ philipp_spiess:
 desene_sterling:
   name: Desene Sterling
   role: Financial Controller
+  team:
   reports_to: vp_operations
   manager_role_slug: financial_controller
 
 prakash_durgani:
   name: Prakash Durgani
   role: Head of International Sales
+  team:
   reports_to: vp_sales
   manager_role_slug: head_international_sales
 
 kristen_stretch:
   name: Kristen Stretch
   role: Engineering Manager, Developer Experience
+  team:
   reports_to: engineering_manager_web
   manager_role_slug: engineering_manager_developer_experience
 
@@ -2466,6 +2695,7 @@ feroz_salam:
   email: feroz.salam@sourcegraph.com
   github: ferozsalam
   role: Security Engineer
+  team:
   reports_to: security_engineering_manager
   location: Bristol and London, UK
   description: Feroz has been working in security engineering for most of his career, initially as a developer of anti-phishing products and more recently within application security and incident response for banking infrastructure. His LinkedIn profile also claims that his skills include French Horn, Dairy Science, and Immigration Issues; some of these might be true.
@@ -2477,6 +2707,7 @@ shawntee_harris:
   github: shawnteeharris
   pronouns: she/her
   role: Program Manager
+  team:
   location: Kansas City, KS, USA 🇺🇸
   description: Shawntee lives in Kansas City, KS with her fiancé and 2 dogs. Outside of work she loves collecting new vinyals, attending live music shows and traveling.
 
@@ -2486,6 +2717,7 @@ pietro_rosa:
   pronouns: he/him
   location: Rovigo Italy, IT 🇮🇹
   role: Software Engineer
+  team:
   links: '[LinkedIn](https://www.linkedin.com/in/pietrorosa77)'
   reports_to: engineering_manager_cloud_saas
   description: Pietro lives in a small city called [Rovigo](https://goo.gl/maps/bFK7n4quTGk5MJBu7) in Italy with his wife and 2 kids. Pietro previously worked in Microsoft, Auth0 and NearForm as a senior full stack engineer. He loves playing football ⚽ (nowadays only 5 aside letting the ball doing most of the job...), hiking 🥾 and wild mushrooms gathering 🍄.
@@ -2497,6 +2729,7 @@ lindsay_murphy:
   github: lindsaykmurphy
   pronouns: she/her
   role: Customer Marketing Lead
+  team:
   links: '[LinkedIn](https://www.linkedin.com/in/lindsaynolan-mba/)'
   location: Hudson, MA, USA 🇺🇸
   description: Lindsay lives in Hudson, MA with her husband and dog, Toro. Outside of work she loves traveling around the world, planning trips for family and friends, drinking copious amounts of coffee, and trying out new recipes in the kitchen.
@@ -2505,6 +2738,7 @@ connor_obrien:
   name: Connor OBrien
   email: connor.obrien@sourcegraph.com
   role: Chief of Staff to CEO
+  team:
   pronouns: he/him
   github: connoro13c
   links: '[LinkedIn](https://www.linkedin.com/in/connorob/)'
@@ -2517,6 +2751,7 @@ brady_garrett:
   github: brady-garrett
   pronouns: he/him
   role: Sr. Data Analyst
+  team:
   reports_to: business_operations_manager
   location: Queen Creek, AZ, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/bradygarrett11/)'
@@ -2527,6 +2762,7 @@ michael_lin:
   pronouns: he/him
   location: Richmond, BC, Canada 🇨🇦
   role: Software Engineer, DevOps
+  team:
   reports_to: engineering_manager_devops
   email: michael.lin@sourcegraph.com
   github: michaellzc
@@ -2541,6 +2777,7 @@ petri_last:
   name: Petri-Johan Last
   pronouns: he/him
   role: Software Engineer
+  team:
   reports_to: engineering_manager_cloud_saas
   location: Stellenbosch, Western Cape, South Africa 🇿🇦
   github: pjlast
@@ -2555,6 +2792,7 @@ jeff_wayman:
   github: jwayman
   pronouns: he/him
   role: Director, Technical Writing
+  team:
   reports_to: vp_product
   manager_role_slug: head_of_technical_writing
   location: Valrico, FL, USA 🇺🇸
@@ -2568,6 +2806,7 @@ sarah_briggs:
   github: 5arahBrigg5
   pronouns: she/her
   role: Program Manager, Customer Support
+  team:
   reports_to: director_customer_support
   location: Portland, OR, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/sarah-briggs-3b690330/)'
@@ -2579,6 +2818,7 @@ quinlan_sparks:
   github: qmsparks
   pronouns: they/them
   role: Application Engineer
+  team:
   reports_to: customer_support_manager_1
   location: Chicago, Illinois, USA
   links: '[LinkedIn](https://www.linkedin.com/in/quinlansparks/)'
@@ -2589,6 +2829,7 @@ shane_carr:
   name: Shane Carr
   pronouns: he/him
   role: Enterprise Account Executive
+  team:
   reports_to: vp_sales_western_region
   location: Berkeley, CA, USA 🇺🇸
   github: shanecarr1
@@ -2602,6 +2843,7 @@ Samantha_Ulrich:
   github: samU713
   pronouns: she/her
   role: Senior Accountant
+  team:
   reports_to: financial_controller
   location: Portland, OR, USA 🇺🇸
   links: '[LinkedIn](https://www.linkedin.com/in/samantha-u-62218837/)'

--- a/data/team.yml
+++ b/data/team.yml
@@ -1240,7 +1240,7 @@ coury_clark:
   name: Coury Clark
   pronouns: He/Him
   role: Software Engineer
-  team: Code WINSIGHTS
+  team: Code Insights
   reports_to: engineering_manager_code_insights
   location: Phoenix, AZ, USA
   email: coury@sourcegraph.com

--- a/data/team.yml
+++ b/data/team.yml
@@ -168,8 +168,8 @@ thorsten_ball:
 
 loïc_guychard:
   name: Loïc Guychard
-  role: Engineering manager, search
-  team:
+  role: Engineering manager
+  team: Search
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_search
   location: Brest, Brittany, France 🇫🇷
@@ -247,8 +247,8 @@ kai_passo:
 rob_rhyne:
   name: Rob Rhyne
   reports_to: director_design
-  role: Senior Product Designer, Batch Changes and Search
-  team:
+  role: Senior Product Designer
+  team: Batch Changes, Search
   location: Wilmington, NC, USA 🇺🇸
   email: rob@sourcegraph.com
   links: '[@robrhyne](https://twitter.com/robrhyne), [LinkedIn](https://www.linkedin.com/in/rrhyne)'
@@ -313,8 +313,8 @@ robert_lin:
 
 marek_zaluski:
   name: Marek Zaluski
-  role: 'Software Engineer, Engineering Education Lead'
-  team:
+  role: Software Engineer, Engineering Education Lead
+  team: Engineering Education
   reports_to: engineering_manager_developer_experience
   location: Ottawa, Canada 🇨🇦
   github: marekweb
@@ -363,8 +363,8 @@ alicja_suska:
   reports_to: director_design
   pronouns: she/her
   pronunciation: /aˈlʲit͡s.ja/
-  role: Product Designer, Frontend Platform, Growth and Integrations, and Code Insights
-  team:
+  role: Product Designer
+  team: Frontend Platform, Growth and Integrations, Code Insights
   location: Poznań, Poland 🇵🇱
   github: AlicjaSuska
   email: alicja@sourcegraph.com
@@ -386,8 +386,8 @@ quinn_keast:
   name: Quinn Keast
   reports_to: director_design
   pronouns: he/him
-  role: Product Designer, Cloud SaaS and Search
-  team:
+  role: Product Designer
+  team: Cloud SaaS, Search
   location: Berlin, Germany 🇩🇪
   github: quinnkeast
   email: qkeast@sourcegraph.com
@@ -422,8 +422,8 @@ tharuntej_kandala:
 chris_pine:
   name: Chris Pine
   pronouns: he/she/they/Chris
-  role: Engineering Manager, Batch Changes
-  team:
+  role: Engineering Manager
+  team: Batch Changes
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_batch_changes
   location: Portland, OR, USA 🇺🇸
@@ -436,7 +436,7 @@ chris_pine:
 gregg_stone:
   name: Gregg Stone
   role: VP of Sales
-  team:
+  team: Sales
   manager_role_slug: vp_sales
   location: San Francisco, CA
 
@@ -483,8 +483,8 @@ maría_craig:
   name: María Craig
   reports_to: product_director_code_graph
   pronouns: she/her
-  role: Product Manager, Code Intelligence
-  team:
+  role: Product Manager
+  team: Code Intelligence
   location: Barcelona, Spain 🇪🇸 / Buenos Aires, Argentina 🇦🇷
   github: macraig
   email: maria@sourcegraph.com
@@ -505,8 +505,8 @@ joel_kwartler:
   name: Joel Kwartler
   reports_to: product_director_code_graph
   pronouns: he/him
-  role: Product Manager, Code Insights
-  team:
+  role: Product Manager
+  team: Code Insights
   location: Los Angeles, CA, USA 🇺🇸
   pronunciation: '[ʤoʊl kwɔrtlɜr](http://ipa-reader.xyz/?text=%CA%A4o%CA%8Al%20kw%C9%94rtl%C9%9Cr&voice=Joey)'
   github: Joelkw
@@ -529,7 +529,7 @@ kacie_jenkins:
   name: Kacie Jenkins
   pronouns: she/her
   role: VP of Marketing
-  team:
+  team: Marketing
   manager_role_slug: vp_marketing
   location: Sea Ranch, CA, USA 🇺🇸
   email: kacie@sourcegraph.com
@@ -551,8 +551,8 @@ jonah_dueck:
 jean_du_plessis:
   name: Jean du Plessis
   pronouns: he/him
-  role: Engineering Manager, Web
-  team:
+  role: Engineering Manager
+  team: Web
   reports_to: vp_engineering
   manager_role_slug: engineering_manager_web
   location: Cape Town, South Africa 🇿🇦
@@ -566,7 +566,7 @@ owen_convey:
   name: Owen Convey
   pronouns: he/him
   role: Engineering Manager
-  team:
+  team: Code Intelligence
   reports_to: director_engineering_global_code_graph
   manager_role_slug: engineering_manager_code_intelligence
   location: Barcelona, Spain 🇪🇸
@@ -591,8 +591,8 @@ virginia_ulrich:
 scott_campbell:
   name: Scott Campbell
   pronouns: he/him
-  role: Regional Director of Sales, East
-  team:
+  role: Regional Director of Sales
+  team: Sales East
   reports_to: vp_sales
   manager_role_slug: regional_director_sales_east
   location: Asheville, North Carolina, United States 🇺🇸
@@ -605,8 +605,8 @@ scott_campbell:
 tommy_o_donnell:
   name: Tommy O Donnell
   pronouns: he/him
-  role: Manager, Financial Planning & Analysis
-  team:
+  role: Manager
+  team: Financial Planning & Analysis
   reports_to: vp_operations
   manager_role_slug: manager_financial_planning
   location: Tralee, County Kerry, Ireland 🇮🇪
@@ -705,7 +705,7 @@ andy_schumeister:
   name: Andy Schumeister
   pronouns: he/him
   role: Director of Product Marketing
-  team:
+  team: Product Marketing
   reports_to: vp_marketing
   manager_role_slug: director_product_marketing
   location: Minneapolis, MN, USA 🇺🇸
@@ -730,7 +730,7 @@ greg_bastis:
   name: Greg Bastis
   pronouns: he/him
   role: VP Sales, Western Region
-  team:
+  team: Sales West
   reports_to: vp_sales
   manager_role_slug: vp_sales_western_region
   location: San Francisco, CA, USA
@@ -754,8 +754,8 @@ seth_hoover:
 ólafur_páll_geirsson:
   name: Ólafur Páll Geirsson
   pronouns: he/him
-  role: Software Engineer, Code Intelligence
-  team:
+  role: Software Engineer
+  team: Code Intelligence
   reports_to: engineering_manager_code_intelligence
   location: Drøbak, Norway 🇳🇴
   github: olafurpg
@@ -767,8 +767,8 @@ malo_marrec:
   name: Malo Marrec
   reports_to: product_director_code_graph
   pronouns: he/him
-  role: Product Manager, Batch Changes
-  team:
+  role: Product Manager
+  team: Batch Changes
   location: Paris, France 🇫🇷
   email: malo@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/malo-marrec)'
@@ -849,8 +849,8 @@ caitlin_moran:
 murat_sutunc:
   name: Murat Sutunc
   pronouns: he/him
-  role: Engineering Manager, Growth and Integrations
-  team:
+  role: Engineering Manager
+  team: Growth and Integrations
   reports_to: director_engineering
   manager_role_slug: engineering_manager_growth
   location: Redwood City, CA, USA 🇺🇸
@@ -888,7 +888,7 @@ tammy_zhu:
   name: Tammy Zhu
   pronouns: she/her
   role: Director of Legal
-  team:
+  team: Legal
   reports_to: vp_operations
   manager_role_slug: director_legal
   location: San Francisco, CA, USA 🇺🇸
@@ -972,8 +972,8 @@ adeola_akinsiku:
 patrick_dubroy:
   name: Patrick Dubroy
   pronouns: he/him
-  role: Engineering Manager, Frontend platform
-  team:
+  role: Engineering Manager
+  team: Frontend platform
   reports_to: engineering_manager_web
   manager_role_slug: engineering_manager_frontend_platform
   location: Munich, Germany 🇩🇪
@@ -1020,8 +1020,8 @@ sam_cregg:
 indradhanush_gupta:
   name: Indradhanush Gupta
   pronouns: he/him
-  role: Software Engineer, Core Application
-  team:
+  role: Software Engineer
+  team: Core Application
   reports_to: software_engineering_manager
   location: Kolkata, India, 🇮🇳
   github: indradhanush
@@ -1033,8 +1033,8 @@ indradhanush_gupta:
 sarah_reece:
   name: Sarah Reece
   pronouns: she/her
-  role: Director, Demand Generation
-  team:
+  role: Director
+  team: Demand Generation
   reports_to: vp_marketing
   manager_role_slug: director_demand_generation
   location: Winston Salem, NC, USA
@@ -1094,8 +1094,8 @@ samson_goddy:
 fabiana_castellanos:
   name: Fabiana Castellanos
   pronouns: she/her
-  role: Project Coordinator, Brand
-  team:
+  role: Project Coordinator
+  team: Brand
   reports_to: director_demand_generation
   location: Oceanside, CA USA 🇺🇸
   github: fabicastp
@@ -1144,8 +1144,8 @@ rebecca_dodd:
 carly_jones:
   name: Carly Jones
   pronouns: she/her
-  role: VP, Talent
-  team:
+  role: VP
+  team: Talent
   location: Denver, CO USA 🇺🇸
   github: carlyj0nes
   description: Carly is a Denver native who went to college in Vermont (Middlebury), lived in Washington, DC for 5 years, and has since returned home to Colorado. Prior to Sourcegraph, she gained experience leading talent teams at high growth startups and is passionate about all things talent acquisition. When not working, you can find Carly tackling a DIY project, practicing her golf game, spending time outdoors, and traveling.
@@ -1153,8 +1153,8 @@ carly_jones:
 rafal_leszczynski:
   name: Rafal Leszczynski
   pronouns: he/him
-  role: Engineering Manager, Cloud SaaS
-  team:
+  role: Engineering Manager
+  team: Cloud SaaS
   reports_to: director_engineering
   manager_role_slug: engineering_manager_cloud_saas
   location: Jelonek (Poznan), Poland 🇵🇱
@@ -1166,8 +1166,8 @@ rafal_leszczynski:
 kelli_rockwell:
   name: Kelli Rockwell
   pronouns: she/her
-  role: Software Engineer, Batch Changes
-  team:
+  role: Software Engineer
+  team: Batch Changes
   reports_to: engineering_manager_batch_changes
   location: Seattle, WA, USA 🇺🇸
   github: courier-new
@@ -1180,8 +1180,8 @@ dan_mckean:
   name: Dan Mckean
   reports_to: product_director_enablement
   pronouns: he/him
-  role: Product Manager, Repo Management & Delivery
-  team:
+  role: Product Manager
+  team: Repo Management, Delivery
   location: Shaftesbury (Dorset), UK 🇬🇧
   github: dan-mckean
   email: dan.mckean@sourcegraph.com
@@ -1202,8 +1202,8 @@ cassie_melani:
 rebecca_rissinger:
   name: Rebecca Rissinger
   pronouns: she/her
-  role: Manager, Marketing Operations
-  team:
+  role: Manager
+  team: Marketing Operations
   reports_to: director_demand_generation
   manager_role_slug: manager_marketing_operations
   location: Red Bank, New Jersey, USA
@@ -1216,8 +1216,8 @@ ryan_phillips:
   name: Ryan Phillips
   reports_to: product_director_cloud
   pronouns: He/Him
-  role: Product Manager, Cloud
-  team:
+  role: Product Manager
+  team: Cloud
   location: San Francisco, CA, USA 🇺🇸
   github: Ryphil
   email: ryphil@sourcegraph.com
@@ -1227,8 +1227,8 @@ ryan_phillips:
 jake_sorensen:
   name: Jake Sorensen
   pronouns: He/Him
-  role: Programs Lead, Demand Gen Campaigns
-  team:
+  role: Programs Lead
+  team: Demand Gen Campaigns
   reports_to: director_demand_generation
   location: Los Angeles, CA, USA 🇺🇸
   github: jakevsen
@@ -1251,7 +1251,7 @@ aimee_menne:
   name: Aimee Menne
   pronouns: she/her
   role: VP of Customer Engineering
-  team:
+  team: Customer Engineering
   manager_role_slug: vp_customer_engineering
   location: Denver, CO USA 🇺🇸
   github: amenne
@@ -1276,7 +1276,7 @@ devon_coords:
   name: Devon Coords
   pronouns: She/Her
   role: Senior Technical Recruiter, Team Lead
-  team:
+  team: Talent
   location: White Plains, NY USA 🇺🇸
   github: devoncoords
   email: devon@sourcegraph.com
@@ -1383,8 +1383,8 @@ nate_maynard:
 jenny_bergen:
   name: Jenny Bergen
   pronouns: she/her
-  role: Manager, Content Marketing
-  team:
+  role: Manager
+  team: Content Marketing
   reports_to: director_content_strategy
   manager_role_slug: manager_content_marketing
   location: Denver, Colorado, USA 🇺🇸
@@ -1656,8 +1656,8 @@ luke_taylor:
 anna_mikhova:
   name: Anna Mikhova
   reports_to: vp_product
-  role: Director of Product, Cloud
-  team:
+  role: Director of Product
+  team: Cloud
   manager_role_slug: product_director_cloud
   location: Salt Lake City, UT, USA 🇺🇸
   github: anna-mikhova
@@ -1816,8 +1816,8 @@ serina_clark:
   name: Serina Clark
   reports_to: vp_product
   pronouns: her/she/hers
-  role: Director of Product, Enablement
-  team:
+  role: Director of Product
+  team: Enablement
   manager_role_slug: product_director_enablement
   location: Erie, Colorado, United States 🇺🇸
   github: serinadawn
@@ -2059,8 +2059,8 @@ sam_jones:
 stephanie_zabala:
   name: Stephanie Zabala
   pronouns: she/her
-  role: Principal Designer, Brand
-  team:
+  role: Principal Designer
+  team: Brand
   location: Brooklyn, NY, United States 🇺🇸
   github: stephzabala
   email: steph.zabala@sourcegraph.com
@@ -2069,8 +2069,8 @@ stephanie_zabala:
 crystal_augustus:
   name: Crystal Augustus
   pronouns: she/her
-  role: Software Engineer, Delivery
-  team:
+  role: Software Engineer
+  team: Delivery
   reports_to: engineering_manager_devops
   location: Ashland, MA, United States 🇺🇸
   github: caugustus-sourcegraph
@@ -2093,8 +2093,8 @@ marisa_kanemoto:
   name: Marisa Kanemoto
   reports_to: director_design
   pronouns: she/her
-  role: Product Designer, Search
-  team:
+  role: Product Designer
+  team: Search
   location: Berkeley, California, United States 🇺🇸
   github: marisak
   email: marisa.kanemoto@sourcegraph.com
@@ -2131,8 +2131,8 @@ nancy_shah:
 michal_sennett:
   name: Michal Sennett
   pronouns: she/her
-  role: Strategic Projects Manager, Engineering
-  team:
+  role: Strategic Projects Manager
+  team: Engineering
   location: Dallas, TX, USA 🇺🇸
   github: msennett22
   email: michal.sennett@sourcegraph.com
@@ -2152,8 +2152,8 @@ keely_aguayo:
 erika_heidi:
   name: Erika Heidi
   pronouns: she/her
-  role: Senior Developer Advocate, Community
-  team:
+  role: Senior Developer Advocate
+  team: Community
   reports_to: director_community
   location: The Hague, Netherlands 🇳🇱
   github: erikaheidi
@@ -2361,8 +2361,8 @@ kevin_wojkovich:
   email: kevin.wojkovich@sourcegraph.com
   github: kevinwojo
   pronouns: he/him
-  role: Software Engineer, Delivery
-  team:
+  role: Software Engineer
+  team: Delivery
   reports_to: engineering_manager_devops
   location: Chicago, IL, USA 🇺🇸
   description: Kevin lives in the Rogers Park neigborhood in Chicago, IL. He's worked within the DevOps and Infrastructure space across many industries including crytpocurrency, finance, retail, and law enforcement. When not working, Kevin enjoys biking, going to the gym, cooking, bread-making, and watching cartoons.
@@ -2761,8 +2761,8 @@ michael_lin:
   name: Michael Lin
   pronouns: he/him
   location: Richmond, BC, Canada 🇨🇦
-  role: Software Engineer, DevOps
-  team:
+  role: Software Engineer
+  team: DevOps
   reports_to: engineering_manager_devops
   email: michael.lin@sourcegraph.com
   github: michaellzc

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -162,7 +162,7 @@ function getReports(teamMembers, role_slug, parentTeam, indent) {
   for (const [teamMemberName, teamMember] of Object.entries(teamMembers)) {
     if (teamMember.reports_to === role_slug) {
       const currentTeam = createValidTeamString(teamMember)
-      const teamString = parentTeam && parentTeam === currentTeam ? '' :currentTeam
+      const teamString = parentTeam && parentTeam === currentTeam ? '' : currentTeam
       console.log(indent)
       const spaces = ' '.repeat(indent * 2)
       content += `${spaces}- [${String(teamMember.name)}](/team/index.md#${String(
@@ -191,7 +191,7 @@ export async function generateReportingStructure(starting_role) {
       )}), ${String(teamMember.role)}\n`
     }
   }
-  pageContent += getReports(teamMembers, starting_role,'', 1)
+  pageContent += getReports(teamMembers, starting_role, '', 1)
   return pageContent
 }
 

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -14,6 +14,10 @@ function createValidTeamAnchor(name) {
   return name.toLowerCase().replace(/\s+/g, '-')
 }
 
+function createValidTeamString(teamMember) {
+  return teamMember.team ? `- ${String(teamMember.team)}` : ''
+}
+
 function createBioLink(name) {
   const bioLinkUrlPrefix = '/team/index.md#'
   return `${bioLinkUrlPrefix}${String(createValidTeamAnchor(name))}`
@@ -153,18 +157,22 @@ export async function generateCodeHostsList() {
   return pageContent
 }
 
-function getReports(teamMembers, role_slug, indent) {
+function getReports(teamMembers, role_slug, parentTeam, indent) {
   let content = ''
   for (const [teamMemberName, teamMember] of Object.entries(teamMembers)) {
     if (teamMember.reports_to === role_slug) {
+      const currentTeam = createValidTeamString(teamMember)
+      const teamString = parentTeam && parentTeam === currentTeam ? '' :currentTeam
+      console.log(indent)
       const spaces = ' '.repeat(indent * 2)
       content += `${spaces}- [${String(teamMember.name)}](/team/index.md#${String(
         createValidTeamAnchor(teamMember.name)
-      )}), ${String(teamMember.role)}\n`
+      )}), ${String(teamMember.role)} ${teamString}\n`
       if (teamMember.manager_role_slug) {
         const reportsIndent = (content += getReports(
           teamMembers,
           teamMember.manager_role_slug,
+          currentTeam,
           parseInt(indent, 10) + 1
         ))
       }
@@ -183,7 +191,7 @@ export async function generateReportingStructure(starting_role) {
       )}), ${String(teamMember.role)}\n`
     }
   }
-  pageContent += getReports(teamMembers, starting_role, 1)
+  pageContent += getReports(teamMembers, starting_role,'', 1)
   return pageContent
 }
 

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -163,7 +163,6 @@ function getReports(teamMembers, role_slug, parentTeam, indent) {
     if (teamMember.reports_to === role_slug) {
       const currentTeam = createValidTeamString(teamMember)
       const teamString = parentTeam && parentTeam === currentTeam ? '' : currentTeam
-      console.log(indent)
       const spaces = ' '.repeat(indent * 2)
       content += `${spaces}- [${String(teamMember.name)}](/team/index.md#${String(
         createValidTeamAnchor(teamMember.name)


### PR DESCRIPTION
This PR adds a `team` field to the teammates data file that will render in the autogenerated org chart. I did some basic data clean up based on some regexp to try and move the data previously in `role` to `team`, but this was spotty at best.

This will append a suffix of `team` to anybody in the org chart whose `team` does *not* match their managers `team`. This way, teams that share a common value (if everyone puts the same tag) will only be visible at the root of that tree to reduce clutter.

I share the same team as Felix
![image](https://user-images.githubusercontent.com/5090588/152230968-d32b6e25-d5ac-43f2-a069-c24ec4e7fa50.png)

I don't share the same team as Felix
![image](https://user-images.githubusercontent.com/5090588/152231000-683a6e64-29ad-448c-980b-45d416e50772.png)
