### PR TITLE
Add `page history as diffs` link

### DIFF
--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -56,6 +56,12 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
                 </div>
             )}
             <div className="sidebar-bottom-links">
+                <Link
+                    href={`https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/handbook%24+file:${CONTENT_FOLDER}/${pagePath}+type:diff+rev:main&patternType=literal`}
+                >
+                    What's new as diff
+                </Link>
+                <br />
                 <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${pagePath}`}>
                     Edit this page
                 </Link>

--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -59,7 +59,7 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
                 <Link
                     href={`https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/handbook%24+file:${CONTENT_FOLDER}/${pagePath}+type:diff+rev:main&patternType=literal`}
                 >
-                    What's new as diff
+                    What's new as diffs
                 </Link>
                 <br />
                 <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${pagePath}`}>

--- a/src/components/EditSection.tsx
+++ b/src/components/EditSection.tsx
@@ -59,7 +59,7 @@ export const EditSection: React.FunctionComponent<EditSectionProps> = ({ page })
                 <Link
                     href={`https://sourcegraph.com/search?q=context:global+repo:%5Egithub.com/sourcegraph/handbook%24+file:${CONTENT_FOLDER}/${pagePath}+type:diff+rev:main&patternType=literal`}
                 >
-                    What's new as diffs
+                    Page history as diffs
                 </Link>
                 <br />
                 <Link href={`https://github.com/sourcegraph/handbook/edit/main/${CONTENT_FOLDER}/${pagePath}`}>


### PR DESCRIPTION
This adds a link which shows a sourcegraph view of what's changed on the page recently. This is a handy way, if you haven't visited a page in a while, to check what's new. It supplements rather than replaces the existing commit-based history view.