### PR TITLE
Document ability to use a custom prefix for managed instance projects

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/delivery/managed/creation_process.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/managed/creation_process.md
@@ -5,13 +5,14 @@ For basic operations like accessing an instance for these steps, see [managed in
 
 1. CE creates an issue with the managed instance template in the `sourcegraph/customer` repository.
 1. Create a new GCP project for the instance by adding it to the [`managed_projects` tfvar in the infrastructure repo's `gcp/projects/terraform.tfvars`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/infrastructure%24%40main+managed_projects+%3D+%7B+:%5B_%5D+%7D&patternType=structural)
-   - It will look something like `sourcegraph-managed-$COMPANY = { ... }` - refer to the existing variables for more details
+   - It will look something like `sourcegraph-managed-$COMPANY = { ... }` - refer to the existing variables for more details. If you customize the `sourcegraph-managed` prefix, make sure to update the PROJECT_PREFIX variable in the below instructions.
    - Ensure when you run `terraform apply` that you commit and push the `terraform.tfstate` file to github
 1. Clone and `cd deploy-sourcegraph-managed/`
 1. Set variables:
    - `export VERSION=vMAJOR.MINOR.PATH`
    - `export COMPANY=$COMPANY`
-   - `export PROJECT_ID=sourcegraph-managed-$COMPANY`
+   - `export PROJECT_PREFIX=sourcegraph-managed` (should match GCP project prefix)
+   - `export PROJECT_ID=$PROJECT_PREFIX-$COMPANY`
    - `export TF_VAR_opsgenie_webhook=<OpsGenie Webhook value>`
      - This can be found in the [Managed Instances vault](https://my.1password.com/vaults/nwbckdjmg4p7y4ntestrtopkuu/allitems/d64bhllfw4wyybqnd4c3wvca2m)
 1. Check out a new branch: `git checkout -b $COMPANY/create-instance`

--- a/content/departments/product-engineering/engineering/cloud/delivery/managed/suspend_process.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/managed/suspend_process.md
@@ -30,7 +30,9 @@ Many of the following commands in this guide, as well as the commands [operation
 ```sh
 # name of customer deployment (should match folder)
 export CUSTOMER=<customer_or_instance_name>
-export CURRENT_DEPLOYMENT=$(gcloud compute instances list --project=sourcegraph-managed-${CUSTOMER} | grep -v "executors" | awk 'NR>1 { if ($1 ~ "-red-") print "red"; else print "black"; }')
+# should match GCP project prefix - typically the default is correct
+export PROJECT_PREFIX=sourcegraph-managed
+export CURRENT_DEPLOYMENT=$(gcloud compute instances list --project=${PROJECT_PREFIX}-${CUSTOMER} | grep -v "executors" | awk 'NR>1 { if ($1 ~ "-red-") print "red"; else print "black"; }')
 # The value can be found in the Managed Instances vault
 # https://my.1password.com/vaults/nwbckdjmg4p7y4ntestrtopkuu/allitems/d64bhllfw4wyybqnd4c3wvca2m
 export TF_VAR_opsgenie_webhook=<OpsGenie Webhook value>

--- a/content/departments/product-engineering/engineering/cloud/delivery/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/managed/upgrade_process.md
@@ -57,8 +57,10 @@ export CUSTOMER=<customer_or_instance_name>
 export SRC_ENDPOINT=http://localhost:4444
 # see 1password "$CUSTOMER admin account", under "token" field
 export SRC_ACCESS_TOKEN=$TOKEN
+# should match GCP project prefix - typically the default is correct
+export PROJECT_PREFIX=sourcegraph-managed
 # currently live instance
-export OLD_DEPLOYMENT=$(gcloud compute instances list --project=sourcegraph-managed-${CUSTOMER} | grep -v "executors" | awk 'NR>1 { if ($1 ~ "-red-") print "red"; else print "black"; }')
+export OLD_DEPLOYMENT=$(gcloud compute instances list --project=${PROJECT_PREFIX}-${CUSTOMER} | grep -v "executors" | awk 'NR>1 { if ($1 ~ "-red-") print "red"; else print "black"; }')
 # the instance we will create
 export NEW_DEPLOYMENT=$([ "$OLD_DEPLOYMENT" = "red" ] && echo "black" || echo "red")
 ```


### PR DESCRIPTION
The new insightstest project had too long a name, so I condensed it to `sg-managed-insightest`. This broke some of the upgrade scripts that assumed a project was named `sourcegraph-managed-<x>`.

Companion PR for the scripts: https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/299. The scripts default to `sourcegraph-managed` if nothing is set, so most of the time it's not even necessary to configure this variable.