### PR TITLE
Adds End-to-End review as onboarding step

### DIFF
--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -6,23 +6,6 @@ Having gone though [the Process St onboarding](https://app.process.st/reports/) 
 
 Your perspective as both a new user of Sourcegraph and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are onboarding and learning the product. We’ll use those notes to improve the product and process.
 
-## Manager checklist
-
-- Complete the [product team manager checklist](../../onboarding/index.md#manager-checklist)
-- Add the designer to these team meetings:
-  - Design sync meeting (both meetings!)
-  - Design retro meeting (first Wednesday of the month)
-  - Add the designer to the relevant meetings for their team (if not handled by email groups)
-- Notify people ops to include the new designer to the following:
-  - GitHub groups:
-    - @sourcegraph/design
-  - Google groups:
-    - product-design@sourcegraph.com
-  - Slack groups:
-    - @design-team
-    - @product-team
-    - Their product team's groups
-- In their 1-1 doc introduce the designer to a few Figma files that are relevant to their team
 
 ## Designer checklist
 
@@ -78,3 +61,42 @@ You'll find we have a strong base to work from, but we are in the early stages o
     - Name pages consistently, use emojis to help indicate purpose
     - Use a cover page and cover component to help with readibly
     - Use an About section to help others know what the file/page/section does
+
+## UX End-To-End Review
+
+To get yourself familiar with the product and the team you are going to be working with, a possible onboarding task can be doing an End-to-End review to the journeys you'll be working on.
+
+Your manager may help you find the right start and end point of the said journey, but the idea is to simply record yourself trying to reach the goal of the task.
+
+This will be useful for you, because you'll be puting the shoes of our users so you'll get a sense of what the UX of the journey is like. 
+
+This is also useful for the rest of the team, because you'll certeanly find insoncsistencies or even bugs that can be then reported to the correct onwers. The fact that your are joining, and have a fresh look of our product is very valuable, and don't forget that similarly to any other user test, we are not evaluating you, our your technical capabilities!
+
+###  How to create an End-To-End Review
+
+For this you can use Quicktime to record your screen. Audio is not needed, but if you want to record your thoughts during the proccess you can add audio. You can also use any other software to record your screen, as long as the final video can be watched by everyone.
+
+Then you may duplicate and fill [this template](https://docs.google.com/document/d/1ct4Fy4H6TLgkUwEdap121-NkvIMMlBp5J7oowmvz3Tk/edit?usp=sharing) with the issues you found and the related timestamps for the video.
+If you choose to upload your video to google drive, you can add the time stamps by appending "/view?t=1m05s" to the video URL
+
+Then, coordinate with you manager and share the results with the design team.
+
+---
+
+## Manager checklist
+
+- Complete the [product team manager checklist](../../onboarding/index.md#manager-checklist)
+- Add the designer to these team meetings:
+  - Design sync meeting (both meetings!)
+  - Design retro meeting (first Wednesday of the month)
+  - Add the designer to the relevant meetings for their team (if not handled by email groups)
+- Notify people ops to include the new designer to the following:
+  - GitHub groups:
+    - @sourcegraph/design
+  - Google groups:
+    - product-design@sourcegraph.com
+  - Slack groups:
+    - @design-team
+    - @product-team
+    - Their product team's groups
+- In their 1-1 doc introduce the designer to a few Figma files that are relevant to their team

--- a/content/departments/product-engineering/product/design/onboarding/index.md
+++ b/content/departments/product-engineering/product/design/onboarding/index.md
@@ -6,7 +6,6 @@ Having gone though [the Process St onboarding](https://app.process.st/reports/) 
 
 Your perspective as both a new user of Sourcegraph and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are onboarding and learning the product. We’ll use those notes to improve the product and process.
 
-
 ## Designer checklist
 
 - Join the design-related Slack channels:
@@ -68,11 +67,11 @@ To get yourself familiar with the product and the team you are going to be worki
 
 Your manager may help you find the right start and end point of the said journey, but the idea is to simply record yourself trying to reach the goal of the task.
 
-This will be useful for you, because you'll be puting the shoes of our users so you'll get a sense of what the UX of the journey is like. 
+This will be useful for you, because you'll be puting the shoes of our users so you'll get a sense of what the UX of the journey is like.
 
 This is also useful for the rest of the team, because you'll certeanly find insoncsistencies or even bugs that can be then reported to the correct onwers. The fact that your are joining, and have a fresh look of our product is very valuable, and don't forget that similarly to any other user test, we are not evaluating you, our your technical capabilities!
 
-###  How to create an End-To-End Review
+### How to create an End-To-End Review
 
 For this you can use Quicktime to record your screen. Audio is not needed, but if you want to record your thoughts during the proccess you can add audio. You can also use any other software to record your screen, as long as the final video can be watched by everyone.
 


### PR DESCRIPTION
Adds end-to-end review as a possible onboarding step, with a brief description on how to do it.

Moves the Manager checklist to the bottom, since there are more Designers than Design Managers, the design manager section is not as useful for most of the readers of this page