### PR TITLE
Update URL to batch change execution with workspace selected

### DIFF
--- a/content/departments/product-engineering/engineering/code-graph/batch-changes/index.md
+++ b/content/departments/product-engineering/engineering/code-graph/batch-changes/index.md
@@ -76,7 +76,7 @@ We are looking to add one [experienced full-stack engineer](https://boards.green
 
 This is a non-exhaustive list of Sourcegaphers use cases for Sourcegraph (either internally or on side-projects):
 
-- Run TS-Morph-powered codemods on the frontend platform repository. [Spec](https://k8s.sgdev.org/batch-changes/executions/QmF0Y2hTcGVjOiI0eGNQQVVIaVoxZCI=?workspace=QmF0Y2hTcGVjV29ya3NwYWNlOjk0ODQwNA==) (private)
+- Run TS-Morph-powered codemods on the frontend platform repository. [Spec](https://k8s.sgdev.org/batch-changes/executions/QmF0Y2hTcGVjOiI0eGNQQVVIaVoxZCI=/workspace/QmF0Y2hTcGVjV29ya3NwYWNlOjk0ODQwNA==) (private)
 - Update PR templates across many repositories.
 - Standardize versions of tools across many repositories by updating .tool-versions files. [Search](https://k8s.sgdev.org/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph+file:%5E%5C.tool-versions+shfmt&patternType=literal&case=yes) (private)
 - Update CI configuration across several repositories. [Blog post](https://unknwon.io/posts/211110_sourcegraph_batch_changes/)


### PR DESCRIPTION
The URL structure for the batch change execution page with a workspace selected was recently changed. I updated references to batch change links in the main repo but forgot to push this one at the time. This just updates it.