### PR TITLE
add release retro to handbook

### DIFF
--- a/content/departments/product-engineering/engineering/process/releases/index.md
+++ b/content/departments/product-engineering/engineering/process/releases/index.md
@@ -53,6 +53,7 @@ The release captain should create a tracking issue using the [release issue temp
 Release captain responsibilities are currently owned by the [Release guild](release_guild.md).
 
 #### Release Retrospective
+
 The release captain is responsible to start an async release retrospective for every release. Typically this will be in a google document located in the [Release Guild folder in Google Drive](https://drive.google.com/drive/folders/1KMGL2iS8yuBHU-fJsTqb8lIqyHcO75nB?usp=sharing). We perform these retrospectives so that we can understand and grow. The long term vision is to improve this release process, and to do so we need to gather information about each release.
 
 The retrospective document should be shared in #release-guild.

--- a/content/departments/product-engineering/engineering/process/releases/index.md
+++ b/content/departments/product-engineering/engineering/process/releases/index.md
@@ -52,6 +52,11 @@ The release captain should create a tracking issue using the [release issue temp
 
 Release captain responsibilities are currently owned by the [Release guild](release_guild.md).
 
+#### Release Retrospective
+The release captain is responsible to start an async release retrospective for every release. Typically this will be in a google document located in the [Release Guild folder in Google Drive](https://drive.google.com/drive/folders/1KMGL2iS8yuBHU-fJsTqb8lIqyHcO75nB?usp=sharing). We perform these retrospectives so that we can understand and grow. The long term vision is to improve this release process, and to do so we need to gather information about each release.
+
+The retrospective document should be shared in #release-guild.
+
 ### Release tooling
 
 The [Sourcegraph release tool] is used to generate releases as associated materials (such as tracking issues).


### PR DESCRIPTION
Adds a section about the release retrospective to the release captain duties.