### PR TITLE
Require `CONTEXT=production` for GitHub data fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Then start the handbook:
 yarn dev
 ```
 
+### Fetching GitHub data
+
+If you want to fetch GitHub data (used for the recent contributors list on the sidebar), you should set the environment variable `GITHUB_TOKEN` to a working personal access token, and set the `CONTEXT` environment variable to `production`.
+
 ### Using Docker
 
 You can run the handbook locally using Docker and the included Dockerfile. This won't require you to have a Node environment installed, you'll need only the Docker engine (Linux) or Docker Desktop (Windows and MacOS) installed.

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -205,7 +205,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
 
     const fullPath = getFullSlugPath(params.slug)
     const page = await getPageBySlugPath(fullPath)
-    var commitData = null
+    let commitData = null
     if (process.env.CONTEXT === 'production') {
         // Only fetch real commit data for production builds
         commitData = await getGitHubCommitData(fullPath)

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -205,7 +205,11 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
 
     const fullPath = getFullSlugPath(params.slug)
     const page = await getPageBySlugPath(fullPath)
-    const commitData = await getGitHubCommitData(fullPath)
+    var commitData = null
+    if (process.env.CONTEXT === 'production') {
+        // Only fetch real commit data for production builds
+        commitData = await getGitHubCommitData(fullPath)
+    }
 
     const { content, title, toc } = await markdownToHtml(page.body || '', fullPath, page.isIndexPage)
 


### PR DESCRIPTION
This requires `CONTEXT` to be set to `production` for fetching commit data, which is used for the display of recent contributors. This will make it so that only production builds fetch this data, reducing the likelihood of rate limits and speeding up the build.

The current usage of `GITHUB_TOKEN` was not documented, so in addition to documenting the use of the `CONTEXT` variable in local builds, it explains that as well.