### PR TITLE
Refactor delivery team page

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -19,7 +19,7 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 - Deployments methods (e.g. docker, kustomize, helm)
 - [Customer deployments and docs](https://docs.sourcegraph.com/admin/install)
 - [Managed instances](./managed/index.md)
-- ~~[Sourcegraph releases](../../process/releases/index.md)~~ releases are owned by the [release guild](../../process/releases/release_guild)
+- ~~[Sourcegraph releases](../../process/releases/index.md)~~ releases are owned by the [release guild](../../process/releases/release_guild.md)
 - Deployment configuration and configuration orchestration ([Kustomize](https://docs.sourcegraph.com/admin/install/kubernetes))
 
 ## Contact
@@ -29,11 +29,11 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 
 ## Support
 
-If in doubt about the process, please ask in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX). Delivery teammates shold consult our [on-call rotation](./processes#on-call-rotation) guide to handle inquiries.
+If in doubt about the process, please ask in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX). Delivery teammates shold consult our [on-call rotation](./processes.md#on-call-rotation) guide to handle inquiries.
 
 ### Requesting our support
 
-Feel free to direct simple questions to us in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) in Slack.
+Feel free to direct simple questions to us in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) in Slack. As a rule of thumb, anything that is not documented in our handbook or [docsite](https://docs.sourcegraph.com/) usually indicates it is not a simple question (e.g. feature requests) and should follow our [support request guidelines](./#support-request-guidelines) below.
 
 - This channel _is_ regularly checked and well-monitored
 - So please do **NOT** directly message or CC an engineer—this is to try and protect their focus

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -19,7 +19,7 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 - Deployments methods (e.g. docker, kustomize, helm)
 - [Customer deployments and docs](https://docs.sourcegraph.com/admin/install)
 - [Managed instances](./managed/index.md)
-- ~~[Sourcegraph releases](../../process/releases/index.md)~~ releases are owned by the [release guild](../../process/releases/release_guild.md)
+- ~~[Sourcegraph releases](../../process/releases/index.md)~~ releases are owned by the [Release Guild](../../process/releases/release_guild.md) and the Delivery provides support to the Release Guild.
 - Deployment configuration and configuration orchestration ([Kustomize](https://docs.sourcegraph.com/admin/install/kubernetes))
 
 ## Contact

--- a/content/departments/product-engineering/engineering/cloud/delivery/index.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/index.md
@@ -16,32 +16,56 @@ Enable any Sourcegraph customer or user to trial or run (in production) Sourcegr
 
 ## Responsibilities
 
-- Deployments methods
+- Deployments methods (e.g. docker, kustomize, helm)
 - [Customer deployments and docs](https://docs.sourcegraph.com/admin/install)
 - [Managed instances](./managed/index.md)
-- ~~[Sourcegraph releases](../../process/releases/index.md)~~
+- ~~[Sourcegraph releases](../../process/releases/index.md)~~ releases are owned by the [release guild](../../process/releases/release_guild)
 - Deployment configuration and configuration orchestration ([Kustomize](https://docs.sourcegraph.com/admin/install/kubernetes))
-
-Specifically not included:
-
-- The release pipeline that serves sourcegraph.com - [Cloud Software-as-a-Service Team](../../cloud/devops/index.md)
 
 ## Contact
 
-- [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) channel or @delivery-team in Slack.
-- [team/delivery](https://github.com/sourcegraph/sourcegraph/labels/team%2Fdelivery) label and @sourcegraph/delivery team on GitHub.
+- [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) channel, or `@delivery-support` in Slack. Please follow our [support guidelines](#support-request-guidelines) below.
+- [team/delivery](https://github.com/sourcegraph/sourcegraph/labels/team%2Fdelivery) label and [@sourcegraph/delivery](https://github.com/orgs/sourcegraph/teams/delivery) team on GitHub.
 
-## Growth plan
+## Support
+
+If in doubt about the process, please ask in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX). Delivery teammates shold consult our [on-call rotation](./processes#on-call-rotation) guide to handle inquiries.
+
+### Requesting our support
+
+Feel free to direct simple questions to us in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) in Slack.
+
+- This channel _is_ regularly checked and well-monitored
+- So please do **NOT** directly message or CC an engineer—this is to try and protect their focus
+- Instead, if it’s urgent, please @ either the PM or the EM in the question in the channel and we'll ensure it gets the best response
+
+### Support request guidelines
+
+Support requests related to our [areas of ownership](index.md#responsibilities) should follow this process:
+
+1. Make sure there is an issue—if there's not, please create one and include:
+   - A short description of the ask
+   - A more detailed explanation of the background, the context and the challenge that needs solving
+   - Any guidance related to the impact this is having
+   - Any extra information that could help us solve or prioritize this
+2. Ensure lable `team/delivery` is added to the issue
+3. Ensure that the issue is added to the "[Delivery](https://github.com/orgs/sourcegraph/projects/205)" board in GitHub
+4. Anything without a status is checked and triaged weekly - so this is enough for feature requests or less urgent issues
+5. If you think this needs eyes 👀 sooner
+   - Within a few hours ➡️ message in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX)
+   - ASAP ➡️ message in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) and CC `@delivery-support`
+
+<!-- ## Growth plan
 
 TODO
 
 ## Tech stack
 
-TODO
+TODO-->
 
 ## Principles
 
-We inherit Sourcegraph's [engineering principles and practices](../../process/principles-and-practices.md) and [Enablement org's principles and practices](../index.md#principles-and-practices).
+We inherit Sourcegraph's [engineering principles and practices](../../process/principles-and-practices.md).
 
 We also have a set of [guiding principles](../../../../../strategy-goals/strategy/cloud/delivery/index.md#guiding-principles) that help inform our decision making about our stretegic and prioritization choices.
 

--- a/content/departments/product-engineering/engineering/cloud/delivery/processes.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/processes.md
@@ -1,33 +1,5 @@
 # Delivery Team Processes
 
-## Support
-
-If in doubt about the process, please ask in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX).
-
-### Requesting our support
-
-Feel free to direct simple questions to us in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) in Slack.
-
-- This channel _is_ regularly checked and well-monitored
-- So please do **NOT** directly message or CC an engineer—this is to try and protect their focus
-- Instead, if it’s urgent, please @ either the PM or the EM in the question in the channel and we'll ensure it gets the best response
-
-### Support request guidelines
-
-Support requests related to our [areas of ownership](index.md#responsibilities) should follow this process:
-
-1. Make sure there is an issue—if there's not, please create one and include:
-   - A short description of the ask
-   - A more detailed explanation of the background, the context and the challenge that needs solving
-   - Any guidance related to the impact this is having
-   - Any extra information that could help us solve or prioritize this
-2. Ensure lable `team/delivery` is added to the issue
-3. Ensure that the issue is added to the "[Delivery](https://github.com/orgs/sourcegraph/projects/205)" board in GitHub
-4. Anything without a status is checked and triaged weekly - so this is enough for feature requests or less urgent issues
-5. If you think this needs eyes 👀 sooner
-   - Within a few hours ➡️ message in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX)
-   - ASAP ➡️ message in [#delivery](https://sourcegraph.slack.com/archives/C02E4HE42BX) and CC `@delivery-support`
-
 ## How we work
 
 ### Planning, sync, & retro
@@ -40,13 +12,12 @@ This allows us to be flexible about what's up next, but still protect the sancti
 
 We still work in 2 week cycles, and have the following ceremonies:
 
-1. Planning (biweekly)
+<!-- TODO (2022-02-27): we should update this in the upcoming weeks when things are more planned out for FY23Q1  -->
+1. Sync (biweekly)
    - This is more of a "line up a queue of work in priority" exercise than it would be with sprints
    - By default, we make no time-based commitments, instead favouring a balance of strategic (long term) and tactical (short term repsonsive) work
    - This does not (and isn't intended to) prevent newly identified work from superceding what gets "planned"
-2. Sync (biweekly)
-   - This happens on the weeks we don't have planning, and is a check in on the plans and anything new
-3. Retro (biweekly)
+2. Retro (biweekly)
    - A review of what we did for learing purposes
 
 ### On-Call Rotation
@@ -62,8 +33,8 @@ The [Delivery GitHub project](https://github.com/orgs/sourcegraph/projects/205) 
 - [Needs More Info](#needs-more-info)
 - [Icebox](#icebox)
 - [Blocked](#blocked)
-- [Backlog][#backlog]
-- [Up Next][#up-next]
+- [Backlog](#backlog)
+- [Up Next](#up-next)
 - [In Progress](#in-progress)
 - [Wating/In Review](#wating-in-review)
 - [Complete](#complete)

--- a/content/departments/product-engineering/engineering/cloud/delivery/processes.md
+++ b/content/departments/product-engineering/engineering/cloud/delivery/processes.md
@@ -13,7 +13,8 @@ This allows us to be flexible about what's up next, but still protect the sancti
 We still work in 2 week cycles, and have the following ceremonies:
 
 <!-- TODO (2022-02-27): we should update this in the upcoming weeks when things are more planned out for FY23Q1  -->
-1. Sync (biweekly)
+
+1. Planning/Sync (weekly)
    - This is more of a "line up a queue of work in priority" exercise than it would be with sprints
    - By default, we make no time-based commitments, instead favouring a balance of strategic (long term) and tactical (short term repsonsive) work
    - This does not (and isn't intended to) prevent newly identified work from superceding what gets "planned"


### PR DESCRIPTION
Noticeable changes

- Move incoming support guidelines to team homepage. The audience of this section is teammates outside of our team, not necessarily how we (the Delivery) work. Also, it's easier to be found by others.
- Clarify what does not count as a "simple question", so we can make sure all inquiries have an issue created prior reaching out to us.

View rendered page here 
- https://deploy-preview-2544--sourcegraph-handbook.netlify.app/departments/product-engineering/engineering/cloud/delivery/
- https://deploy-preview-2544--sourcegraph-handbook.netlify.app/departments/product-engineering/engineering/cloud/delivery/processes/