### PR TITLE
Changes to delivery team

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -1,10 +1,10 @@
 # Delivery team
 
-Delivery team is a part of the [DevOps](../devops/index.md) team (part of the [Cloud](../index.md) org).
+Delivery team is a part of  the [Cloud](../index.md) org.
 
 ## Mission
 
-Enable any Sourcegraph customer or user to trial or run (in production) Sourcegraph in a way fits within their environment, supports their level of technical expertise and allows them to easily access the value that our product provides. Make it as easy as possible to access this value, and to maintain it going forwards by easily staying up to date with Sourcegraph's latest developments.
+Enable any Sourcegraph customer or user to trial or run (in production) Sourcegraph in a way that is compatible with their environment, supports their level of technical expertise, and allows them to easily access the value that our product provides. Make it as easy as possible to access this value, and to maintain it going forwards by easily staying up to date with Sourcegraph's latest developments.
 
 ## Members
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -8,7 +8,7 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 
 ## Members
 
-{{generator:product_team.devops}}
+{{generator:product_team.delivery}}
 
 ## Strategy
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -1,6 +1,6 @@
 # Delivery team
 
-Delivery team is a part of  the [Cloud](../index.md) org.
+Delivery team is a part of the [Cloud](../index.md) org.
 
 ## Mission
 

--- a/content/departments/product-engineering/engineering/cloud/devops/index.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/index.md
@@ -1,12 +1,6 @@
 # Cloud DevOps Team
 
-Cloud DevOps team consists of two streams with different focus area.
-
-- DevOps
-- [Delivery]
-
-If you're looking for DevOps stream documentation, stay on this page.
-If you're looking for [Delivery] specific documentation, visit this [page](../delivery/index.md).
+If you're looking for [Delivery] documentation instead of DevOps, visit this [page](../delivery/index.md).
 
 ## Vision
 

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -101,7 +101,7 @@ devops:
 delivery:
   title: Delivery
   strategy_link: /strategy-goals/strategy/enablement/delivery/index.md
-  product_org:
+  product_org: cloud
   pm: dan_mckean
   em: virginia_ulrich
   issue_labels:

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -91,7 +91,6 @@ cloud_saas:
 
 devops:
   title: DevOps
-  strategy_link:
   product_org: cloud
   pm: bill_creager
   em: jennifer_mitchell

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -90,13 +90,21 @@ cloud_saas:
     - team/cloud-saas
 
 devops:
-  title: DevOps (and Delivery)
-  strategy_link: /strategy-goals/strategy/enablement/delivery/index.md
+  title: DevOps
+  strategy_link: 
   product_org: cloud
   pm: bill_creager
   em: jennifer_mitchell
   issue_labels:
     - team/devops
+    
+delivery:
+  title: Delivery
+  strategy_link: /strategy-goals/strategy/enablement/delivery/index.md
+  product_org:
+  pm: dan_mckean
+  em: virginia_ulrich
+  issue_labels:
     - team/delivery
 
 dev_experience:

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -91,13 +91,13 @@ cloud_saas:
 
 devops:
   title: DevOps
-  strategy_link: 
+  strategy_link:
   product_org: cloud
   pm: bill_creager
   em: jennifer_mitchell
   issue_labels:
     - team/devops
-    
+
 delivery:
   title: Delivery
   strategy_link: /strategy-goals/strategy/enablement/delivery/index.md

--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -91,6 +91,7 @@ cloud_saas:
 
 devops:
   title: DevOps
+  strategy_link: /departments/product-engineering/engineering/cloud/devops/#goals
   product_org: cloud
   pm: bill_creager
   em: jennifer_mitchell


### PR DESCRIPTION
Separate out Delivery from DevOps. 
Small tweaks to the Delivery team page.