### PR TITLE
onboarding for designers tweaks

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/growth-and-integrations/index.md
+++ b/content/departments/product-engineering/engineering/cloud/growth-and-integrations/index.md
@@ -81,17 +81,6 @@ Note: It is expected that this team will split into two teams in FY23. As such, 
     <div class="col" style="flex: 1;">
       <div>
         <div>
-          <a href="/team#rob-rhyne" target="_blank" rel="noopener">
-            <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/extensibility/rob-rhyne.png" alt="Picture of Rob Rhyne" style="background: transparent; width:128px;"/>
-          </a>
-        </div>
-        <div style="text-align: center;">Rob Rhyne</div>
-        <div style="text-align: center; font-size: 12px;">Temporary Product Manager and Product Designer (Growth)</div>
-      </div>
-    </div>
-    <div class="col" style="flex: 1;">
-      <div>
-        <div>
           <a href="/team#stephen-gutekanst" target="_blank" rel="noopener">
             <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/extensibility/stephen-gutekanst.png" alt="Picture of Stephen Gutekanst" style="background: transparent; width:128px;"/>
           </a>

--- a/content/departments/product-engineering/product/design/design_process.md
+++ b/content/departments/product-engineering/product/design/design_process.md
@@ -129,7 +129,7 @@ While asynchronous communication is a core attribute of remote work, key moments
   - A GitHub issue should be created to track the work
   - Designs are produced in Figma
   - Let others know about your designs in your team Slack channel
-  - Linked to your designs in the GitHub issue before they are complete to promote designing in the open
+  - Link to your designs in the GitHub issue before they are complete to promote designing in the open
   - Ensure designs meet the visual design checklist:
   - Ensure spacing is consistent and matches the 8pt grid system
   - Ensure text, colors and other styles match existing styles, if possible.

--- a/content/departments/product-engineering/product/design/design_process.md
+++ b/content/departments/product-engineering/product/design/design_process.md
@@ -91,15 +91,13 @@ While asynchronous communication is a core attribute of remote work, key moments
   - Announce results in slack
   - Create a GitHub issue to address items in the test results
 - Tools
-  - Maze.design
-  - UserTesting.org
+  - UserTesting.com
 
 ### Visual design
 
-- Visual design should utilize the Sourcegraph’s Figma based component system
+- Product design should utilize the [Wildcard Design System](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=891%3A0)
 - Dark compositions will be created for each major design
 - If new components are required, the following process should be followed:
-
   - Design component in the Figma file which requires it
     - If creating a component make sure it is prefaced by '\_' so that it is not used while in review
   - Create a proposal frame with the following items:
@@ -123,14 +121,14 @@ While asynchronous communication is a core attribute of remote work, key moments
   - Does the language in the UI map to the language in the CLI?
   - Does the documentation reflect the change?
   - Light mode / Dark mode
-  - Enterprise / Cloud
-  - Signed in vs. anonymous user
+  - Server / Cloud
+  - If Cloud: Signed in vs. anonymous users
   - User permissions
-  - Interactive mode / plain text mode
 - Process
   - A GitHub issue should be created to track the work
   - Designs are produced in Figma
-  - Designs will be announced in Slack and linked in the GitHub issue well before they are complete for review
+  - Let others know about your designs in your team Slack channel
+  - Linked to your designs in the GitHub issue before they are complete to promote designing in the open
   - Ensure designs meet the visual design checklist:
   - Ensure spacing is consistent and matches the 8pt grid system
   - Ensure text, colors and other styles match existing styles, if possible.

--- a/content/departments/product-engineering/product/design/design_process.md
+++ b/content/departments/product-engineering/product/design/design_process.md
@@ -128,7 +128,7 @@ While asynchronous communication is a core attribute of remote work, key moments
 - Process
   - A GitHub issue should be created to track the work
   - Designs are produced in Figma
-  - Let others know about your designs in your team Slack channel
+  - Let others know about your designs in your team Slack channel and in the product-design channel and other places of interest
   - Link to your designs in the GitHub issue before they are complete to promote designing in the open
   - Ensure designs meet the visual design checklist:
   - Ensure spacing is consistent and matches the 8pt grid system

