### PR TITLE
Add charter for #gender-diversity-allies cohort

### DIFF
--- a/content/company-info-and-process/communication/code_of_conduct.md
+++ b/content/company-info-and-process/communication/code_of_conduct.md
@@ -2,7 +2,7 @@
 
 Last updated: January 24, 2022
 
-Related: see "[Diversity, equity, and inclusion](dei.md)"
+Related: see "[Diversity, equity, and inclusion](../diversity-equity-and-inclusion/index.md)"
 
 The purpose of this Code is to promote responsible and ethical conduct in the way we run our business. We want this Code to help you respond to common ethical dilemmas and avoid pitfalls.
 

--- a/content/company-info-and-process/diversity-equity-and-inclusion/gender-diversity.md
+++ b/content/company-info-and-process/diversity-equity-and-inclusion/gender-diversity.md
@@ -1,0 +1,51 @@
+# Cohort for Gender Diversity in Tech at Sourcegraph
+
+_Known informally by the name of the group’s public Slack channel, [#gender-diversity-allies](https://sourcegraph.slack.com/archives/C02V14KPZQU)._
+
+## What is the cohort?
+
+The cohort is an employee-led opt-in group for fostering inclusivity, community, and connectedness amongst the members of engineering and engineering-adjacent organizations here at Sourcegraph who do not identify as cisgender male. The cohort fits the traditional definition of an “Employee Resource Group (ERG)” (a network of employees who share certain characteristics, background, or experiences that is sponsored by the organization they work for), but for the purposes of keeping the group’s methodology light and unrestrictive, we prefer in most settings to refer to it as a “cohort” instead.
+
+## Who can join the cohort?
+
+The spirit of this group is to celebrate gender diversity in tech! As such, any employee at Sourcegraph is welcome to join the cohort, regardless of how they identify, what organization they are part of, or whether their role is considered technical or non-technical. However, as the group was initially formed from within engineering and a large percentage of the group identify as engineers, prospective members can expect that some events and conversation will center around the experiences of engineers in the industry.
+
+Furthermore, this is not just a “women’s group”; though the majority of its members identify as women, the cohort is also committed to supporting trans, genderqueer/genderfluid/gender-nonconforming, and non-binary members of our community. To do so, the cohort recognizes that the experiences of cisgender women are not necessarily representative of folks of other gender identities that are targeted for oppression who are navigating the tech industry. As members of the cohort, we seek to proactively understand and embrace these differences, practice allyship towards members of the group who identify differently from us, unpack our own assumptions and subconscious biases, and resist the tendency to generalize or reinforce the notion of a gender binary. If you identify as a cisgender woman and want to improve upon how you show up as an ally for your trans, genderqueer/genderfluid/gender-nonconforming, and non-binary coworkers in and outside of this cohort, here are two good places to start: [[1](https://www.stonewall.org.uk/about-us/news/10-ways-step-ally-non-binary-people)] [[2](https://medium.com/@just.elise/how-to-build-a-trans-friendly-workplace-culture-allies-a2a6955b5597)].
+
+The group is opt-in, so no one is required to join the cohort or stick around if it is not their sort of thing.
+
+Allies who want to listen and learn are also encouraged to join the group. We ask that allies take extra care to consider how and why they want to show up in the group as well as the space they are taking up as they participate in it. As an ally, it is healthy to feel uneasy, uncertain, or uncomfortable in these spaces, and we encourage allies to orient their “why” around this discomfort and resisting the tendency to center themselves when being present feels hard. If you are interested in exploring how you can better serve the group as an ally, here are two good places to start: [[1](https://careerfoundry.com/en/blog/career-change/ally-women-in-tech/)] [[2](https://greatergood.berkeley.edu/article/item/nine_tips_for_being_a_male_ally_at_work)].
+
+As with anything here, anyone who participates in the cohort is expected to abide by Sourcegraph’s [code of conduct](../communication/code_of_conduct.md).
+
+## What is the mission of the cohort?
+
+Supporting diversity at Sourcegraph does not start and end with diversifying the talent pipeline. The mission of this cohort is to embrace our value of “[be welcoming and inclusive](../values/index.md#be-welcoming-and-inclusive)” by amplifying the voices of those who are systemically minimized and pressured to leave the industry on account of their gender identity or gender expression. In practice, this translates primarily to promoting a community where it is safe to acknowledge our adversities, celebrate our victories, and come together over our shared experiences. This also means providing structure to facilitate cross-team interactions and connections, as well as advocating for resources, practices, and policies that promote inclusion and equity for folks of every gender identity here at Sourcegraph.
+
+This group serves the needs of its members first and foremost. However, other positive outcomes of the group may include:
+
+- Higher retention and employee satisfaction ratings among members
+- Increased levels of psychological safety among members
+- Increased cross-team collaboration
+- Better insights into making inclusive product experiences
+- Increased rate of success attracting diverse talent
+- More fun 👀
+
+## How is the cohort operated?
+
+The cohort is still just getting started, and operations will likely evolve over time. The group is presently being led by [Kelli Rockwell](../../team/index.md#kelli-rockwell), software engineer from Batch Changes, with support from executive sponsor [Christina Forney](../../team/index.md#christina-forney), VP of Product. The cohort primarily operates out of its public slack channel, [#gender-diversity-allies](https://sourcegraph.slack.com/archives/C02V14KPZQU), with bi-weekly syncs to connect and discuss specific activities, ideas, and needs of its members. The cohort also has an opt-in private slack channel to function as a dedicated safe space for its members who aren’t participating as allies. Other activities of the cohort will be scoped out in time and may involve:
+
+- Virtual team-building activities
+- Members happy hour
+- Members pairing
+- In-person gatherings or meet-ups
+- Conferences
+- Invited speaker/internal speaker events
+- Readings/presentations
+- Community outreach
+
+## How do I participate in the cohort?
+
+Start by joining our public slack channel, [#gender-diversity-allies](https://sourcegraph.slack.com/archives/C02V14KPZQU)! By joining the channel, you will also be invited to any public events that the cohort is hosting. Announcements and general discussion are encouraged in the public channel.
+
+If you would also like to join our private slack channel, you can fill out [this form](https://forms.gle/71YXaxz8WX1Mmbkw5) to receive an invite automatically. We ask allies to refrain from joining the private one so that those who are present in it feel the most comfortable expressing themselves and speaking freely. Think of the private channel as your place to vent or get advice. 🙂 However, to maintain an environment of respect, we also ask that members of the private channel refrain from discussing non-members by name.

--- a/content/company-info-and-process/diversity-equity-and-inclusion/index.md
+++ b/content/company-info-and-process/diversity-equity-and-inclusion/index.md
@@ -1,8 +1,15 @@
 # Diversity, Equity, and Inclusion
 
-## How we create an environment where everyone feels welcome and has equal opportunity
+## Resources
 
-> At Sourcegraph, we want to make it so [everyone can code](../../strategy-goals/strategy/index.md), so that technology's benefits reach the whole world. To do that, and to even understand what's necessary to do that, our team needs to represent a diverse set of perspectives, experiences, and backgrounds. We also believe that talent is equally distributed, so we strive for our team to demonstrate that by being inclusive of and equitable toward all people. This page describes our efforts and commitments to work toward these outcomes, and we expect to improve and expand our plans here as we learn and grow.
+- [Gender Diversity Allies and ERG](./gender-diversity.md)
+- [Personal pronouns](./personal-pronouns.md)
+
+## Strategy
+
+### How we create an environment where everyone feels welcome and has equal opportunity
+
+> At Sourcegraph, we want to make it so [everyone can code](../../strategy-goals/strategy/index.md#purpose), so that technology's benefits reach the whole world. To do that, and to even understand what's necessary to do that, our team needs to represent a diverse set of perspectives, experiences, and backgrounds. We also believe that talent is equally distributed, so we strive for our team to demonstrate that by being inclusive of and equitable toward all people. This page describes our efforts and commitments to work toward these outcomes, and we expect to improve and expand our plans here as we learn and grow.
 
 — Quinn Slack (CEO/co-founder)
 

--- a/content/company-info-and-process/diversity-equity-and-inclusion/personal-pronouns.md
+++ b/content/company-info-and-process/diversity-equity-and-inclusion/personal-pronouns.md
@@ -4,9 +4,9 @@ To help make everyone feel welcome at Sourcegraph, we ask everyone to use people
 
 Some may choose to use singular “they” pronouns, e.g.:
 
-- "X would probably love these extra adorable pictures I took of my cat today, I should send them some!""
-- "X deleted all the databases and their backups!? How did they even do that?
-- "I should ask X to make me a playlist, their music is always so groovy!""
+- "X would probably love these extra adorable pictures I took of my cat today, I should send them some!"
+- "X deleted all the databases and their backups!? How did they even do that?"
+- "I should ask X to make me a playlist, their music is always so groovy!"
 
 Other [enby](https://www.dictionary.com/e/gender-sexuality/enby/) pronouns include: ze/hir, co/cos, xe/xem/xyr, hy/hym/hys, or no pronoun and using that person’s name instead.
 

--- a/content/company-info-and-process/index.md
+++ b/content/company-info-and-process/index.md
@@ -12,6 +12,7 @@ This area of the Handbook is dedicated to information about Sourcegraph, working
 
 ## [Diversity, Equity, and Inclusion](diversity-equity-and-inclusion/index.md)
 
+- [Gender Diversity Allies and ERG](diversity-equity-and-inclusion/gender-diversity.md)
 - [Personal pronouns](diversity-equity-and-inclusion/personal-pronouns.md)
 
 ## [Communication](communication/index.md)

--- a/content/company-info-and-process/index.md
+++ b/content/company-info-and-process/index.md
@@ -10,6 +10,10 @@ This area of the Handbook is dedicated to information about Sourcegraph, working
 
 - [Customer-first](values/customer-first.md)
 
+## [Diversity, Equity, and Inclusion](diversity-equity-and-inclusion/index.md)
+
+- [Personal pronouns](diversity-equity-and-inclusion/personal-pronouns.md)
+
 ## [Communication](communication/index.md)
 
 - [Announcements](communication/announcements.md)
@@ -18,12 +22,10 @@ This area of the Handbook is dedicated to information about Sourcegraph, working
 - [Conflicts](communication/conflicts.md)
 - [Content Guidelines](communication/content_guidelines/index.md)
 - [Customer ethics](communication/customer_ethics.md)
-- [Diversity, Equity, Inclusion](communication/dei.md)
 - [Feedback](communication/seeking-and-giving-feedback.md)
 - Meetings
   - [1-1](communication/1-1.md)
   - [Company meeting](communication/company_meeting.md)
-- [Personal Pronouns](communication/personal-pronouns.md)
 - [Retrospectives](communication/retrospectives.md)
 - [RFCs](communication/rfcs/index.md)
 - [Slack](communication/team_chat.md)

--- a/content/company-info-and-process/values/index.md
+++ b/content/company-info-and-process/values/index.md
@@ -71,9 +71,7 @@ We view equity and inclusion as foundational elements to our culture, our succes
 - We all have unconscious biases we need to confront.
 - Good people can say and do biased or racist things (and this doesn’t automatically make them bad people).
 - Diversity supports our moral values and practical goals and we cannot truly have diversity without also having equity and inclusion.
-- We consider a focus on diversity, equity, and inclusion a critical job function of all leaders at Sourcegraph.
-
-For more information, see our "[Diversity, equity, and inclusion](../communication/dei.md)".
+- We consider a focus on [diversity, equity, and inclusion](../diversity-equity-and-inclusion/index.md) a critical job function of all leaders at Sourcegraph.
 
 ### Open and transparent
 

--- a/content/departments/people-ops/index.md
+++ b/content/departments/people-ops/index.md
@@ -132,8 +132,8 @@ See how we manage project and updates [here](process/people-ops-project-manageme
 
 ## DEI
 
-- [Diversity, equity, and inclusion](../../company-info-and-process/communication/dei.md)
-- [Personal Pronouns](../../company-info-and-process/communication/personal-pronouns.md)
+- [Diversity, equity, and inclusion](../../company-info-and-process/diversity-equity-and-inclusion/index.md)
+- [Personal Pronouns](../../company-info-and-process/diversity-equity-and-inclusion/personal-pronouns.md)
 
 ## Wellbeing
 

--- a/content/index.md
+++ b/content/index.md
@@ -42,6 +42,7 @@ The handbook is a living document and we expect every teammate to propose improv
 - [All-remote](company-info-and-process/remote/index.md)
 - [Values](company-info-and-process/values/index.md)
 - [Diversity, Equity, and Inclusion](company-info-and-process/diversity-equity-and-inclusion/index.md)
+  - [Gender Diversity Allies and ERG](company-info-and-process/diversity-equity-and-inclusion/gender-diversity.md)
 - [Communication](company-info-and-process/communication/index.md)
   - [Content guidelines](company-info-and-process/communication/content_guidelines/index.md)
   - [RFCs](company-info-and-process/communication/rfcs/index.md)

--- a/content/index.md
+++ b/content/index.md
@@ -41,6 +41,7 @@ The handbook is a living document and we expect every teammate to propose improv
 - [General office information](company-info-and-process/about-sourcegraph/general-office-info.md)
 - [All-remote](company-info-and-process/remote/index.md)
 - [Values](company-info-and-process/values/index.md)
+- [Diversity, Equity, and Inclusion](company-info-and-process/diversity-equity-and-inclusion/index.md)
 - [Communication](company-info-and-process/communication/index.md)
   - [Content guidelines](company-info-and-process/communication/content_guidelines/index.md)
   - [RFCs](company-info-and-process/communication/rfcs/index.md)


### PR DESCRIPTION
Incorporates the charter for the cohort for gender diversity in tech (aka #gender-diversity-allies, previously known as #dev-for-her) into the handbook and brings the DEI-related pages together into their own folder as a top-level item under company info and process.