### PR TITLE
deployments: add sg ci build to replace manual branch push

### DIFF
--- a/content/departments/product-engineering/engineering/process/deployments/playbooks.md
+++ b/content/departments/product-engineering/engineering/process/deployments/playbooks.md
@@ -54,7 +54,13 @@ Note: sample for `2021-08-19` code freeze.
 **Image build**
 
 To ensure stability during a [code freeze](https://en.wikipedia.org/wiki/Freeze_%28software_engineering%29), a separate `release/YYYY-MM-dd` branch will be created from `main`, with only approved commits to be `cherry-picked` onto `release/YYYY-MM-dd` branch for release. To ensure any compability between the `main` and `release/YYYY-MM-dd` branches, **ALL** commits must first be merged to `main` and pass [CI](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main) for being `cherry-picked`. All tests will be run on the `release/YYYY-MM-dd` branch and must pass before docker images are published to docker hub.
-When creating a hotfix PR in `sourcegraph/sourcegraph`, it is important to create a branch with prefix `main-dry-run/` (it enables CI pipeline similar to the pipeline which is run against every commit in main branch). More about [run types](https://docs.sourcegraph.com/dev/background-information/continuous_integration#run-types).
+When creating a hotfix PR in `sourcegraph/sourcegraph`, it is important to create a branch with prefix `main-dry-run/` (it enables CI pipeline similar to the pipeline which is run against every commit in main branch). This can be done with:
+
+```sh
+sg ci build main-dry-run
+```
+
+More about [pipeline run types](https://docs.sourcegraph.com/dev/background-information/ci/reference).
 
 **Deploy**
 

--- a/content/departments/product-engineering/engineering/process/deployments/testing.md
+++ b/content/departments/product-engineering/engineering/process/deployments/testing.md
@@ -138,7 +138,7 @@ Again, please delete your test project when done. Click on the upper right corne
 
 If you need to build Docker images on Buildkite for testing purposes, e.g. you
 have a PR with a fix and want to deploy that fix to a test instance, you can
-push the branch to the special `docker-images-patch` and `docker-images-patch-notest` branches.
+push the branch to the special [`docker-images-patch`](https://docs.sourcegraph.com/dev/background-information/ci/reference#patch-image) and [`docker-images-patch-notest`](https://docs.sourcegraph.com/dev/background-information/ci/reference#patch-image-without-testing) branches.
 [Learn more about pipeline run types](https://docs.sourcegraph.com/dev/background-information/ci/reference).
 
 To request a build with to build images, you can use [`sg`](https://docs.sourcegraph.com/dev/background-information/sg):

--- a/content/departments/product-engineering/engineering/process/deployments/testing.md
+++ b/content/departments/product-engineering/engineering/process/deployments/testing.md
@@ -138,21 +138,22 @@ Again, please delete your test project when done. Click on the upper right corne
 
 If you need to build Docker images on Buildkite for testing purposes, e.g. you
 have a PR with a fix and want to deploy that fix to a test instance, you can
-push the branch to the special `docker-images-patch` and
-`docker-images-patch-notest` branches. You shouldn't need to resolve merge conflicts, instead you can simply force-push.
+push the branch to the special `docker-images-patch` and `docker-images-patch-notest` branches.
+[Learn more about pipeline run types](https://docs.sourcegraph.com/dev/background-information/ci/reference).
 
-Example: you want to build a new Docker image for `frontend` and `gitserver`
-based on the branch `my_fix`.
+To request a build with to build images, you can use [`sg`](https://docs.sourcegraph.com/dev/background-information/sg):
 
-```
-git push -f origin my_fix:docker-images-patch-notest/frontend
-git push -f origin my_fix:docker-images-patch-notest/gitserver
-git push -f origin my_fix:docker-images-patch-notest/$(Docker_image_to_build)
+```sh
+sg ci build [docker-images-patch|docker-images-patch-no-test]
 ```
 
-This will trigger two builds on Buildkite for these branches:
+Example: You want to build a new Docker image for `frontend` and `gitserver` based on your currently checked out branch. You would like to test `gitserver` as well, but the changes to `frontend` are trivial and don't need to be tested again. The commands you would run are:
 
-- https://buildkite.com/sourcegraph/sourcegraph/builds?branch=docker-images-patch-notest%2Ffrontend
-- https://buildkite.com/sourcegraph/sourcegraph/builds?branch=docker-images-patch-notest%2Fgitserver
+```sh
+sg ci build docker-images-patch gitserver
+sg ci build docker-images-patch-notest frontend
+```
 
-And the end of the build you can find the name of the newly built Docker image.
+> NOTE: You can simply force-push if you would like to re-use a branch name with `--force`.
+
+This will trigger two builds on Buildkite that will publish newly built Docker images.

--- a/content/departments/product-engineering/engineering/process/incidents/playbooks/ci.md
+++ b/content/departments/product-engineering/engineering/process/incidents/playbooks/ci.md
@@ -85,7 +85,7 @@ In order to handle problems with the CI, the following elements are necessary:
          1. [Open a GitHub issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=testing%2Cflake&template=flaky_test.md&title=Flake%3A+%24TEST_NAME+disabled) mentioning the build and the context to explain to the team owning that test what happened.
          1. Checkout the PR branch.
          1. Rebase it so it includes the changes that broke it when merged in the `main` branch.
-         1. Rename the branch to `main-dry-run/your-branch` in order to get the CI to run the same exact checks it does on the `main` branch.
+         1. Create a build using `sg ci build main-dry-run` in order to get the CI to run the same exact checks it does on the `main` branch.
       1. No, but it seems to fail in step or code from another team.
          1. Reach out a member of the team responsible for that test.
          2. go for a. or b. from the previous points.


### PR DESCRIPTION
Documents capabilities introduced in https://github.com/sourcegraph/sourcegraph/pull/30932 and https://github.com/sourcegraph/sourcegraph/pull/31193 for triggering `docker-images-patch`, `main-dry-run`, etc builds