### PR TITLE
Create new enablement page for code insights

### DIFF
--- a/content/departments/support/process/enablement/index.md
+++ b/content/departments/support/process/enablement/index.md
@@ -29,6 +29,7 @@ This table correlates to our [technical competency matrix](https://docs.google.c
 - [How to Migrate Sourcegraph from one Cluster to another](k8-migration.md)
 - [Kubernetes and Docker](k8s-resources.md)
 - [Determining root cause](root-cause.md)
+- [Using code insights to monitor recently resolved tickets](keeping-up-with-resolved-issues.md)
 
 ## Videos
 

--- a/content/departments/support/process/enablement/keeping-up-with-resolved-issues.md
+++ b/content/departments/support/process/enablement/keeping-up-with-resolved-issues.md
@@ -1,0 +1,16 @@
+### Staying Current on Recently Resolved Tickets
+
+As an Application Engineer, it is helpful to understand current trends in our resolved tickets database. Doing so can help heighten your awareness of current issues that may come up in your own tickets. 
+
+## Code Insights is your friend
+
+At Sourcegraph, we can leverage code insights to stay up to date on recently resolved tickets.
+
+For example, some AERs have found it helpful to create a monitor that sends an email each time a new search result becomes available in the resolved tickets database. An added benefit of enabling this feature for yourself is that it will help you gain knowledge of the code insights user interface. 
+
+To enable this for yourself, [add a code monitor](https://docs.sourcegraph.com/code_monitoring/quickstart) to track the following query: 
+
+`repo:^github\.com/sourcegraph/support-tools-internal$@HEAD file:^resolved-tickets type:diff patternType:literal`
+
+
+

--- a/content/departments/support/process/enablement/keeping-up-with-resolved-issues.md
+++ b/content/departments/support/process/enablement/keeping-up-with-resolved-issues.md
@@ -1,16 +1,13 @@
 ### Staying Current on Recently Resolved Tickets
 
-As an Application Engineer, it is helpful to understand current trends in our resolved tickets database. Doing so can help heighten your awareness of current issues that may come up in your own tickets. 
+As an Application Engineer, it is helpful to understand current trends in our resolved tickets database. Doing so can help heighten your awareness of current issues that may come up in your own tickets.
 
 ## Code Insights is your friend
 
 At Sourcegraph, we can leverage code insights to stay up to date on recently resolved tickets.
 
-For example, some AERs have found it helpful to create a monitor that sends an email each time a new search result becomes available in the resolved tickets database. An added benefit of enabling this feature for yourself is that it will help you gain knowledge of the code insights user interface. 
+For example, some AERs have found it helpful to create a monitor that sends an email each time a new search result becomes available in the resolved tickets database. An added benefit of enabling this feature for yourself is that it will help you gain knowledge of the code insights user interface.
 
-To enable this for yourself, [add a code monitor](https://docs.sourcegraph.com/code_monitoring/quickstart) to track the following query: 
+To enable this for yourself, [add a code monitor](https://docs.sourcegraph.com/code_monitoring/quickstart) to track the following query:
 
 `repo:^github\.com/sourcegraph/support-tools-internal$@HEAD file:^resolved-tickets type:diff patternType:literal`
-
-
-


### PR DESCRIPTION
Add new page to enablement that instructs AERs on how to use Code-insights to their advantage.