### PR TITLE
Use `<video>` to embed engineering video instead of `<iframe>`

### DIFF
--- a/content/departments/product-engineering/engineering/index.md
+++ b/content/departments/product-engineering/engineering/index.md
@@ -38,9 +38,7 @@
 
 Welcome to Engineering!
 
-<div class="container my-4 video-embed embed-responsive embed-responsive-16by9">
-    <iframe class="embed-responsive-item" src="https://storage.googleapis.com/sourcegraph-assets/handbook/Engineering%20Dept%20Video.mp4" allowfullscreen="" allow="accelerometer; encrypted-media; gyroscope; picture-in-picture" frameborder="0"></iframe>
-</div>
+<video controls src="https://storage.googleapis.com/sourcegraph-assets/handbook/Engineering%20Dept%20Video.mp4"></video>
 
 ## Org chart
 


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/CQ44Y7F4G/p1645121987346909

Separate note/accessibility issue: This video is missing captions.