### PR TITLE
Remove call for champions, add slack group alias, fill in champion profiles

### DIFF
--- a/content/company-info-and-process/mentorship/index.md
+++ b/content/company-info-and-process/mentorship/index.md
@@ -3,8 +3,6 @@
 > NOTE: The mentorship program will officially open to all Sourcegraph employees on **Monday, April 11th**.
 >
 > **Call for mentors.** Anyone can be a mentor! Consider submitting a _[mentor profile](https://forms.gle/CUWbzL9KMLuXFzhv5)_ for yourself to appear on our mentors bulletin board.
->
-> **Call for program champions.** We are building out a small team of representatives from different orgs to own and maintain the program and its [operations](./operations.md) as it matures. If the mission of our program speaks to you, consider filling out our [champions interest form](https://forms.gle/pPzaS8UVWMz5iKze9) before Wednesday, April 6th.
 
 ## Introduction
 
@@ -43,7 +41,7 @@ Did you already strike something up informally with someone you’re already wor
 
 ### What if I have questions or run into a problem not addressed here?
 
-You can reach the mentorship program champions at [#mentorship](https://sourcegraph.slack.com/archives/C0374C9PRKK) with questions, concerns, feedback, or anything else mentoring-related.
+You can reach the mentorship program champions by tagging @mentorship-champions or posting in [#mentorship](https://sourcegraph.slack.com/archives/C0374C9PRKK) with questions, concerns, feedback, or anything else mentoring-related.
 
 We understand that sometimes the nature of these issues can be more sensitive. While we hope that anyone here feels empowered to speak directly about issues they are facing with those involved, we know that this isn’t always possible, and both the mentorship program champions and People Ops are here to support you in those cases. To privately contact the members of the committee to help you while keeping matters in confidence, you can fill out [this form](https://forms.gle/Pma3Vguhz7knkWeR9). [Inés Roitman](../../team/index.md#inés-roitman) is our program’s advocate from within People Ops.
 
@@ -85,7 +83,7 @@ Mentorship is a two-way street, and it’s important that any mentoring relation
 
 If there isn’t a good mentor available for the areas you are interested in, or if you are just having a hard time getting something to work out, the mentorship program champions are here to help!
 
-For these and any other issues you may run into with the mentorship program, you can always reach the mentorship program champions by posting in [#mentorship](https://sourcegraph.slack.com/archives/C0374C9PRKK).
+For these and any other issues you may run into with the mentorship program, you can always reach the mentorship program champions by tagging @mentorship-champions or posting in [#mentorship](https://sourcegraph.slack.com/archives/C0374C9PRKK).
 
 We understand that sometimes the nature of these issues can be more sensitive. While we hope that anyone here feels empowered to speak directly about issues they are facing with those involved, we know that this isn’t always possible, and both the mentorship program champions and People Ops are here to support you in those cases. To privately contact the members of the committee to help you while keeping matters in confidence, you can fill out [this form](https://forms.gle/Pma3Vguhz7knkWeR9). [Inés Roitman](../../team/index.md#inés-roitman) is our program’s advocate from within People Ops.
 

--- a/content/company-info-and-process/mentorship/operations.md
+++ b/content/company-info-and-process/mentorship/operations.md
@@ -6,10 +6,10 @@ Surveys and other forms related to the _Find a mentor, Be a mentor_ program live
 
 The committee of mentorship program champions are the designated owners and maintainers of the [_Find a mentor, Be a mentor_ program](./index.md). As it is inherently cross-functional, the committee is composed of representatives from engineering, product, CS, and people ops. The current representatives are:
 
-- Bio link (CS)
+- [Stompy Mwendwa](../../team/index.md#stompy-mwendwa) (CS)
 - [Kelli Rockwell](../../team/index.md#kelli-rockwell) (Engineering)
-- Bio link (Engineering)
-- Bio link (Product)
+- [Joe Chen](../../team/index.md#joe-chen) (Engineering)
+- [Marisa Kanemoto](../../team/index.md#marisa-kanemoto) (Product)
 - [Inés Roitman](../../team/index.md#inés-roitman) (People Ops)
 
 The responsibilities of the mentorship program champions are 3-fold:


### PR DESCRIPTION
A couple miscellaneous updates now that our team of mentorship program champions has been formed!