### PR TITLE
Fix generated absolute links

### DIFF
--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -19,13 +19,6 @@ function createBioLink(name) {
   return `${bioLinkUrlPrefix}${String(createValidTeamAnchor(name))}`
 }
 
-function createRelativeProductLink(link) {
-  if (link.startsWith('http')) {
-    return link
-  }
-  return `../../../..${String(link)}`
-}
-
 export async function generateMaturityDefinitions() {
   const maturityLevels = await readYamlFile('data/maturity_levels.yml')
   let pageContent = ''
@@ -46,13 +39,12 @@ export async function generateFeatureMaturityLevels() {
     let featureCount = 0
     let areaContent = `\n### ${String(productTeam.title)}\n`
     if (productOrgs[productTeam.product_org].strategy_link) {
-      const strategyUrl = createRelativeProductLink(productOrgs[productTeam.product_org].strategy_link)
-      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(strategyUrl)}) | `
+      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(
+        productOrgs[productTeam.product_org].strategy_link
+      )}) | `
     }
     if (productTeam.strategy_link) {
-      areaContent += `[${String(productTeam.title)} Strategy](${String(
-        createRelativeProductLink(productTeam.strategy_link)
-      )}))\n`
+      areaContent += `[${String(productTeam.title)} Strategy](${String(productTeam.strategy_link)}))\n`
     }
     if (productTeam.pm) {
       const bioLink = createBioLink(teamMembers[productTeam.pm].name)
@@ -66,8 +58,7 @@ export async function generateFeatureMaturityLevels() {
       if (feature.product_team === productTeamName) {
         featureCount++
         if (feature.documentation_link) {
-          const url = createRelativeProductLink(feature.documentation_link)
-          areaContent += `|[${String(feature.title)}](${String(url)})`
+          areaContent += `|[${String(feature.title)}](${String(feature.documentation_link)})`
         } else {
           areaContent += `|${String(feature.title)}`
         }
@@ -93,13 +84,12 @@ export async function generateFeatureCodeHostCompatibilities() {
     let areaContent = `\n### ${String(productTeam.title)}\n`
     const productOrg = productOrgs[productTeam.product_org]
     if (productOrg.strategy_link) {
-      const strategyUrl = createRelativeProductLink(productOrg.strategy_link)
-      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(strategyUrl)}) | `
+      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(
+        productOrg.strategy_link
+      )}) | `
     }
     if (productTeam.strategy_link) {
-      areaContent += `[${String(productTeam.title)} Strategy](${String(
-        createRelativeProductLink(productTeam.strategy_link)
-      )}))\n`
+      areaContent += `[${String(productTeam.title)} Strategy](${String(productTeam.strategy_link)}))\n`
     }
     if (productTeam.pm) {
       const bioLink = createBioLink(teamMembers[productTeam.pm].name)
@@ -121,9 +111,7 @@ export async function generateFeatureCodeHostCompatibilities() {
       let featureContent = ''
       if (feature.product_team === productTeamName && feature.compatibility !== undefined) {
         if (feature.documentation_link) {
-          featureContent += `|[${String(feature.title)}](${String(
-            createRelativeProductLink(feature.documentation_link)
-          )})`
+          featureContent += `|[${String(feature.title)}](${String(feature.documentation_link)})`
         } else {
           featureContent += `|${String(feature.title)}`
         }
@@ -241,7 +229,7 @@ export async function generateProductTeamsList() {
   for (const [productOrgName, productOrg] of Object.entries(productOrgs)) {
     pageContent += `\n### ${String(productOrg.title)} org\n\n`
     if (productOrg.strategy_link) {
-      pageContent += `- [Strategy Page](${String(createRelativeProductLink(productOrg.strategy_link))})\n`
+      pageContent += `- [Strategy Page](${String(productOrg.strategy_link)})\n`
     }
     if (productOrg.strategy_link) {
       const bioLinkPM = createBioLink(teamMembers[productOrg.pm].name)
@@ -253,7 +241,7 @@ export async function generateProductTeamsList() {
       if (productTeam.product_org === productOrgName) {
         pageContent += `\n\n#### ${String(productTeam.title)} team\n`
         if (productTeam.strategy_link) {
-          pageContent += `- [Strategy Page](${String(createRelativeProductLink(productTeam.strategy_link))})\n`
+          pageContent += `- [Strategy Page](${String(productTeam.strategy_link)})\n`
         }
         if (productTeam.pm) {
           const bioLink = createBioLink(teamMembers[productTeam.pm].name)
@@ -455,13 +443,12 @@ export async function generateDeploymentOptions() {
     let areaContent = `\n### ${String(productTeam.title)}\n`
     const productOrg = productOrgs[productTeam.product_org]
     if (productOrg.strategy_link) {
-      const strategyUrl = createRelativeProductLink(productOrg.strategy_link)
-      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(strategyUrl)}) | `
+      areaContent += ` ([${String(productOrgs[productTeam.product_org].title)} Strategy](${String(
+        productOrg.strategy_link
+      )}) | `
     }
     if (productTeam.strategy_link) {
-      areaContent += `[${String(productTeam.title)} Strategy](${String(
-        createRelativeProductLink(productTeam.strategy_link)
-      )}))\n`
+      areaContent += `[${String(productTeam.title)} Strategy](${String(productTeam.strategy_link)}))\n`
     }
     if (productTeam.pm) {
       const bioLink = createBioLink(teamMembers[productTeam.pm].name)
@@ -482,7 +469,7 @@ export async function generateDeploymentOptions() {
       if (feature.product_team === productTeamName && feature.deployment !== undefined) {
         featureCount++
         if (feature.documentation_link) {
-          areaContent += `|[${String(feature.title)}](${String(createRelativeProductLink(feature.documentation_link))})`
+          areaContent += `|[${String(feature.title)}](${String(feature.documentation_link)})`
         } else {
           areaContent += `|${String(feature.title)}`
         }
@@ -515,17 +502,16 @@ export async function generateGuildRoster(guildReference) {
 
   pageContent += '## Members\n'
   const leaderReference = guild.leader
-  const teamLinkPrefix = '../../../../../'
   if (leaderReference) {
     const name = teamMembers[leaderReference].name
-    pageContent += `- [${String(name)}](${teamLinkPrefix}${String(createBioLink(name))}) - Guild Leader\n`
+    pageContent += `- [${String(name)}](${String(createBioLink(name))}) - Guild Leader\n`
   }
   for (const memberReference of guild.members) {
     if (memberReference === leaderReference) {
       continue
     }
     const name = teamMembers[memberReference].name
-    pageContent += `- [${String(name)}](${teamLinkPrefix}${String(createBioLink(name))})\n`
+    pageContent += `- [${String(name)}](${String(createBioLink(name))})\n`
   }
 
   return pageContent

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -120,9 +120,11 @@ function rewriteLinkUrl(match: UrlMatch, contextUrlPath: string, isOnIndexPage: 
         return
     }
 
-    // Rewrite links on non-index pages to be relative
+    // Rewrite links on non-index pages to be relative, excluding intentionally absolute oness
     if (parsedUrl.pathname && !isOnIndexPage) {
-        parsedUrl.pathname = `../${parsedUrl.pathname}`
+        if (parsedUrl.pathname[0] !== '/') {
+            parsedUrl.pathname = `../${parsedUrl.pathname}`
+        }
     }
 
     // Rewrite index.md references to point to the directory

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -122,7 +122,7 @@ function rewriteLinkUrl(match: UrlMatch, contextUrlPath: string, isOnIndexPage: 
 
     // Rewrite links on non-index pages to be relative, excluding intentionally absolute oness
     if (parsedUrl.pathname && !isOnIndexPage) {
-        if (parsedUrl.pathname[0] !== '/') {
+        if (!parsedUrl.pathname.startsWith('/')) {
             parsedUrl.pathname = `../${parsedUrl.pathname}`
         }
     }


### PR DESCRIPTION
The trailing slash detection fix (https://github.com/sourcegraph/handbook/commit/d4aa8316f5dc3b5febd8cec65686b3c0044ddaa8) was resulting in all generated links having an extra `../` in their URLs, making them invalid. This corrects it.