--- a/content/departments/product-engineering/product/design/design_process.md
+++ b/content/departments/product-engineering/product/design/design_process.md
@@ -98,6 +98,7 @@ While asynchronous communication is a core attribute of remote work, key moments
 - Product design should utilize the [Wildcard Design System](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=891%3A0)
 - Dark compositions will be created for each major design
 - If new components are required, the following process should be followed:
+
   - Design component in the Figma file which requires it
     - If creating a component make sure it is prefaced by '\_' so that it is not used while in review
   - Create a proposal frame with the following items:

--- a/content/departments/product-engineering/product/design/index.md
+++ b/content/departments/product-engineering/product/design/index.md
@@ -8,11 +8,14 @@ We also seek to make it easier and more efficient to build Sourcegraph itself. T
 
 ## Team
 
-- [Alicja Suska](../../../../team/index.md#alicja-suska) (she/her)
-- [Rob Rhyne](../../../../team/index.md#rob-rhyne) (he/him)
-- [Quinn Keast](../../../../team/index.md#quinn-keast) (he/him) – [ReadMe](https://quinnkeast.com/readme)
-- [Sara Lee](../../../../team/index.md#sara-lee) (she/her)
-- [Marisa Kanemoto](../../../../team/index.md#marisa-kanemoto) (she/her)
+- [Christina Forney](../../../../team/#sts=Christina%20Forney) Interim Director of Design
+  - [Rob Rhyne](../../../../team/index.md#rob-rhyne) Code Graph Design Manager (he/him)
+    - [Alicja Suska](../../../../team/index.md#alicja-suska) Product Designer, Code Insights (she/her)
+    - [Marisa Kanemoto](../../../../team/index.md#marisa-kanemoto) Product Designer, Search Product (she/her)
+    - [D.M. (starting soon)] Product Designer, Batch Chnages
+  - [Christina Forney](../../../../team/#sts=Christina%20Forney) Interim Cloud Design Manager
+    - [Quinn Keast](../../../../team/index.md#quinn-keast) Product Designer, Cloud SaaS (he/him) – [ReadMe](https://quinnkeast.com/readme)
+    - [Sara Lee](../../../../team/index.md#sara-lee) Product Designer, Growth & Integrations (she/her)
 
 We’re hiring! [Check out our open roles](https://boards.greenhouse.io/sourcegraph91).
 

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -36,9 +36,9 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
   - code editors: [VS Code](https://code.visualstudio.com/) (and other IDEs like [IntelliJ](https://www.jetbrains.com/idea/) and [Atom](https://atom.io/))
   - similar products: [grepp.app](https://grep.app/) and [cs.opensource.google](https://cs.opensource.google)
 - Read the [Product Design team handbook](../index.md), especially:
-  - [User research](https://handbook.sourcegraph.com/departments/product-engineering/product/design/research/)
-  - [Analytics and product design](https://handbook.sourcegraph.com/departments/product-engineering/product/design/metrics/)
-  - [Wildcard design system](https://handbook.sourcegraph.com/departments/product-engineering/product/design/wildcard_design_system/)
+  - [User research](/departments/product-engineering/product/design/research/)
+  - [Analytics and product design](/departments/product-engineering/product/design/metrics/)
+  - [Wildcard design system](/departments/product-engineering/product/design/wildcard_design_system/)
 
 ### Set up your design environment
 
@@ -50,7 +50,7 @@ You'll find we have a strong base to work from, but we are in the early stages o
   - Download [Figma](https://www.figma.com)
   - (Optional) Set nudge to 8px in preferences > nudge amount
   - Install Figma plugins:
-    - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet our [accessibility standards](../design/design-and-interaction-guidelines.md#accessibility-standards)
+    - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet our [accessibility standards](../../design/design-and-interaction-guidelines.md#accessibility-standards)
     - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
     - [Style organizer](https://www.figma.com/community/plugin/816627069580757929/Style-Organizer) - helps us manage color
   - Other helpful plugins:

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -21,7 +21,6 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
   - Their product team
 - In their 1-1 doc introduce the designer to a few Figma files that are relevant to their team
 
-
 ## Designer checklist
 
 - Join the design-related Slack channels:
@@ -47,5 +46,5 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
 - Consider using the [Project Template](https://www.figma.com/file/JzufQnpTQtreyfnA3qpmfz/Project-Template?node-id=246%3A11) (read more in [Documents and Templates](../documents_templates/index.md))
   - This project doesn't fit all working styles or projects. If it doesn't work for you, consider trying to standardize on the following conventions:
     - Name pages consistently, use emojis to help indicate purpose
-    - Use  a cover page and cover component to help with readibly
+    - Use a cover page and cover component to help with readibly
     - Use an About section to help others know what the file/page/section does

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -1,4 +1,4 @@
-# Onboarding
+# Product designer onboarding
 
 Welcome to the Design Team!
 

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -36,9 +36,9 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
   - code editors: [VS Code](https://code.visualstudio.com/) (and other IDEs like [IntelliJ](https://www.jetbrains.com/idea/) and [Atom](https://atom.io/))
   - similar products: [grepp.app](https://grep.app/) and [cs.opensource.google](https://cs.opensource.google)
 - Read the [Product Design team handbook](../index.md), especially:
-  - [User research](/departments/product-engineering/product/design/research/)
-  - [Analytics and product design](/departments/product-engineering/product/design/metrics/)
-  - [Wildcard design system](/departments/product-engineering/product/design/wildcard_design_system/)
+  - [User research](../research/)
+  - [Analytics and product design](../metrics/)
+  - [Wildcard design system](../wildcard_design_system/)
 
 ### Set up your design environment
 

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -6,7 +6,7 @@ Having gone though [the Process St onboarding](https://app.process.st/reports/) 
 
 Your perspective as both a new user of Sourcegraph and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are onboarding and learning the product. We’ll use those notes to improve the product and process.
 
-# Manager checklist
+## Manager checklist
 
 - Complete the [product team manager checklist](../../onboarding/index.md#manager-checklist)
 - Add the designer to these team meetings:
@@ -40,6 +40,34 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
   - [Analytics and product design](https://handbook.sourcegraph.com/departments/product-engineering/product/design/metrics/)
   - [Wildcard design system](https://handbook.sourcegraph.com/departments/product-engineering/product/design/wildcard_design_system/)
 - Set up Figma
+
+### Set up your design environment
+
+Use the following resources to get up to speed on design at Sourcegraph.
+
+You'll find we have a strong base to work from, but we are in the early stages of creating our program. Your input will be critical to our success, so take notes about everything you experience while onboarding. We'll use them to help us improve our process and the product!
+
+- Set up Figma
+  - Download [Figma](https://www.figma.com)
+  - (Optional) Set nudge to 8px in preferences > nudge amount
+  - Install Figma plugins:
+    - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet our [accessibility standards](../design/design-and-interaction-guidelines.md#accessibility-standards)
+    - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
+    - [Style organizer](https://www.figma.com/community/plugin/816627069580757929/Style-Organizer) - helps us manage color
+  - Other helpful plugins:
+    - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
+    - [Data for design](https://drive.google.com/drive/folders/1UPxQ4Ln_JH7KNBVGP6ZepSK5WiGWfVDO)
+    - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
+    - Suggest plugins to help make us more efficient!
+  - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/1X1hwQr4lGGVn5BDe4f09q_xRqboQZpsQ)
+- UserTesting.com
+  - Review a few [usability studies](https://drive.google.com/drive/folders/1WcvPUtdVH2XE3Hak6tutoPWRCuEXPvCd) to get an idea of some of our early research efforts.
+- As you learn the product, if you come across a quick win for better usability, create a GitHub issue identifying the problem and proposing a quick solution, and tag it with 'design'.
+- Suggest a tool you love to the team in the #design channel on Slack!
+- Storybook houses our React component library. We use [Chromatic](https://www.chromatic.com/library?appId=5f0f381c0e50750022dc6bf7) to easily access and collaborate on the components. You can access the React components library in two ways:
+  - Log in to Chromatic with your GitHub account and open Sourcegraph library
+  - From the root of your local development environment run storybook: `yarn storybook`.
+- Explore and favorite the [Google Drive design folder](https://drive.google.com/drive/folders/1ow-19Yd4AFtT8HjVZ9ln_nEGpCzQ2CTf)
 
 ## Creating your first Figma project
 

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -6,26 +6,46 @@ Having gone though [the Process St onboarding](https://app.process.st/reports/) 
 
 Your perspective as both a new user of Sourcegraph and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are onboarding and learning the product. We’ll use those notes to improve the product and process.
 
+# Manager checklist
+
+- Complete the [product team manager checklist](../../onboarding/index.md#manager-checklist)
+- Add the designer to these team meetings:
+  - Design sync meeting (both meetings!)
+  - Design retro meeting (first Wednesday of the month)
+  - Add the designer to the relevant meetings for their team (if not handled by email groups)
+- Notify people ops to include the new designer on the following GitHub groups:
+  - @sourcegraph/design
+- Notify people ops to include the new designer on the following Slack groups:
+  - @design-team
+  - @product-team
+  - Their product team
+- In their 1-1 doc introduce the designer to a few Figma files that are relevant to their team
+
+
 ## Designer checklist
 
-- Add your name to the [Project card](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/🛠Project-Tools?node-id=1%3A203) designer list
-- Check if you're added to the Design Team group on Slack. Join the design-related channels:
+- Join the design-related Slack channels:
   - design
   - product-design-internal
   - accessibility
   - analytics-review
   - wildcard-components-library-wcl
   - hallway-testing
-- Make sure that your Name is set to your First and Last name on GitHub so that other teammates can easily indentify you. Go to GitHub -> Your profile -> Edit profile -> Fill out the 'Name field' -> Save
 - Add yourself as a designer to the handbook pages of the teams you're working with. You can also add those teams to your Slack profile description, for ex. 'Product Designer (Code Insights)'
 - Get familiar with the products that we use as inspirations for reference in the developer tools industry:
   - code hosts: [GitHub](https://github.com/) and [GitLab] (https://gitlab.com/)
   - code editors: [VS Code](https://code.visualstudio.com/) (and other IDEs like [IntelliJ](https://www.jetbrains.com/idea/) and [Atom](https://atom.io/))
-  - similar products: [grepp.app](https://grep.app/)
-- Add yourself to the design club meeting on Tuesdays
-- Read the [Product Design team handbook](../index.md) content
+  - similar products: [grepp.app](https://grep.app/) and [cs.opensource.google](https://cs.opensource.google)
+- Read the [Product Design team handbook](../index.md), especially:
+  - [User research](https://handbook.sourcegraph.com/departments/product-engineering/product/design/research/)
+  - [Analytics and product design](https://handbook.sourcegraph.com/departments/product-engineering/product/design/metrics/)
+  - [Wildcard design system](https://handbook.sourcegraph.com/departments/product-engineering/product/design/wildcard_design_system/)
+- Set up Figma
 
 ## Creating your first Figma project
 
-- Use the [Project Template](https://www.figma.com/file/JzufQnpTQtreyfnA3qpmfz/Project-Template?node-id=246%3A11) (read more in [Documents and Templates](../documents_templates/index.md))
-- Remember to add the Project card
+- Consider using the [Project Template](https://www.figma.com/file/JzufQnpTQtreyfnA3qpmfz/Project-Template?node-id=246%3A11) (read more in [Documents and Templates](../documents_templates/index.md))
+  - This project doesn't fit all working styles or projects. If it doesn't work for you, consider trying to standardize on the following conventions:
+    - Name pages consistently, use emojis to help indicate purpose
+    - Use  a cover page and cover component to help with readibly
+    - Use an About section to help others know what the file/page/section does

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the Design Team!
 
-Having gone though [the Process St onboarding](https://app.process.st/reports/) and [the Product onboarding](../../onboarding/index.md), it's time for the Design onboarding!
+Having gone though [the Process St onboarding](https://app.process.st/reports/) and [product onboarding](../../onboarding/index.md), it's time for the design onboarding!
 
 Your perspective as both a new user of Sourcegraph and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are onboarding and learning the product. We’ll use those notes to improve the product and process.
 
@@ -39,7 +39,6 @@ Your perspective as both a new user of Sourcegraph and a new teammate is very va
   - [User research](https://handbook.sourcegraph.com/departments/product-engineering/product/design/research/)
   - [Analytics and product design](https://handbook.sourcegraph.com/departments/product-engineering/product/design/metrics/)
   - [Wildcard design system](https://handbook.sourcegraph.com/departments/product-engineering/product/design/wildcard_design_system/)
-- Set up Figma
 
 ### Set up your design environment
 
@@ -72,7 +71,7 @@ You'll find we have a strong base to work from, but we are in the early stages o
 ## Creating your first Figma project
 
 - Consider using the [Project Template](https://www.figma.com/file/JzufQnpTQtreyfnA3qpmfz/Project-Template?node-id=246%3A11) (read more in [Documents and Templates](../documents_templates/index.md))
-  - This project doesn't fit all working styles or projects. If it doesn't work for you, consider trying to standardize on the following conventions:
+  - This template doesn't fit all working styles or projects. If it doesn't work for you, consider try to standardize on the following conventions:
     - Name pages consistently, use emojis to help indicate purpose
     - Use a cover page and cover component to help with readibly
     - Use an About section to help others know what the file/page/section does

--- a/content/departments/product-engineering/product/design/wildcard_design_system/index.md
+++ b/content/departments/product-engineering/product/design/wildcard_design_system/index.md
@@ -21,7 +21,6 @@ Colors:
 - Of these groups, the Semantic colors are the ones to be used in day-to-day design work.
   - Semantic colors control things like background colors, borders, links, and input styles
 
-
 Spacing:
 
 - Sourcegraph uses an 8-point grid. Modify your [nudge settings](https://help.figma.com/hc/en-us/articles/4404575206295-Set-small-and-big-nudge-values) accordingly!

--- a/content/departments/product-engineering/product/design/wildcard_design_system/index.md
+++ b/content/departments/product-engineering/product/design/wildcard_design_system/index.md
@@ -2,7 +2,7 @@
 
 We use [Wildcard](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=891%3A0), Sourcegraph’s design system, to create visual design artifacts in Figma. Designers utilize components from Wildcard whenever possible to ensure consistent design across Sourcegraph and efficient development time. We also use [Chromatic](https://www.chromatic.com/library?appId=5f0f381c0e50750022dc6bf7) to manage our storybook.
 
-## Libraries
+## Figma libraries
 
 The [Wildcard Design System](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=891%3A0) is the primary library to use in order to have access to all of our components and styles. The [Helpers and Tooling](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/%F0%9F%9B%A0Project-Tools?node-id=72%3A20) also contains useful components like redlines and annotation.
 
@@ -12,22 +12,23 @@ Text:
 
 - We use SF Pro for all text. [Download SF Pro](https://drive.google.com/drive/folders/1X1hwQr4lGGVn5BDe4f09q_xRqboQZpsQ) and install it on your system.
   - You may also need the [Figma font installer](https://www.figma.com/downloads/) if you use Figma in the browser instead of on desktop.
-- All text styles are available through Wildcard text styles.
-- The style definitions for our text styles are in the [Sticker Sheet](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=908%3A0).
+- All text styles are available through Wildcard [text styles page](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/?node-id=5601%3A65477)
 
 Colors:
 
 - There are four groups of colors used in Wildcard: Root, Semantic, Brand, and Open Color (OC).
+  - They can be found on the [colors page](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/?node-id=5123%3A64178)
 - Of these groups, the Semantic colors are the ones to be used in day-to-day design work.
-- The style defitions for the Root and Semantic color styles are in the [Sticker Sheet](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Wildcard-Design-System?node-id=908%3A0). The Open Color definitions are in the Colors page.
+  - Semantic colors control things like background colors, borders, links, and input styles
 
-Space:
 
-- Sourcegraph uses an 8-point grid.
+Spacing:
+
+- Sourcegraph uses an 8-point grid. Modify your [nudge settings](https://help.figma.com/hc/en-us/articles/4404575206295-Set-small-and-big-nudge-values) accordingly!
 
 ## Adding a component
 
-When a new component is required, the designer who uncovered the gap is responsible for expanding Wildcard with the following process:
+When a new component is required, the designer who discovered the gap is responsible for expanding Wildcard with the following process:
 
 - Create component in the Figma file that requires the new component. Preface the name of the component with '\_' so that it is not used while in review
 - Create a proposal frame with the following items:

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -114,6 +114,7 @@ Remember:
 - **Screenshot/GIF making software**: See the [handbook](../../../marketing/process/adding_screenshots_screen_recording.md) for guidelines about software. Expense the program that works for you when you need it.
 - [Product documentation guidelines](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/dev/documentation.md)
 - [Docs to Markdown add-on for Google Docs](https://gsuite.google.com/marketplace/app/docs_to_markdown/700168918607)
+
 ## Week 2–3 - initial projects
 
 - The goal is to give you a handful of projects that will help you familiarize yourself with the product, and get some quick wins in your first weeks.

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -8,7 +8,9 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
 
 - Visit the [Onboarding process for Hiring Managers](../../../../company-info-and-process/onboarding/onboarding-for-hiring-managers.md) page to understand the workflow with People Ops.
 - Create an onboarding Google doc for the new teammate
-- Update the onboarding doc with initial projects for weeks 2–4
+  - Link to this page and relevant team specific pages such as [designer onboarding](https://handbook.sourcegraph.com/departments/product-engineering/product/design/onboarding/)
+  - Customize your teammates onboarding tasks as required
+  - Update the onboarding doc with initial projects for weeks 2–4
 - Notify People Ops on the tools needed by day one - [Tools for new teammates form](https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform)
   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
   - Invite to GitHub teams, including @sourcegraph/everyone

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -8,7 +8,7 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
 
 - Visit the [Onboarding process for Hiring Managers](../../../../company-info-and-process/onboarding/onboarding-for-hiring-managers.md) page to understand the workflow with People Ops.
 - Create an onboarding Google doc for the new teammate
-  - Link to this page and relevant team specific pages such as [designer onboarding](/departments/product-engineering/product/design/onboarding/)
+  - Link to this page and relevant team specific pages such as [designer onboarding](../design/onboarding/index.md)
   - Customize your teammates onboarding tasks as required
   - Update the onboarding doc with initial projects for weeks 2–4
 - Notify People Ops on the tools needed by day one - [Tools for new teammates form](https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform)
@@ -99,7 +99,7 @@ Remember:
 - Looker
   - [How Sourcegraph uses Looker](../../../bizops/analytics/index.md#using-looker)
 - Amplitude
-  - We use Amplitude for analytics on Sourcegraph Cloud. [More on Amplitude here](/departments/bizops/tools/amplitude/).
+  - We use Amplitude for analytics on Sourcegraph Cloud. [More on Amplitude here](../../../bizops/tools/amplitude.md).
 - UserTesting.com
   - Walk through UserTesting.com with one of the designers on the team
 

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -37,7 +37,7 @@ Remember:
   - One of our values is to be [open and transparent](../../../../company-info-and-process/values/index.md#open-and-transparent)
   - Good reasons for things to be private: sensitive customer information, sensitive personal information
   - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and make a PR to update the handbook so the next person starting is granted access to that system).
-  - When you have a question, try to ask publically. Other people probably have the same question.
+  - When you have a question, try to ask publicly. Other people probably have the same question.
   - In a DM a teammate might say: "Do you mind asking this publically? I'll answer there". You can use this phrase too to help generate open conversations.
 - Unlike at many companies, it is OK (and important) to call out when we did something poorly or when something doesn't go well (e.g., a sales pitch falls flat). That helps us be real and do it better in the future.
 

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -8,7 +8,7 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
 
 - Visit the [Onboarding process for Hiring Managers](../../../../company-info-and-process/onboarding/onboarding-for-hiring-managers.md) page to understand the workflow with People Ops.
 - Create an onboarding Google doc for the new teammate
-  - Link to this page and relevant team specific pages such as [designer onboarding](https://handbook.sourcegraph.com/departments/product-engineering/product/design/onboarding/)
+  - Link to this page and relevant team specific pages such as [designer onboarding](/departments/product-engineering/product/design/onboarding/)
   - Customize your teammates onboarding tasks as required
   - Update the onboarding doc with initial projects for weeks 2–4
 - Notify People Ops on the tools needed by day one - [Tools for new teammates form](https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform)
@@ -99,7 +99,7 @@ Remember:
 - Looker
   - [How Sourcegraph uses Looker](../../../bizops/analytics/index.md#using-looker)
 - Amplitude
-  - We use Amplitude for analytics on Sourcegraph Cloud. [More on Amplitude here](https://handbook.sourcegraph.com/departments/bizops/tools/amplitude/).
+  - We use Amplitude for analytics on Sourcegraph Cloud. [More on Amplitude here](/departments/bizops/tools/amplitude/).
 - UserTesting.com
   - Walk through UserTesting.com with one of the designers on the team
 

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -16,11 +16,9 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
   - Productboard
   - Looker
   - Amplitude
-- Grant access to necessary services.
-  - UserTesting.com
 - Schedule a recurring [1-1](../../../../company-info-and-process/communication/1-1.md).
 - Schedule check-ins for the first and second weeks at Sourcegraph to keep up with onboarding and to create space for answering any questions that might come up.
-- Create a 1-1 doc and add initial discussion items
+- Create a 1-1 doc and add initial discussion items. Some suggestions:
   - Onboarding doc - YAYYYYYYYYYY WELCOME!!!!! 🎉
     - Your onboarding doc is to help outline the projects and tasks you have over your first 30 days.
     - This 1-1 doc will be where we take notes on discussions, set goals, and make sure you’re on track.
@@ -43,7 +41,7 @@ Remember:
 
 - Complete [Process st onboarding](https://app.process.st/reports/)
   - Keep the [guiding principles](../../../../company-info-and-process/onboarding/index.md#guiding-principles) from the general onboarding page in mind - we are here to support you and you should act like an owner!
-- Write your 30–60–90 day objectives in your 1:1 doc with Christina
+- Write your 30–60–90 day objectives in your 1:1 doc with your manager
 
 ### Get to know the team
 
@@ -60,6 +58,7 @@ Remember:
 ### Set up the basics
 
 - [Configure your GitHub notifications.](../../../../company-info-and-process/onboarding/git-intro/github-notifications/index.md)
+  - Make sure that your Name is set to your First and Last name on GitHub so that other teammates can easily indentify you. Go to GitHub -> Your profile -> Edit profile -> Fill out the ‘Name field’ -> Save
 - Familiarize yourself with our [team chat](../../../../company-info-and-process/communication/team_chat.md) and join team channels on Slack, as well as any other channels you find interesting. [Product team chat documentation](../../../../company-info-and-process/communication/team_chat.md#product).
 - Set up your [local development environment](https://docs.sourcegraph.com/dev/setup). If you encounter any issues, ask for help in Slack and then update the documentation to reflect the resolution (so the next person that we hire doesn't run into the same problem).
   - You will need to run Sourcegraph locally to test and validate work that engineering is doing, to provide early feedback, or to review the UX of recently implemented work.

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -7,8 +7,8 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
 ## Manager checklist
 
 - Visit the [Onboarding process for Hiring Managers](../../../../company-info-and-process/onboarding/onboarding-for-hiring-managers.md) page to understand the workflow with People Ops.
-- Create onboarding Google doc and copy in this page to customize week 2–4 tasks and have a personal checklist for the new teammate.
-- Update onboarding doc Week 2–4 with initial projects.
+- Create an onboarding Google doc for the new teammate
+- Update the onboarding doc with initial projects for weeks 2–4
 - Notify People Ops on the tools needed by day one - [Tools for new teammates form](https://docs.google.com/forms/d/e/1FAIpQLSeQjfoLjAZUim7pVYw9joQCssXuVz2t2RlpjLadzmHrj15cwQ/viewform)
   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
   - Invite to GitHub teams, including @sourcegraph/everyone
@@ -16,8 +16,6 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
   - Productboard
   - Looker
   - Amplitude
-<<<<<<< HEAD
-=======
 - Suggest product people the new teammate should create a 1:1 with
 - Schedule check-ins for the first and second weeks at Sourcegraph to keep up with onboarding and to create space for answering any questions that might come up.
 - Create a 1-1 doc and add initial discussion items. Some suggestions:

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -96,6 +96,8 @@ Remember:
   - Read [Figma developers guide](https://www.smashingmagazine.com/2020/09/figma-developers-guide/)
 - Looker
   - [How Sourcegraph uses Looker](../../../bizops/analytics/index.md#using-looker)
+- Amplitude
+  - We use Amplitude for analytics on Sourcegraph Cloud. [More on Amplitude here](https://handbook.sourcegraph.com/departments/bizops/tools/amplitude/).
 - UserTesting.com
   - Walk through UserTesting.com with one of the designers on the team
 
@@ -112,39 +114,6 @@ Remember:
 - **Screenshot/GIF making software**: See the [handbook](../../../marketing/process/adding_screenshots_screen_recording.md) for guidelines about software. Expense the program that works for you when you need it.
 - [Product documentation guidelines](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/dev/documentation.md)
 - [Docs to Markdown add-on for Google Docs](https://gsuite.google.com/marketplace/app/docs_to_markdown/700168918607)
-
-### Set up your design environment
-
-If you are a designer on the team, use the following resources to get up to speed on design at Sourcegraph.
-
-You'll find we have a strong base to work from, but we are in the early stages of creating our program. Your input will be critical to our success, so take notes about everything you experience while onboarding. We'll use them to help us improve our process and the product!
-
-- Set up Figma
-  - Download [Figma](https://www.figma.com)
-  - (Optional) Set nudge to 8px in preferences > nudge amount
-  - Install Figma plugins:
-    - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet our [accessibility standards](../design/design-and-interaction-guidelines.md#accessibility-standards)
-    - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
-    - [Style organizer](https://www.figma.com/community/plugin/816627069580757929/Style-Organizer) - helps us manage color
-    - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
-    - [Data for design](https://drive.google.com/drive/folders/1UPxQ4Ln_JH7KNBVGP6ZepSK5WiGWfVDO)
-    - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
-    - Suggest plugins to help make us more efficient!
-  - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/1X1hwQr4lGGVn5BDe4f09q_xRqboQZpsQ)
-  - Review the [component library](https://www.figma.com/files/project/14326173/%F0%9F%93%9ADesign-system)
-  - Review the [Project Tools](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/Project-Tools?node-id=0%3A1)
-  - Take a moment to add some inspiring design to the Figma [styleboards](https://www.figma.com/files/project/10712517/Styleboards)
-- UserTesting.com
-  - Get a tour of UserTesting.com from another designer on the team.
-  - Review a few [usability studies](https://drive.google.com/drive/folders/1WcvPUtdVH2XE3Hak6tutoPWRCuEXPvCd) to get an idea of how you will use the product.
-- As you learn the product, if you come across a quick win for better usability based on general heuristics, create a GitHub issue identifying the problem and proposing a quick solution, and tag it with 'UX'.
-- Suggest a tool you love to the team in the #design channel on Slack!
-- Storybook houses our React component library. We use [Chromatic](https://www.chromatic.com/library?appId=5f0f381c0e50750022dc6bf7) to easily access and collaborate on the components. You can access the React components library in two ways:
-  1.  Log in to Chromatic with your GitHub account and open Sourcegraph library
-  1.  from the root of your local development environment run storybook: `yarn storybook`.
-- Explore and favorite the [Google Drive design folder](https://drive.google.com/drive/folders/1ow-19Yd4AFtT8HjVZ9ln_nEGpCzQ2CTf)
-- Review the [Potential UX projects document](https://docs.google.com/document/d/1LemO13R3f0Ku88WK8tFr7_Qo4teDA0Bebs8Y2TGkS3U/edit)
-
 ## Week 2–3 - initial projects
 
 - The goal is to give you a handful of projects that will help you familiarize yourself with the product, and get some quick wins in your first weeks.

--- a/content/departments/product-engineering/product/onboarding/index.md
+++ b/content/departments/product-engineering/product/onboarding/index.md
@@ -16,8 +16,8 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
   - Productboard
   - Looker
   - Amplitude
-<<<<<<< HEAD
-=======
+    <<<<<<< HEAD
+    =======
 - Suggest product people the new teammate should create a 1:1 with
 - Schedule check-ins for the first and second weeks at Sourcegraph to keep up with onboarding and to create space for answering any questions that might come up.
 - Create a 1-1 doc and add initial discussion items. Some suggestions:


### PR DESCRIPTION
## Design section changes
* Defines design people and roles
* Updates onboarding for product designers
* Creates a new product design manager onboarding section of the design onboarding page

## Product onboarding changes
* Alters manager onboarding steps to link to handbook instead of copy handbook to onboarding doc
* Moves setting up the design environment from the product onboarding page to the product design onboarding page