### PR TITLE
remove reference to baremetal agents

### DIFF
--- a/content/departments/product-engineering/engineering/tools/infrastructure/ci/index.md
+++ b/content/departments/product-engineering/engineering/tools/infrastructure/ci/index.md
@@ -31,4 +31,4 @@ We have several different types of agents availables. We recommend explicitly de
 The currently available queues:
 
 - `standard`: our default Buildkite agents, currently Docker-in-Docker agents running in Kubernetes
-- `baremetal`: special Buildkite agents running on standalone machines
+- `vagrant`: special Buildkite agents desgined to run resource intensive test on docker deployments.


### PR DESCRIPTION
We no longer use a `baremetal` queue for any of our agents after the introduction of stateless agents and the subsequent cutover of all e2e/qa tests. 