### PR TITLE
Add link to roadmap tracker

### DIFF
--- a/content/departments/product-engineering/process/planning-process.md
+++ b/content/departments/product-engineering/process/planning-process.md
@@ -87,7 +87,7 @@ Guidelines:
 
 ## Monthly PMM roadmap update
 
-In addition to the monthly team update, each PM should update the [PMM roadmap deck](https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) (internal only) for their features at the same time. This deck contains a manually updated copy of the current plan, plus recently launched important customer-facing features from the OKR and roadmap tracker. In the future we may transition updating this to PMM, but for now its important product managers are involved in ensuring it is up to date and correct.
+In addition to the monthly team update, each PM should update the [PMM roadmap deck](https://docs.google.com/presentation/d/1o3R8WUIhzzRz0x5laTwVcizOzVWrMBe5MCAz74H45Ss/edit#slide=id.gf131fe1596_2_7) (internal only) for their features at the same time. This deck contains a manually updated copy of the current plan, plus recently launched important customer-facing features from the [roadmap tracker](https://github.com/orgs/sourcegraph/projects/214/views/21) (so be sure the tracker is also updated at this point, if you haven't already). In the future we may transition updating this to PMM, but for now its important product managers are involved in ensuring it is up to date and correct.
 
 ## Quarterly department retrospective
 


### PR DESCRIPTION
Also, be explicit about making sure you aren't copying out of date items from the tracker (this should be obvious, but being explicit is good). 

Merging directly as this should be non-controversial, just documenting more clearly how things work today.