### PR TITLE
Fix glossary schema

### DIFF
--- a/schema/glossary.schema.json
+++ b/schema/glossary.schema.json
@@ -2,14 +2,17 @@
   "type": "object",
   "additionalProperties": {
     "type": "array",
-    "properties": {
-      "term": {
-        "type": "string"
+    "items": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "string"
+        }
       },
-      "definition": {
-        "type": "string"
-      }
-    },
-    "required": ["title", "definition"]
+      "required": ["term", "definition"]
+    }
   }
 }


### PR DESCRIPTION
Schema was incorrect, this should fix it and prevent the warning when running validation.