### PR TITLE
remove handbook hacking hours

### DIFF
--- a/content/handbook/editing/editing-the-handbook-product.md
+++ b/content/handbook/editing/editing-the-handbook-product.md
@@ -46,7 +46,7 @@ The Handbook is part of the [Content Platform team strategy](../../strategy-goal
 
 **Owner:** Handbook Team
 
-**Contributions:** The Handbook team aggregates feedback on the Handbook publishing process and logs issues in [Github](https://github.com/sourcegraph/handbook/issues). Work on these issues may occur ad hoc during [Handbook Hacking Hours](../index.md#handbook-hacking-hours) or as part of the [Content Platform team strategy](../../strategy-goals/strategy/enablement/content-platform/index.md). Raise any questions, feedback or concerns in the #handbook channel.
+**Contributions:** The Handbook team aggregates feedback on the Handbook publishing process and logs issues in [Github](https://github.com/sourcegraph/handbook/issues). Work on these issues occur as part of the [Content Platform team strategy](../../strategy-goals/strategy/enablement/content-platform/index.md). Raise any questions, feedback or concerns in the #handbook channel.
 
 ### Product Engineering & Deployment
 

--- a/content/handbook/index.md
+++ b/content/handbook/index.md
@@ -65,13 +65,9 @@ The handbook consists of Markdown files in the Git repository at github.com/sour
 
 ## Handbook Support
 
-### Handbook support in Slack
+### Slack
 
 Contact @handbook-support in the #handbook channel for help with the Handbook. @handbook-support is a volunteer-based group of Sourcegraph teammates that are passionate about the Handbook and eager to help. Join the @handbook-support group in Slack if you're interested in helping in this capacity.
-
-### Handbook Hacking Hours
-
-Handbook Hacking Hours are held every other Monday at 15:00 UTC, open to all Sourcegraph teammates to work on the Handbook website. We usually work through [Handbook Issues](https://github.com/sourcegraph/handbook/projects/1). The goal is to create some dedicated time to talk handbook, try things out, make it better, fail at things together, etc.
 
 ## Handbook feedback
 


### PR DESCRIPTION
Due to lack of attendance for the last few sessions, Handbook hacking hours are being removed from the calendar. These were created before the existence of the Content Platform Team, when we didn't have dedicated teammates to work on the handbook product. Now, with a dedicated team, we can make progress on these things as part of normal work planning.