### PR TITLE
Add missing GitHub handle for Malo Marrec

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -712,6 +712,7 @@ malo_marrec:
   role: Product Manager, Batch Changes
   location: Paris, France 🇫🇷
   email: malo@sourcegraph.com
+  github: malomarrec
   links: '[Linkedin](https://www.linkedin.com/in/malo-marrec)'
   description: Malo lives in Paris, France after some time in the Bay Area. Prior to Sourcegraph, he bounced around a few early stage startups building infrastucture and developer tools. Malo graduated with an MS from Stanford, and an MS from Ecole Centrale Paris. Outside of work, he kite surfs and reads a ton of books.
 


### PR DESCRIPTION
Spotted a missing handle in the scripts for the deployment notifications: https://buildkite.com/sourcegraph/deploy-sourcegraph-cloud/builds/197890#dbe321cc-1f4c-4366-ae41-15b5e0b8e579/54-79 

This change fixes it. 