### PR TITLE
Add logic for bio links to make them non-relative

### DIFF
--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -121,7 +121,7 @@ function rewriteLinkUrl(match: UrlMatch, contextUrlPath: string, isOnIndexPage: 
     }
 
     // Rewrite links on non-index pages to be relative
-    if (parsedUrl.pathname && !isOnIndexPage) {
+    if (parsedUrl.pathname && !isOnIndexPage && !parsedUrl.pathname.startsWith('/team')) {
         parsedUrl.pathname = `../${parsedUrl.pathname}`
     }
 


### PR DESCRIPTION
Closes #2606 by updating the logic we use to assign relative links. 

## Problem:

We need to add some logic to handle bio links that come from **both** non-index and index pages. We add these links in a programmatic way (like [here](https://github.com/sourcegraph/handbook/blob/a5136194fc8f0a349b8269490c106ff196d0f3a9/src/lib/generatedMarkdown.js#L18) for example) but we also update links to be [relative on non-index pages](https://github.com/sourcegraph/handbook/blob/a5136194fc8f0a349b8269490c106ff196d0f3a9/src/lib/markdownToHtml.ts#L123-L126), following work on #1822. Tl;dr: links to teammates from non-index pages don't work.

## To Test
- Hit a non-index page with an autogenerated chart and ensure that all links work: `/departments/product-engineering/engineering/code-graph/search/core/  ` for example
- Hit an index page and ^^: `/departments/product-engineering/engineering/cloud/devops/`
