### PR TITLE
Add Stephen's GitHub handle

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -38,6 +38,7 @@ stephen_gutekanst:
   role: Internal Contributor / Software Engineer
   reports_to: director_engineering
   location: Phoenix, AZ, USA 🇺🇸
+  github: slimsag
   email: stephen@sourcegraph.com
   links: '[@slimsag](https://twitter.com/slimsag), [LinkedIn](https://www.linkedin.com/in/slimsag)'
   pronunciation: '[pronounce my name 🔊](https://www.name-coach.com/stephen-gutekanst)'


### PR DESCRIPTION
Was working with the [`team` package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/team/team.go?L27) and @slimsag handle was missing from this file. This fixes it :)