### PR TITLE
Clarify IC5 reporting structure

### DIFF
--- a/content/departments/product-engineering/engineering/career-development/ic5/index.md
+++ b/content/departments/product-engineering/engineering/career-development/ic5/index.md
@@ -32,3 +32,7 @@ If the new IC5 profile represents the promotion of an existing teammate, the EM 
 - [Code Intelligence - Platform](./code-intelligence-platform.md)
 - [Search Core](./search-core.md)
 - [Search Product](./search-product.md)
+
+## Reporting structure
+
+The nature of some IC5 roles may impact their reporting structure. For instance, an IC5 dedicated to problem-solving at the org level, who frequently navigates between teams, may report to the org's Director rather than to an Engineering Manager. Conversely, IC5s focused on with a deep technical problem area will still report to the Engineering Manager of the owning team for said problem area.

--- a/content/departments/product-engineering/engineering/career-development/ic5/index.md
+++ b/content/departments/product-engineering/engineering/career-development/ic5/index.md
@@ -35,4 +35,4 @@ If the new IC5 profile represents the promotion of an existing teammate, the EM 
 
 ## Reporting structure
 
-The nature of some IC5 roles may impact their reporting structure. For instance, an IC5 dedicated to problem-solving at the org level, who frequently navigates between teams, may report to the org's Director rather than to an Engineering Manager. Conversely, IC5s focused on with a deep technical problem area will still report to the Engineering Manager of the owning team for said problem area.
+The nature of some IC5 roles may impact their reporting structure. For instance, an IC5 dedicated to problem-solving at the org level, who frequently navigates between teams, may report to the org's Director rather than to an Engineering Manager. Conversely, IC5s focused on a deeply technical problem area will still report to the Engineering Manager of the owning team for the problem area.


### PR DESCRIPTION
I've heard confusion around the reporting structure for IC5 roles; this PR documents the current state.