### PR TITLE
Define ownership of GitHub and its applications

### DIFF
--- a/data/engineering_ownership.yml
+++ b/data/engineering_ownership.yml
@@ -790,25 +790,25 @@ webhooks:
 github:
   category: Tooling
   title: GitHub
-  type: Tech  
+  type: Tech
   product_org: enablement
   product_team: dev_experience
   slack_channels: '#dev-experience'
   ownership_model: Owner
-  
+
 github_applications:
   category: Tooling
   title: GitHub Applications (incl. 3rd party apps)
-  type: Tech  
+  type: Tech
   product_org: enablement
   product_team: dev_experience
   slack_channels: '#dev-experience'
-  ownership_model: Owner  
-  
+  ownership_model: Owner
+
 cla_bot:
   category: Tooling
   title: Contributor Licence Agreement Bot (cla-bot)
-  type: Tech  
+  type: Tech
   product_org: enablement
   product_team: dev_experience
   slack_channels: '#dev-experience'

--- a/data/engineering_ownership.yml
+++ b/data/engineering_ownership.yml
@@ -786,3 +786,30 @@ webhooks:
   category: Web App - Core Feature
   title: Webhooks
   type: Product
+
+github:
+  category: Tooling
+  title: GitHub
+  type: Tech  
+  product_org: enablement
+  product_team: dev_experience
+  slack_channels: '#dev-experience'
+  ownership_model: Owner
+  
+github_applications:
+  category: Tooling
+  title: GitHub Applications (incl. 3rd party apps)
+  type: Tech  
+  product_org: enablement
+  product_team: dev_experience
+  slack_channels: '#dev-experience'
+  ownership_model: Owner  
+  
+cla_bot:
+  category: Tooling
+  title: Contributor Licence Agreement Bot (cla-bot)
+  type: Tech  
+  product_org: enablement
+  product_team: dev_experience
+  slack_channels: '#dev-experience'
+  ownership_model: Owner


### PR DESCRIPTION
The Dev Experience team is the owner of GitHub and any third-party applications installed.
This also includes the `cla-bot`, which gets external contributors to sign the Contributor Licence Agreement.