### PR TITLE
Exclude irrelevant features from compatibility matrix

### DIFF
--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -117,7 +117,7 @@ export async function generateFeatureCodeHostCompatibilities() {
     areaContent += '\n'
 
     for (const feature of Object.values(features)) {
-      if (feature.product_team === productTeamName && feature.compatibility !== undefined ) {
+      if (feature.product_team === productTeamName && feature.compatibility !== undefined) {
         featureCount++
         if (feature.documentation_link) {
           areaContent += `|[${String(feature.title)}](${String(createRelativeProductLink(feature.documentation_link))})`

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -117,7 +117,7 @@ export async function generateFeatureCodeHostCompatibilities() {
     areaContent += '\n'
 
     for (const feature of Object.values(features)) {
-      if (feature.product_team === productTeamName) {
+      if (feature.product_team === productTeamName && feature.compatibility !== undefined ) {
         featureCount++
         if (feature.documentation_link) {
           areaContent += `|[${String(feature.title)}](${String(createRelativeProductLink(feature.documentation_link))})`


### PR DESCRIPTION
Some features do not list out compatibility with codehostx, because it is irrelevant.
For example, server-side batch changes has strictly the same compatibility as batch changes, so listing it here with duplicate data creates noise and clutters this page. Similarly for other features.

This PR removes features without compatibility listed form the code host compatibility page, making that page more compact.
