### PR TITLE
Setup tracker for product initiatives

### DIFF
--- a/content/departments/product-engineering/product/index.md
+++ b/content/departments/product-engineering/product/index.md
@@ -39,20 +39,9 @@ You can reach us at the #product channel or @product-team on Slack. If you have 
 
 ## Product team initiatives
 
-Occasionally the product team takes on special initiatives that are not strictly tied to product delivery. Those are tracked here.
+Occasionally the product team takes on special initiatives that are not strictly tied to product delivery. Those are tracked [here](https://github.com/sourcegraph/product-engineering-tracker/issues?q=is%3Aopen+is%3Aissue+label%3A%22Product+Initiative%22).
 
-### Product management and Product design impact ladders
-
-To help guide people within the product organization on career growth we are creating a clearly defined impact ladder.
-
-- Owner: Christina
-- [Working Document](https://docs.google.com/document/d/1L-TnZjcYNjwTo2fqUF3DOfUvznbfwCAYvDYLBwwqJW8/edit?usp=sharing)
-
-### Document known product gaps and process
-
-There are various problems, feature areas, or initiatives related to Product (which sometimes touch on Engineering or other departments) without a clear owner: we need a list of those, what people should do in the meantime for each of them (if we are not actively working on solving them), a link to a ticket or other resource where the work is happening to fix it, and how to report or add one if someone thinks they have found a new ownership gap.
-
-- Owner: TBD
+To create a new one, go to the [new issue screen](https://github.com/sourcegraph/product-engineering-tracker/issues/new/choose) for the [product-engineering-tracker repo](https://github.com/sourcegraph/product-engineering-tracker) and choose `Product Initiative`; this will ensure it gets the correct label to be included in the search above.
 
 ## References
 


### PR DESCRIPTION
This sets up new, simple GitHub-based tracking for Product Initiatives.