### PR TITLE
Explain Enablement org-level engineering role.

### DIFF
--- a/content/departments/product-engineering/engineering/career-development/ic5/enablement-org.md
+++ b/content/departments/product-engineering/engineering/career-development/ic5/enablement-org.md
@@ -44,3 +44,11 @@ If a particular challenge is predominantly in a specific team’s domain the eng
 - Effectively able to communicate technological needs and strategy to drive alignment in multi-team/stakeholder situations.
 - Proactively identify areas for improvement, beyond the scope of the org, and contribute meaningfully to solutions while continuing to deliver on the org’s goals.
 - Invest in technology, tools, and processes that benefit the entire engineering department.
+
+### Partnership modes
+
+**Advisor** - Available to review artifacts, consult changes or designs, inject engineering context for PMs and EMs.
+
+**Collaborator** - Available for all of the above, plus can be temporarily plugged into the team and work as any other member, respect meetings, standups, and whatever is required in order to drive the project(s) in question to completion.
+
+**Coordinator** - all of the above, plus can own engineering issues spanning multiple teams.

--- a/content/departments/product-engineering/engineering/enablement/index.md
+++ b/content/departments/product-engineering/engineering/enablement/index.md
@@ -6,7 +6,7 @@ Our mission is to provide technical foundations critical to the business, our cu
 
 ## Team
 
-The org is lead by [Serina Clark](../../../../team/index.md#serina-clark) ([Director of Product](../../product/roles/index.md#director-of-product)) and [Jean du Plessis](../../../../team/index.md#jean-du-plessis) ([Director of Engineering](../roles/index.md#director-of-engineering)). [Michal Vrtiak](../../../../team/index.md#michal-vrtiak) serves as an org-level engineer, reporting into the Director of Engineering, and partners with the teams below.
+The org is lead by [Serina Clark](../../../../team/index.md#serina-clark) ([Director of Product](../../product/roles/index.md#director-of-product)) and [Jean du Plessis](../../../../team/index.md#jean-du-plessis) ([Director of Engineering](../roles/index.md#director-of-engineering)).
 
 **[Repo Management](./repo-management/index.md)**
 {{generator:product_team.repo_management}}
@@ -16,6 +16,17 @@ The org is lead by [Serina Clark](../../../../team/index.md#serina-clark) ([Dire
 {{generator:product_team.frontend_platform}}
 **[Content Platform](./content-platform/index.md)**
 {{generator:product_team.content_platform}}
+
+[Michal Vrtiak](../../../../team/index.md#michal-vrtiak) serves as an org-level engineer, reporting into the Director of Engineering, and partners with the individual teams in the following modes:
+
+|Team Name|Partnership mode|
+|---|---|
+|Repo Management|coordinator, collaborator, advisor|
+|Dev Experience|coordinator, collaborator, advisor|
+|Frontend Platform|advisor|
+|Content Platform|advisor|
+
+The collaboration modes are described in the [profile role description](../career-development/ic5/enablement-org.md#partnership-modes).
 
 ## Principles and practices
 

--- a/content/departments/product-engineering/engineering/enablement/index.md
+++ b/content/departments/product-engineering/engineering/enablement/index.md
@@ -19,12 +19,12 @@ The org is lead by [Serina Clark](../../../../team/index.md#serina-clark) ([Dire
 
 [Michal Vrtiak](../../../../team/index.md#michal-vrtiak) serves as an org-level engineer, reporting into the Director of Engineering, and partners with the individual teams in the following modes:
 
-|Team Name|Partnership mode|
-|---|---|
-|Repo Management|coordinator, collaborator, advisor|
-|Dev Experience|coordinator, collaborator, advisor|
-|Frontend Platform|advisor|
-|Content Platform|advisor|
+| Team Name         | Partnership mode                   |
+| ----------------- | ---------------------------------- |
+| Repo Management   | coordinator, collaborator, advisor |
+| Dev Experience    | coordinator, collaborator, advisor |
+| Frontend Platform | advisor                            |
+| Content Platform  | advisor                            |
 
 The collaboration modes are described in the [profile role description](../career-development/ic5/enablement-org.md#partnership-modes).
 


### PR DESCRIPTION
Explain Enablement's org-level engineering role (currently filled by me) in the Enablement handbook home page.