### PR TITLE
Surfacing a GitHub issue to a team

### DIFF
--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -1,6 +1,6 @@
 # Working with issues
 
-Product-engineering teams are free to adopt the workflow they want for planning out sprints and organizing their backlog. However, we need to ensure that there is a clear way to submit issues to a team, and that issues get looked at. To balance the need for flexibility (the workflow that works best for each team) with the need for consistency, each product-engineering team needs to implement a minimum set of constraints. 
+Product-engineering teams are free to adopt the workflow they want for planning out sprints and organizing their backlog. However, we need to ensure that there is a clear way to submit issues to a team, and that issues get looked at. To balance the need for flexibility (the workflow that works best for each team) with the need for consistency, each product-engineering team needs to implement a minimum set of constraints.
 
 In other words, pick the workflow you want, as long as you implement this interface:
 

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -1,0 +1,9 @@
+# Working with issues
+
+Product-engineering teams are free to adopt the workflow they want for planning out sprints and organizing their backlog. However, we need to ensure that there is a clear way to submit issues to other teams, and that issues get looked at. To balance the need for flexibility (the workflow that works best for each team) with the need for consistency, each product-engineering team needs to implement a minimum set of constraints. In other words, pick the workflow you want, as long as you implement this interface:
+
+- **use GitHub as the single source of truth** (if you want to use something else, it's your responsibility to build the mechanism to sync it with GitHub)
+- **the only thing needed to surface an issue to a team is to add its team label to the issue** (eg. `team/batchers`). It's the responsibility of each team to setup the right process or [automation](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/label-move.yml) to make that happen. Note that this does not guarantee that this issue will be prioritized and worked on, just that it will be on the team's radar.
+- **teams have a Triage column on their board**, where everybody (including automation) can add things for prioritization
+- **teams have a Backlog column on their board**
+

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -10,5 +10,4 @@ In other words, pick the workflow you want, as long as you implement this interf
 - **teams have a Triage column on their board**, where everybody (including automation) can add things for prioritization
 - **teams have a Backlog column on their board**
 
-
 Note that customers are not expected to follow this process and cannot label issues. The [PM on feedback rotation](../product/process/ product_feedback_rotation) makes sure that issues submitted by users outside Sourcegraph get labeled properly, so that they get on the owning team's radar.

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -1,8 +1,11 @@
 # Working with issues
 
-Product-engineering teams are free to adopt the workflow they want for planning out sprints and organizing their backlog. However, we need to ensure that there is a clear way to submit issues to other teams, and that issues get looked at. To balance the need for flexibility (the workflow that works best for each team) with the need for consistency, each product-engineering team needs to implement a minimum set of constraints. In other words, pick the workflow you want, as long as you implement this interface:
+Product-engineering teams are free to adopt the workflow they want for planning out sprints and organizing their backlog. However, we need to ensure that there is a clear way to submit issues to a team, and that issues get looked at. To balance the need for flexibility (the workflow that works best for each team) with the need for consistency, each product-engineering team needs to implement a minimum set of constraints. 
+
+In other words, pick the workflow you want, as long as you implement this interface:
 
 - **use GitHub as the single source of truth** (if you want to use something else, it's your responsibility to build the mechanism to sync it with GitHub)
+- **all issues have a team label**
 - **the only thing needed to surface an issue to a team is to add its team label to the issue** (eg. `team/batchers`). It's the responsibility of each team to setup the right process or [automation](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/label-move.yml) to make that happen. Note that this does not guarantee that this issue will be prioritized and worked on, just that it will be on the team's radar.
 - **teams have a Triage column on their board**, where everybody (including automation) can add things for prioritization
 - **teams have a Backlog column on their board**

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -11,3 +11,7 @@ In other words, pick the workflow you want, as long as you implement this interf
 - **teams have a Backlog column on their board**
 
 Note that customers are not expected to follow this process and cannot label issues. The [PM on feedback rotation](../product/process/ product_feedback_rotation) makes sure that issues submitted by users outside Sourcegraph get labeled properly, so that they get on the owning team's radar.
+
+#### Surfacing issues to the design team
+
+Issues that need design work can be tagged with the `needs-design` label.

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -6,4 +6,3 @@ Product-engineering teams are free to adopt the workflow they want for planning 
 - **the only thing needed to surface an issue to a team is to add its team label to the issue** (eg. `team/batchers`). It's the responsibility of each team to setup the right process or [automation](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/label-move.yml) to make that happen. Note that this does not guarantee that this issue will be prioritized and worked on, just that it will be on the team's radar.
 - **teams have a Triage column on their board**, where everybody (including automation) can add things for prioritization
 - **teams have a Backlog column on their board**
-

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -9,3 +9,6 @@ In other words, pick the workflow you want, as long as you implement this interf
 - **the only thing needed to surface an issue to a team is to add its team label to the issue** (eg. `team/batchers`). It's the responsibility of each team to setup the right process or [automation](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/label-move.yml) to make that happen. Note that this does not guarantee that this issue will be prioritized and worked on, just that it will be on the team's radar.
 - **teams have a Triage column on their board**, where everybody (including automation) can add things for prioritization
 - **teams have a Backlog column on their board**
+
+
+Note that customers are not expected to follow this process and cannot label issues. The [PM on feedback rotation](../product/process/ product_feedback_rotation) makes sure those issues get labeled properly, so that they get on the owning team's radar.

--- a/content/departments/product-engineering/process/working-with-issues.md
+++ b/content/departments/product-engineering/process/working-with-issues.md
@@ -11,4 +11,4 @@ In other words, pick the workflow you want, as long as you implement this interf
 - **teams have a Backlog column on their board**
 
 
-Note that customers are not expected to follow this process and cannot label issues. The [PM on feedback rotation](../product/process/ product_feedback_rotation) makes sure those issues get labeled properly, so that they get on the owning team's radar.
+Note that customers are not expected to follow this process and cannot label issues. The [PM on feedback rotation](../product/process/ product_feedback_rotation) makes sure that issues submitted by users outside Sourcegraph get labeled properly, so that they get on the owning team's radar.

--- a/content/departments/product-engineering/product/process/surfacing_product_feedback.md
+++ b/content/departments/product-engineering/product/process/surfacing_product_feedback.md
@@ -69,5 +69,5 @@ If you are uncomfortable posting feedback directly for any reason at all, you ar
 
 ## Surfacing internal feedback or requests
 
-- Any teammate can open an issue for consideration by a product-engineering team, and assign the team's label. Product-engineering teams each have their own workflow for triaging issues, but use [common principles](../../working-with-issues.md)
+- Any teammate can open an issue for consideration by a product-engineering team, and assign the team's label. Product-engineering teams each have their own workflow for triaging issues, but use [common principles](../../process/working-with-issues.md)
 - The #wg-dogfood is currently working on improving this process.

--- a/content/departments/product-engineering/product/process/surfacing_product_feedback.md
+++ b/content/departments/product-engineering/product/process/surfacing_product_feedback.md
@@ -1,5 +1,7 @@
 # Surfacing feedback to the product team
 
+## Surfacing customer feedback
+
 > If you're working with a specific customer on a bug or issue and need to directly involve a product engineering team, please refer to [engaging other teams](../../../support/process/engaging-other-teams.md).
 
 CEs, application engineers (CS), Sales, Marketing, Engineering, and other teammates that interact directly with Sourcegraph users and/or Sourcegraph itself should share product feedback or feature requests with the product team.
@@ -11,9 +13,9 @@ We deeply value this feedback, so we make this process as frictionless for teamm
 
 Bugs can be directly submitted as a GitHub issue.
 
-## Product gaps
+### Product gaps
 
-### What is a Product gap?
+#### What is a Product gap?
 
 It is important to distinguish all customer feedback you receive from what would be considered a product gap. A product gap would be some feedback you collect from a prospect during your initial sales cycle, or from an existing customer, that could be within the expected scope of work for our Product and Engineering team. This especially pertains to either new feature requests or enhancements to existing features that could likely be incorporated in to our roadmap. In contrast, a product gap is NOT a bug nor should it be a potential request that falls well outside the scope of Sourcegraph intended use and function.
 
@@ -35,7 +37,7 @@ View the [full list of product gap categories/subcategories](https://docs.google
 
 New product gap submissions will be automatically posted to the #feedback channel, @-mentioning the PM responsible for the relevant product area. This automation relies on a [zap](https://zapier.com/app/editor/145738791), and the PM - area mapping is hard-coded there and should be modified when necessary.
 
-### Product Gap Statuses
+#### Product Gap Statuses
 
 PMs are responsible for updating a Gap after it's been opened. If a particular feature request is known to have a different status than what is reflected in a Product Gap, anyone is encouraged to update the status (e.g. if a feature is currently in Beta but the gap does not reflect).
 
@@ -49,7 +51,7 @@ PMs are responsible for updating a Gap after it's been opened. If a particular f
 - **GA** - fully available in standard release.
 - **Won't do** - we're not going to do this
 
-### Creating GitHub Issues
+#### Creating GitHub Issues
 
 Customer Engineers should no longer be creating GitHub issues for feature requests from their Customers. Instead, Product Eng will manage the process of extracting Product Gaps from Salesforce to add to GitHub.
 
@@ -57,10 +59,15 @@ Bugs can still be submitted as GitHub issues.
 
 Note: while this will currently be a manual process, we intend to automate the creation of GH issues upon creating of a new Product Gap in Salesforce.
 
-### What if the feedback is [a possible exception]?
+#### What if the feedback is [a possible exception]?
 
 There are no exceptions to the above process! Please do post all ARR-impacting product feedback in Salesforce – **this includes feedback that you feel might be: minor, not worth surfacing, too harsh, just a personal opinion, or from you rather than a customer**. All feedback helps us make Sourcegraph the best product possible.
 
-## If you are uncomfortable posting the feedback
+### If you are uncomfortable posting the feedback
 
 If you are uncomfortable posting feedback directly for any reason at all, you are very welcome to DM it on Slack to any [member of the product team](index.md#members). They will make sure it reaches the right folks. In some cases, this may mean they post the feedback to slack after removing any possible connection to you.
+
+## Surfacing internal feedback or requests
+
+- Any teammate can open an issue for consideration by a product-engineering team, and assign the team's label. Product-engineering teams each have their own workflow for triaging issues, but use [common principles](../../working-with-issues.md)
+- The #wg-dogfood is currently working on improving this process.


### PR DESCRIPTION
TL;DR - use whatever workflow you want, but we use team labels to assign to teams.