### PR TITLE
Remove references to IC7 from career development framework

### DIFF
--- a/content/departments/product-engineering/engineering/career-development/framework.md
+++ b/content/departments/product-engineering/engineering/career-development/framework.md
@@ -4,7 +4,7 @@ Our career development framework is here to help you understand the expectations
 
 ## What are the expectations of my role?
 
-There are currently seven levels for software engineers at Sourcegraph. A level is composed of three categories, each with a summary statement and several example behaviors. These categories are:
+There are currently six levels for software engineers at Sourcegraph. A level is composed of three categories, each with a summary statement and several example behaviors. These categories are:
 
 - Proficiency
 - Execution
@@ -112,10 +112,10 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     padding: 2.5rem;
   }
   /*
-  Safari doesn't make the two IC6/IC7 rows equal size automatically, so give them explicit heights
+  Safari doesn't make the two IC6 rows equal size automatically, so give them explicit heights
   Note that min-height also doesn't work.
   */
-  th#ic6, th#ic7 {
+  th#ic6 {
     height: 11rem;
   }
 </style>

--- a/content/departments/product-engineering/engineering/career-development/framework.md
+++ b/content/departments/product-engineering/engineering/career-development/framework.md
@@ -112,7 +112,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     padding: 2.5rem;
   }
   /*
-  Safari doesn't make the IC6 row equal size automatically, so give them explicit heights
+  Safari doesn't make the IC6 row equal size automatically, so give it explicit height.
   Note that min-height also doesn't work.
   */
   th#ic6 {

--- a/content/departments/product-engineering/engineering/career-development/framework.md
+++ b/content/departments/product-engineering/engineering/career-development/framework.md
@@ -112,7 +112,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     padding: 2.5rem;
   }
   /*
-  Safari doesn't make the two IC6 rows equal size automatically, so give them explicit heights
+  Safari doesn't make the IC6 row equal size automatically, so give them explicit heights
   Note that min-height also doesn't work.
   */
   th#ic6 {


### PR DESCRIPTION
Removes references to IC7 that was itself removed in #2353 