### PR TITLE
Scope strategy pages to next year or so

### DIFF
--- a/content/strategy-goals/strategy/code-graph/batch-changes/index.md
+++ b/content/strategy-goals/strategy/code-graph/batch-changes/index.md
@@ -1,6 +1,6 @@
 # Batch Changes strategy
 
-Batch Changes is a tool to find code that needs to be changed and change it at scale by running code. This page outlines the vision, strategy, and goals of the Batch Changes team.
+Batch Changes is a tool to find code that needs to be changed and change it at scale by running code. This page outlines the vision, strategy, and goals of the Batch Changes team over the next year or so.
 
 ## Quick links
 

--- a/content/strategy-goals/strategy/code-graph/code-insights/index.md
+++ b/content/strategy-goals/strategy/code-graph/code-insights/index.md
@@ -2,7 +2,7 @@
 
 Code Insights is an upcoming product that lets you track and understand what's in your code and how it changes over time.
 
-This page outlines the vision, strategy, and goals of the Code Insights team.
+This page outlines the vision, strategy, and goals of the Code Insights team over the next year or so.
 
 Quick links:
 

--- a/content/strategy-goals/strategy/code-graph/code-intelligence/index.md
+++ b/content/strategy-goals/strategy/code-graph/code-intelligence/index.md
@@ -1,6 +1,6 @@
 # Code intelligence strategy
 
-Code intelligence provides features and services that help developers better understand and navigate code. This page outlines the vision, strategy and goals of the Code intelligence team.
+Code intelligence provides features and services that help developers better understand and navigate code. This page outlines the vision, strategy and goals of the Code intelligence team over the next year or so.
 
 Quicklinks:
 

--- a/content/strategy-goals/strategy/code-graph/index.md
+++ b/content/strategy-goals/strategy/code-graph/index.md
@@ -1,6 +1,6 @@
 # Code Graph strategy
 
-Code Graph comprises teams working on [Search](./search/index.md), [Code Insights](./code-insights/index.md), [Code Intelligence](./code-intelligence/index.md), and [Batch Changes](./batch-changes/index.md); this page describes the mission and strategy that ties them together, but each linked page provides a more detailed strategy for that team. There is also a whole-company [Sourcegraph strategy](../index.md) and [Product & Engineering strategy](../../../departments/product-engineering/strategy-goals/index.md) to which all of this is aligned.
+Code Graph comprises teams working on [Search](./search/index.md), [Code Insights](./code-insights/index.md), [Code Intelligence](./code-intelligence/index.md), and [Batch Changes](./batch-changes/index.md); this page describes the mission and strategy that ties them together over the next year or so, but each linked page provides a more detailed strategy for that team. There is also a whole-company [Sourcegraph strategy](../index.md) and [Product & Engineering strategy](../../../departments/product-engineering/strategy-goals/index.md) to which all of this is aligned.
 
 ## Mission
 

--- a/content/strategy-goals/strategy/code-graph/search/core.md
+++ b/content/strategy-goals/strategy/code-graph/search/core.md
@@ -1,6 +1,6 @@
 # Search Core strategy
 
-This page outlines the strategy, and goals of the [Search Core team](../../../../departments/product-engineering/engineering/code-graph/search/core.md).
+This page outlines the strategy, and goals of the [Search Core team](../../../../departments/product-engineering/engineering/code-graph/search/core.md) over the next year or so.
 
 For context on the mission, vision and guiding principles of Search, see the top-level [search strategy](index.md) page.
 

--- a/content/strategy-goals/strategy/code-graph/search/index.md
+++ b/content/strategy-goals/strategy/code-graph/search/index.md
@@ -1,6 +1,6 @@
 # Search strategy
 
-Sourcegraph aims to be the best tool for universal code search. There are two teams that work together to make this possible: [Search Product](../../../../departments/product-engineering/engineering/code-graph/search/product.md) and [Search Core](../../../../departments/product-engineering/engineering/code-graph/search/core.md), with the Product team focusing primarily on the user-facing aspects of search, and the Core team focusing on backend, relevancy, and performance. This page outlines the vision, strategy and goals that are shared by both teams.
+Sourcegraph aims to be the best tool for universal code search. There are two teams that work together to make this possible: [Search Product](../../../../departments/product-engineering/engineering/code-graph/search/product.md) and [Search Core](../../../../departments/product-engineering/engineering/code-graph/search/core.md), with the Product team focusing primarily on the user-facing aspects of search, and the Core team focusing on backend, relevancy, and performance. This page outlines the vision, strategy and goals that are shared by both teams over the next year or so.
 
 Quicklinks:
 

--- a/content/strategy-goals/strategy/code-graph/search/product.md
+++ b/content/strategy-goals/strategy/code-graph/search/product.md
@@ -1,6 +1,6 @@
 # Search Product strategy
 
-This page outlines the strategy, and goals of the [Search Product team](../../../../departments/product-engineering/engineering/code-graph/search/product.md).
+This page outlines the strategy, and goals of the [Search Product team](../../../../departments/product-engineering/engineering/code-graph/search/product.md) over the next year or so.
 
 For context on the mission, vision and guiding principles of Search, see the top-level [search strategy](index.md) page.
 


### PR DESCRIPTION
This updates the header on the Code Graph strategy pages to make it clear that they are scoped to within the next year or so.