### PR TITLE
Explicit requirements handling in SDLC

### DIFF
--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -2,7 +2,7 @@
 
 <span class="badge badge-note">SOC2/GN-98</span>
 
-Sourcegraph uses three types of approaches to drive changes.
+Sourcegraph uses three types of approaches to drive changes:
 
 - [Product Documents](../product/process/product_documents.md) to communicate high-level product problems that need to be solved. All PDs are available in our [public Google Drive folder](https://drive.google.com/drive/folders/1UbuN9izpTj7ppJiduKI5tid8GEFuAiEx).
   - See also the [product process](../product/process/index.md).

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -2,33 +2,37 @@
 
 <span class="badge badge-note">SOC2/GN-98</span>
 
-Sourcegraph uses three types of approaches to drive changes:
+Sourcegraph uses three types of approaches to drive changes (either a new feature or extending an existing one).
 
 - [Product Documents](../product/process/product_documents.md) to communicate high-level product problems that need to be solved. All PDs are available in our [public Google Drive folder](https://drive.google.com/drive/folders/1UbuN9izpTj7ppJiduKI5tid8GEFuAiEx).
 - [Request For Comments](../../../company-info-and-process/communication/rfcs/index.md) to communicate technical problems or specific solutions in response to a Product Document.
 - Tickets (GitHub, GitHub discussions, JIRA, ...) and Pull Requests to communicate targeted technical problems or solutions, possibly (but not always) in response to RFCs or PDs.
 
-Sourcegraph follows an agile process, which means that the teams go through repeated iterations on a solution in order to refine results and adapt to changes discovered during each phase.
+Sourcegraph follows an agile process, which means that the teams go through repeated iterations on a solution in order to refine results and adapt to changes discovered during each phase. Learn more about the [product process](../product/process/index.md).
 
 ## Design
 
-Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work progresses.
+Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work requirements gathering progresses. 
 
 The outcome of the design step is an updated Product Document that links to design work and user research that supports it. The design team follows [product design principles](../product/design/index.md) and iteratively solidifies its work into deliverables that can be shipped in order to measure and evaluate the solution design.
+
+When an RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements. 
 
 A detailed version of the [design process](../product/design/design_process.md) is available. This process may also include engineering discovery work that explores the problem space to frame the right boundaries for the implementation phase and to surface potential problems as soon as possible.
 
 ## Implementation
 
-With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice.
+With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice. This optionally takes the form of a [tracking issue](../process/tracking_issues/index.md). Embedding security in the developement process, [security ambassadors](../engineering/cloud/security/#security-ambassador-program) are present to provide early feedback and assistance on security related requirements. 
 
-Engineering teams iterate and plan the implementation of these units of work on their own time. The Product Manager is ultimately responsible for the conformance of the result to the requirements stated in the Product Document, though an Engineering Manager or Engineer may also lead the work in this manner.
+Engineering teams iterate and plan the implementation of these units of work on their own time. The Product Manager is ultimately responsible for the conformance of the result to the requirements stated in the Product Document or RFC, though an Engineering Manager or Engineer can also lead the work.
 
 If complex problems surface during this step, an RFC can be created to frame the discussions around that particular problem to provide an adequate solution.
 
-## Testing
+## Verification and Testing
 
-The testing phase ensures conformance to the requirements stated in the Product Document/RFC/Ticket and to appropriate standards for service and security. Security is evaluated through automated [vulnerability scanning and SAST](../../product-engineering/engineering/cloud/security/tooling/index.md#cicd-pipeline-vulnerability-scanning) during continuous integration.
+The testing phase ensures conformance to the requirements stated in the Product Document/RFC/Ticket and to appropriate standards for service and security. The solution is scrutized to evaluate if the requirements stated in the design phase are met.
+
+Security is evaluated through automated [vulnerability scanning and SAST](../../product-engineering/engineering/cloud/security/tooling/index.md#cicd-pipeline-vulnerability-scanning) during continuous integration.
 
 If necessary, the changes will be deployed on an internal Sourcegraph instance to be internally tried until enough confidence is reached.
 
@@ -40,3 +44,7 @@ Sourcegraph uses two different mechanisms to deploy its changes in production:
 
 - [Continuous deployments](../engineering/index.md#sourcegraph-deployments-and-other-developer-test-instances) on soucegraph.com
 - [Release-based model](../engineering/process/releases/index.md) for [managed instances](../engineering/cloud/delivery/managed/index.md).
+
+## Maintenance and monitoring
+
+The Product Manager and the owning team are in charge of ensuring that the newly introduced feature are meeting the requirements, observing the behaviour in the production environments through monitoring, feedback or bug reports from customers. If any incorrect behaviour is found or a requirement isn't met, they write corrective changes to fix those issues. 

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -5,10 +5,11 @@
 Sourcegraph uses three types of approaches to drive changes.
 
 - [Product Documents](../product/process/product_documents.md) to communicate high-level product problems that need to be solved. All PDs are available in our [public Google Drive folder](https://drive.google.com/drive/folders/1UbuN9izpTj7ppJiduKI5tid8GEFuAiEx).
+  - See also the [product process](../product/process/index.md).
 - [Request For Comments](../../../company-info-and-process/communication/rfcs/index.md) to communicate technical problems or specific solutions in response to a Product Document.
 - Tickets (GitHub, GitHub discussions, JIRA, ...) and Pull Requests to communicate targeted technical problems or solutions, possibly (but not always) in response to RFCs or PDs.
 
-Sourcegraph follows an agile process, which means that the teams go through repeated iterations on a solution in order to refine results and adapt to changes discovered during each phase. Learn more about the [product process](../product/process/index.md).
+Sourcegraph follows an agile process, which means that the teams go through repeated iterations on a solution in order to refine results and adapt to changes discovered during each phase.
 
 ## Design
 

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -2,7 +2,7 @@
 
 <span class="badge badge-note">SOC2/GN-98</span>
 
-Sourcegraph uses three types of approaches to drive changes (either a new feature or extending an existing one).
+Sourcegraph uses three types of approaches to drive changes.
 
 - [Product Documents](../product/process/product_documents.md) to communicate high-level product problems that need to be solved. All PDs are available in our [public Google Drive folder](https://drive.google.com/drive/folders/1UbuN9izpTj7ppJiduKI5tid8GEFuAiEx).
 - [Request For Comments](../../../company-info-and-process/communication/rfcs/index.md) to communicate technical problems or specific solutions in response to a Product Document.
@@ -47,4 +47,4 @@ Sourcegraph uses two different mechanisms to deploy its changes in production:
 
 ## Maintenance and monitoring
 
-The Product Manager and the owning team are in charge of ensuring that the newly introduced feature are meeting the requirements, observing the behaviour in the production environments through monitoring, feedback or bug reports from customers. If any incorrect behaviour is found or a requirement isn't met, they write corrective changes to fix those issues.
+The Product Manager and the owning team are in charge of ensuring that the newly introduced changes are meeting the requirements, observing the behaviour in the production environments through monitoring, feedback or bug reports from customers. If any incorrect behaviour is found or a requirement isn't met, they write corrective changes to fix those issues.

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -12,7 +12,7 @@ Sourcegraph follows an agile process, which means that the teams go through repe
 
 ## Design
 
-Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work requirements gathering progresses.
+Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work and gathering of requirements progresses.
 
 The outcome of the design step is an updated Product Document that links to design work and user research that supports it. The design team follows [product design principles](../product/design/index.md) and iteratively solidifies its work into deliverables that can be shipped in order to measure and evaluate the solution design.
 

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -17,7 +17,7 @@ Designing at Sourcegraph starts with a design document, which can be either a fo
 
 The outcome of the design step is an updated Product Document that links to design work and user research that supports it. The design team follows [product design principles](../product/design/index.md) and iteratively solidifies its work into deliverables that can be shipped in order to measure and evaluate the solution design.
 
-When an RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements.
+When a RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements.
 
 A detailed version of the [design process](../product/design/design_process.md) is available. This process may also include engineering discovery work that explores the problem space to frame the right boundaries for the implementation phase and to surface potential problems as soon as possible.
 

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -12,17 +12,17 @@ Sourcegraph follows an agile process, which means that the teams go through repe
 
 ## Design
 
-Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work requirements gathering progresses. 
+Designing at Sourcegraph starts with a design document, which can be either a formal PD or RFC, or an informal GitHub Issue or Google Doc that gets formalized into an RFC or PD as the explorative work requirements gathering progresses.
 
 The outcome of the design step is an updated Product Document that links to design work and user research that supports it. The design team follows [product design principles](../product/design/index.md) and iteratively solidifies its work into deliverables that can be shipped in order to measure and evaluate the solution design.
 
-When an RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements. 
+When an RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements.
 
 A detailed version of the [design process](../product/design/design_process.md) is available. This process may also include engineering discovery work that explores the problem space to frame the right boundaries for the implementation phase and to surface potential problems as soon as possible.
 
 ## Implementation
 
-With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice. This optionally takes the form of a [tracking issue](../engineering/process/tracking_issues.md). Embedding security in the developement process, [security ambassadors](../engineering/cloud/security/#security-ambassador-program) are present to provide early feedback and assistance on security related requirements. 
+With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice. This optionally takes the form of a [tracking issue](../engineering/process/tracking_issues.md). Embedding security in the developement process, [security ambassadors](../engineering/cloud/security/#security-ambassador-program) are present to provide early feedback and assistance on security related requirements.
 
 Engineering teams iterate and plan the implementation of these units of work on their own time. The Product Manager is ultimately responsible for the conformance of the result to the requirements stated in the Product Document or RFC, though an Engineering Manager or Engineer can also lead the work.
 
@@ -47,4 +47,4 @@ Sourcegraph uses two different mechanisms to deploy its changes in production:
 
 ## Maintenance and monitoring
 
-The Product Manager and the owning team are in charge of ensuring that the newly introduced feature are meeting the requirements, observing the behaviour in the production environments through monitoring, feedback or bug reports from customers. If any incorrect behaviour is found or a requirement isn't met, they write corrective changes to fix those issues. 
+The Product Manager and the owning team are in charge of ensuring that the newly introduced feature are meeting the requirements, observing the behaviour in the production environments through monitoring, feedback or bug reports from customers. If any incorrect behaviour is found or a requirement isn't met, they write corrective changes to fix those issues.

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -17,7 +17,7 @@ Designing at Sourcegraph starts with a design document, which can be either a fo
 
 The outcome of the design step is an updated Product Document that links to design work and user research that supports it. The design team follows [product design principles](../product/design/index.md) and iteratively solidifies its work into deliverables that can be shipped in order to measure and evaluate the solution design.
 
-When a RFC or PD reaches the [REVIEW](../product/process/product_documents/index.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements.
+When a RFC or PD reaches the [REVIEW](../product/process/product_documents.md#status) phase, reviewers and approvers scrutinize the proposed solution, seeking to establish it if meets the stated requirements.
 
 A detailed version of the [design process](../product/design/design_process.md) is available. This process may also include engineering discovery work that explores the problem space to frame the right boundaries for the implementation phase and to surface potential problems as soon as possible.
 
@@ -33,7 +33,7 @@ If complex problems surface during this step, an RFC can be created to frame the
 
 The testing phase ensures conformance to the requirements stated in the Product Document/RFC/Ticket and to appropriate standards for service and security. The solution is scrutized to evaluate if the requirements stated in the design phase are met.
 
-Security is evaluated through automated [vulnerability scanning and SAST](../../product-engineering/engineering/cloud/security/tooling/index.md#cicd-pipeline-vulnerability-scanning) during continuous integration.
+Security is evaluated through automated [vulnerability scanning and SAST](../../product-engineering/engineering/cloud/security/tooling/index.md#cicd-pipeline-vulnerability-scanning) during [continuous integration](https://docs.sourcegraph.com/dev/background-information/ci).
 
 If necessary, the changes will be deployed on an internal Sourcegraph instance to be internally tried until enough confidence is reached.
 

--- a/content/departments/product-engineering/process/sdlc.md
+++ b/content/departments/product-engineering/process/sdlc.md
@@ -22,7 +22,7 @@ A detailed version of the [design process](../product/design/design_process.md) 
 
 ## Implementation
 
-With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice. This optionally takes the form of a [tracking issue](../process/tracking_issues/index.md). Embedding security in the developement process, [security ambassadors](../engineering/cloud/security/#security-ambassador-program) are present to provide early feedback and assistance on security related requirements. 
+With the help of a Product Manager, the relevant engineering teams divide the necessary work into smaller tracked units of effort with the management system of their choice. This optionally takes the form of a [tracking issue](../engineering/process/tracking_issues.md). Embedding security in the developement process, [security ambassadors](../engineering/cloud/security/#security-ambassador-program) are present to provide early feedback and assistance on security related requirements. 
 
 Engineering teams iterate and plan the implementation of these units of work on their own time. The Product Manager is ultimately responsible for the conformance of the result to the requirements stated in the Product Document or RFC, though an Engineering Manager or Engineer can also lead the work.
 


### PR DESCRIPTION
@bobheadxi the requirements part of the SDLC wasn't explicit enough as per the feedback I got from the sec-team. Here is a reference link they shared: https://snyk.io/learn/secure-sdlc/ 

This PR addresses it through more precise wording without introducing changes in our process. 