### PR TITLE
Remove underscores from breadcrumbs

### DIFF
--- a/data/use_cases.yml
+++ b/data/use_cases.yml
@@ -2,20 +2,20 @@
 
 developer_onboarding:
   title: Developer Onboarding
-  link: /strategy-goals/strategy/use_cases/dev-onboarding
+  link: /strategy-goals/strategy/use-cases/dev-onboarding
 
 code_reuse:
   title: Code Reuse
-  link: /strategy-goals/strategy/use_cases/code_reuse
+  link: /strategy-goals/strategy/use-cases/code-reuse
 
 code_health:
   title: Code Health
-  link: /strategy-goals/strategy/use_cases/code_health
+  link: /strategy-goals/strategy/use-cases/code-health
 
 fixing_security_vulnerabilities:
   title: Fixing Security Vulnerabilities
-  link: /strategy-goals/strategy/use_cases/fixing_security_vulnerabilities
+  link: /strategy-goals/strategy/use-cases/fixing-security-vulnerabilities
 
 incident_response:
   title: Incident Response
-  link: /strategy-goals/strategy/use_cases/incident_response
+  link: /strategy-goals/strategy/use-cases/incident-response

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -95,9 +95,10 @@ export default function Page({ page }: PageProps): JSX.Element {
         return <ErrorPage statusCode={404} />
     }
 
-    const slugParts = page.slugPath.split('/')
+    const slugParts = page.slugPath
+        .split('/')
         .filter(Boolean)
-        .map(part => part.includes('_') ? part.replace('_', '-') : part)
+        .map(part => (part.includes('_') ? part.replace('_', '-') : part))
 
     return (
         <>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -95,7 +95,9 @@ export default function Page({ page }: PageProps): JSX.Element {
         return <ErrorPage statusCode={404} />
     }
 
-    const slugParts = page.slugPath.split('/').filter(Boolean)
+    const slugParts = page.slugPath.split('/')
+        .filter(Boolean)
+        .map(part => part.includes('_') ? part.replace('_', '-') : part)
 
     return (
         <>


### PR DESCRIPTION
In #2066 we saw several things happening: a parent directory was swapped into the URL for links (when a trailing slash was present), adding an additional term, and breadcrumbs had underscores. The missing index page issue was resolved in #2105 

Underscores **shouldn't** be present in breadcrumbs or URLs, given the redirects we have in place. If, however, there are any, this PR will remove them. It also removes lingering references to underscored files in `use_cases.yml` (part of the larger effort of #1932 to standardize file names).