### PR TITLE
Improve MI upgrade process

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -210,6 +210,7 @@ Then, to upgrade the new `$NEW_DEPLOYMENT` deployment to `$NEW_VERSION`:
 
 ```sh
 VERSION=$NEW_VERSION ../util/update-docker-compose.sh $NEW_DEPLOYMENT/
+go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
 git --no-pager diff $NEW_DEPLOYMENT
 ```
 

--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -210,7 +210,6 @@ Then, to upgrade the new `$NEW_DEPLOYMENT` deployment to `$NEW_VERSION`:
 
 ```sh
 VERSION=$NEW_VERSION ../util/update-docker-compose.sh $NEW_DEPLOYMENT/
-go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
 git --no-pager diff $NEW_DEPLOYMENT
 ```
 
@@ -223,6 +222,12 @@ You can list references like so (if nothing shows up, you should be good to go):
 ```sh
 cat $NEW_DEPLOYMENT/docker-compose/docker-compose.yaml | grep "$OLD_VERSION#v"
 cat $NEW_DEPLOYMENT/docker-compose/docker-compose.yaml | grep upstream
+```
+
+Ensure all images are pinned to `$NEW_VERSION`
+
+```sh
+go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
 ```
 
 Commit and apply the upgrade:
@@ -567,7 +572,6 @@ Update version references:
 
 ```sh
 VERSION=$NEW_VERSION ../util/update-docker-compose.sh $NEW_DEPLOYMENT/
-go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
 git --no-pager diff $NEW_DEPLOYMENT
 ```
 
@@ -579,6 +583,12 @@ cat $NEW_DEPLOYMENT/docker-compose/docker-compose.yaml | grep upstream
 ```
 
 Resolve any merge conflicts that have arisen.
+
+Ensure all images are pinned to `$NEW_VERSION`
+
+```sh
+go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
+```
 
 ### 3) Apply changes to instance
 

--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -338,7 +338,11 @@ Remove the notice previously added to the global user settings:
 git push origin HEAD
 ```
 
-And click the provided link to open a pull request in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed).
+And click the provided link to open a pull request in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed). Or use [gh](https://github.com/cli/cli):
+
+```sh
+gh pr create --title "$CUSTOMER: upgrade to $NEW_VERSION" --body "## Test plan No review required: normal upgrade"
+```
 
 **IMPORTANT: DO NOT FORGET TO GET YOUR PR APPROVED AND MERGED**, if you forget then the next person upgrading the instance will have a very bad time.
 

--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -567,6 +567,7 @@ Update version references:
 
 ```sh
 VERSION=$NEW_VERSION ../util/update-docker-compose.sh $NEW_DEPLOYMENT/
+go run ../util/enforce-tags.go $NEW_VERSION $NEW_DEPLOYMENT/docker-compose/.
 git --no-pager diff $NEW_DEPLOYMENT
 ```
 


### PR DESCRIPTION
some customer's docker-compose is quite different from the upstream.

for example, this has two frontend containers https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/glovo/black/docker-compose/docker-compose.yaml#L170

the usual way of merging with upstream docker-compose will leave these services image tag unchanged, and result in undesired behaviour
https://sourcegraph.slack.com/archives/C02VDNKBWDU/p1646664478240469

the added step can ensure all images in the docker-compose are using the correct version