### PR TITLE
Add support for hiding the sidebar on certain pages

### DIFF
--- a/content/departments/product-engineering/engineering/process/engineering_ownership.md
+++ b/content/departments/product-engineering/engineering/process/engineering_ownership.md
@@ -1,5 +1,6 @@
 ---
 data_source: [/data/engineering_ownership.yml, engineering ownership]
+hide_sidebar: true
 ---
 
 # Engineering Ownership

--- a/content/departments/product-engineering/product/tools/deployment_options.md
+++ b/content/departments/product-engineering/product/tools/deployment_options.md
@@ -1,6 +1,7 @@
 ---
 data_source: [/data/features.yml, features]
 data_source_2: [/data/deployment_options.yml, deployment options]
+hide_sidebar: true
 ---
 
 # Features available by deployment option

--- a/content/departments/product-engineering/product/tools/feature_compatibility.md
+++ b/content/departments/product-engineering/product/tools/feature_compatibility.md
@@ -1,6 +1,7 @@
 ---
 data_source: [/data/code_hosts.yml, code hosts]
 data_source_2: [/data/product_teams.yml, product teams]
+hide_sidebar: true
 ---
 
 # Product Feature Compatibility

--- a/content/departments/product-engineering/product/tools/feature_maturity.md
+++ b/content/departments/product-engineering/product/tools/feature_maturity.md
@@ -1,6 +1,7 @@
 ---
 data_source: [/data/maturity_levels.yml, maturity levels]
 data_source_2: [/data/features.yml, features]
+hide_sidebar: true
 ---
 
 # Product Features by Maturity

--- a/content/handbook/editing/hiding-the-sidebar.md
+++ b/content/handbook/editing/hiding-the-sidebar.md
@@ -1,0 +1,11 @@
+# Hiding the sidebar
+
+Some pages have extra wide content and benefit from hiding the sidebar. You can enable this on a page by updating the frontmatter to include `hide_sidebar: true` as follows:
+
+```
+---
+hide_sidebar: true
+---
+```
+
+This will cause the page to not have a table of contents or contributor list. The edit page and history as diffs link will be at the bottom of the page instead.

--- a/content/handbook/editing/index.md
+++ b/content/handbook/editing/index.md
@@ -40,6 +40,7 @@ We don't expect everyone on the team to figure this out on their own. Other team
 - [Moving a Page](move-a-page.md)
 - [Deleting a Page](delete-a-page.md)
 - [Editing the Handbook Product](editing-the-handbook-product.md)
+- [Hiding the sidebar](hiding-the-sidebar.md)
 
 ## Advanced topics
 

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -101,13 +101,16 @@ export default function Page({ page }: PageProps): JSX.Element {
         <>
             <NextSeo title={page.frontMatter?.title || page.title} description={page.frontMatter?.description} />
             <div className="container">
-                <nav id="right-sidebar">
-                    <section className="right-sidebar-section" ref={tocReference}>
-                        <h4 className="sidebar-heading">On this page</h4>
-                        <TableOfContents toc={page.toc} className="table-of-contents" />
-                    </section>
-                    <EditSection page={page} />
-                </nav>
+                {!page.frontMatter?.hide_sidebar ? (
+                    <nav id="right-sidebar">
+                        <section className="right-sidebar-section" ref={tocReference}>
+                            <h4 className="sidebar-heading">On this page</h4>
+                            <TableOfContents toc={page.toc} className="table-of-contents" />
+                        </section>
+
+                        <EditSection page={page} />
+                    </nav>
+                ) : null}
                 <div id="content">
                     {page.content ? (
                         <>
@@ -149,6 +152,7 @@ export default function Page({ page }: PageProps): JSX.Element {
                     ) : (
                         <h1>Unexpected error</h1>
                     )}
+                    {page.frontMatter?.hide_sidebar ? <EditSection page={page} /> : null}
                 </div>
             </div>
         </>


### PR DESCRIPTION
Some page content really benefits from not having the sidebar. In that case, this option allows for hiding the sidebar (removing the table of contents and contributors) and moving the edit links to the bottom of the page.