### PR TITLE
Refresh the security index and infra pages

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/security/index.md
+++ b/content/departments/product-engineering/engineering/cloud/security/index.md
@@ -4,7 +4,7 @@
   <img src="https://storage.googleapis.com/sourcegraph-assets/security-team-logo.jpg" width="50%" alt="Shielding Sourcegraph from attackers">
 </div>
 
-We think that security is an enabler for the business. Sourcegraph is committed to proactive security, and addressing vulnerabilities in a timely manner. We approach security with a can-do philosophy, and look to achieve product goals while maintaining a positive posture, and increasing our security stance over time.
+We think that security is an enabler for the business. Sourcegraph is committed to proactive security, and addressing vulnerabilities in a timely manner. We approach security with a can-do philosophy, and look to achieve product goals while maintaining a positive posture, and improving our security stance over time.
 
 ## Members
 
@@ -13,7 +13,7 @@ We think that security is an enabler for the business. Sourcegraph is committed 
 ## Contact
 
 - [security@sourcegraph.com](mailto:security@sourcegraph.com)
-- #security channel Slack.
+- #security channel on Slack.
 - @sourcegraph/security on GitHub.
 - [report a vulnerability](reporting-vulnerabilities.md)
 
@@ -25,9 +25,12 @@ See [security goals and priorities](../../../../../strategy-goals/strategy/cloud
 
 - New members [onboarding guide](./security-onboarding.md)
 
-## Security Tooling
 
-See [tooling](./tooling/index.md) for a list of active tools we use.
+## Security infrastructure and tooling
+
+See [tooling](./tooling/index.md) for a list of active tools we use and
+[infrastructure](./infrastructure/index.md) for more information on the infrastructure
+that we maintain.
 
 ---
 
@@ -40,7 +43,6 @@ See [tooling](./tooling/index.md) for a list of active tools we use.
   - https://github.com/sourcegraph/security-issues
 - Increase our security posture by running traditional security tools such as vulnerability scanners, SAST, and DAST tools.
   - https://github.com/sourcegraph/sourcegraph/security/code-scanning
-  - [Infrastructure information](./infrastructure/index.md)
   - [Security tooling](./tooling/index.md)
 - Create a culture of security at Sourcegraph that empowers all of our engineers to write secure code.
 - Respond to Security Incidents as per our [Security Incident Response Policy](./security-incident-response.md)

--- a/content/departments/product-engineering/engineering/cloud/security/index.md
+++ b/content/departments/product-engineering/engineering/cloud/security/index.md
@@ -25,7 +25,6 @@ See [security goals and priorities](../../../../../strategy-goals/strategy/cloud
 
 - New members [onboarding guide](./security-onboarding.md)
 
-
 ## Security infrastructure and tooling
 
 See [tooling](./tooling/index.md) for a list of active tools we use and

--- a/content/departments/product-engineering/engineering/cloud/security/infrastructure/index.md
+++ b/content/departments/product-engineering/engineering/cloud/security/infrastructure/index.md
@@ -1,20 +1,34 @@
 # Security infrastructure
 
-We maintain multiple flavors of infrastructure with various degrees of management.
+The team runs most of the infrastructure that it manages itself on GCP, while Elastic
+Cloud is used for centralized logging and monitoring.
 
-## GCP infrastructure basics
+Further technical information on the security team's infrastructure can be found
+[here](https://github.com/sourcegraph/infrastructure/tree/main/security/docs).
 
-GCP infrastructure is configured via [terraform](https://www.terraform.io/) in the [infrastructure repository](https://github.com/sourcegraph/infrastructure/). All configuration for security projects should be stored in the [security subdirectory](https://github.com/sourcegraph/infrastructure/tree/main/security). Please adhere to this [terraform style guide](https://docs.sourcegraph.com/dev/background-information/languages/terraform) when working here.
+## GCP infrastructure
+
+GCP infrastructure is configured via [Terraform](https://www.terraform.io/) in the [infrastructure repository](https://github.com/sourcegraph/infrastructure/). All configuration for security projects should be stored in the [security subdirectory](https://github.com/sourcegraph/infrastructure/tree/main/security). Please adhere to this [Terraform style guide](https://docs.sourcegraph.com/dev/background-information/languages/terraform) when working here.
 
 For instructions on how to deploy this infrastructure, see [GCP Deployment Playbooks](./playbooks.md#gcp-deployment-playbooks).
 
-#### Logging
+### GCP projects
 
-## Projects
+These are the security team's current GCP projects, and what they do:
 
-These are security's current GCP projects, and what they do.
+#### sourcegraph-security-logging
 
-### sourcegraph-security-logging
-
-- Currently ingests all stackdriver logs from the projects `sourcegraph-dev`(cloud) and `sourcegraph-dogfood`(dogfood). Will later ingest logs from other sources using additional deployments within the cluster.
+- Ingests audit logging from various sources for monitoring and review. See the
+  Github documentation linked above for detailed technical documentation of
+  exactly which sources are consumed, through which pipelines, and how the data
+  is managed and monitored once it is in the cluster.
 - Currently ingests all published SCC (Security Command Center) findings and posts critical / highs to internal slack channel #security-monitoring.
+
+## Elastic Cloud
+
+Elastic Cloud can be accessed via the Okta [app dashboard](https://sourcegraph.okta.com/app/UserHome).
+Ask Tech Ops to grant you access to the application; only Security team members
+will be granted access to the platform.
+
+The process to gain administrative access to the cluster is described in more detail
+in the technical documentation linked at the top of this page.


### PR DESCRIPTION
- Fix various grammar and style nits that have been gnawing at me
- Make the link to our infrastructure page more prominent
- Update the infrastructure page to be more relevant to our current setup
- Point from the infrastructure page to the internal security infra documentation,
  as suggested by Diego