### PR TITLE
Adjust OKR grading

### DIFF
--- a/content/departments/product-engineering/process/planning-process.md
+++ b/content/departments/product-engineering/process/planning-process.md
@@ -55,11 +55,11 @@ Sourcegraph has a top-level [strategy page](../../../strategy-goals/strategy/ind
 - **Grading:** At the end of the quarter we grade both KRs and Objectives.
   - We grade KRs based on how they are worded at the end of the quarter. If our understanding of what success looks like changes throughout the quarter, then we need to update KR definitions before the end of the quarter.
   - After we grade the KRs individually, we review whether we subjectively achieved the objectives or not.
-  - Rubric 
+  - Rubric
     | Status | Description |
     | ------------- | -------------------------------------------- |
-    | 🟢 | We achieved success (90-100% completion for non-binary outcomes)  |
-    | ⚠️ | We achieved partial success (75–89% completion for non-binary outcomes)  |
+    | 🟢 | We achieved success (90-100% completion for non-binary outcomes) |
+    | ⚠️ | We achieved partial success (75–89% completion for non-binary outcomes) |
     | 🛑 | We did not achieve success (<75% completion for non-binary outcomes) |
 
 Our philosophy on goal setting as well as a view into our history of goals is [published in our handbook](../../../strategy-goals/goals/index.md).
@@ -215,12 +215,13 @@ Updates and highlights of what has changed are shared in #prod-eng-announce Slac
 ### Weekly OKR updates
 
 The DRI (directly responsible individaul) for each OKR is responsible for posting an update to the associated tracking issue by 19:00 UTC each Friday. To post an update, create a new comment with the following details:
-  - Forecasted grade for the KR at the end of the quarter: 🟢, ⚠️, 🛑.
-  - Short description of why the forecast is what it is. Here are some example questions to consider (not every question here is relevant to every update):
-    - What gives us confidence we're on track?
-    - What recent progress have we made? 
-    - For numeric goals, what is the current state of the metric and the trend line?
-    - What has slowed us down?
-    - What are the risks looking ahead?
-    - What are next steps (and who is owning those steps)?
-    - What can be done to get this KR back on track?
+
+- Forecasted grade for the KR at the end of the quarter: 🟢, ⚠️, 🛑.
+- Short description of why the forecast is what it is. Here are some example questions to consider (not every question here is relevant to every update):
+  - What gives us confidence we're on track?
+  - What recent progress have we made?
+  - For numeric goals, what is the current state of the metric and the trend line?
+  - What has slowed us down?
+  - What are the risks looking ahead?
+  - What are next steps (and who is owning those steps)?
+  - What can be done to get this KR back on track?

--- a/content/departments/product-engineering/process/planning-process.md
+++ b/content/departments/product-engineering/process/planning-process.md
@@ -52,6 +52,15 @@ Sourcegraph has a top-level [strategy page](../../../strategy-goals/strategy/ind
     - [OKR Github tracker](https://github.com/sourcegraph/product-engineering-tracker/issues/65) is the source of truth for prod/eng OKRs and is updated weekly with progress. This is private because KRs frequently contain sensitive business metrics and customer names. Each KR has an associated GitHub issue following [this template](https://github.com/sourcegraph/product-engineering-tracker/issues/new?template=product-engineering-kr.md).
     - A [Prod/Eng dashboard slide](https://docs.google.com/presentation/d/1KUOElUkrH-29teXmZBmgmIgLngf-I_6Ikixub1SR0yM/edit#slide=id.g1122c1a30bf_10_0) in the Exec OKR Google Slide deck which is used to signal any critical updates on a weekly basis. An OKR progress review is done monthly
     - The [handbook OKR page](../../../strategy-goals/goals/index.md) is the sanitized public version of our OKRs. It captures a distilled version of our department OKRs and does not include status updates
+- **Grading:** At the end of the quarter we grade both KRs and Objectives.
+  - We grade KRs based on how they are worded at the end of the quarter. If our understanding of what success looks like changes throughout the quarter, then we need to update KR definitions before the end of the quarter.
+  - After we grade the KRs individually, we review whether we subjectively achieved the objectives or not.
+  - Rubric 
+    | Status | Description |
+    | ------------- | -------------------------------------------- |
+    | 🟢 | We achieved success (90-100% completion for non-binary outcomes)  |
+    | ⚠️ | We achieved partial success (75–89% completion for non-binary outcomes)  |
+    | 🛑 | We did not achieve success (<75% completion for non-binary outcomes) |
 
 Our philosophy on goal setting as well as a view into our history of goals is [published in our handbook](../../../strategy-goals/goals/index.md).
 
@@ -205,16 +214,13 @@ Updates and highlights of what has changed are shared in #prod-eng-announce Slac
 
 ### Weekly OKR updates
 
-- The DRI (directly responsible individaul) for each OKR is responsible for posting an update to the associated tracking issue by 19:00 UTC each Friday. To post an update, create a new comment with the following details:
-  - The status of how we are tracking toward the goal (for numeric goals, include the current number we are at).
-    | Status | Description |
-    | ------------- | -------------------------------------------- |
-    | 🟢 On track | 90–100% confidence we will achieve the goal. |
-    | ⚠️ At risk | 75–89% confidence we will achieve the goal. |
-    | 🛑 Off track | <75% confidence we will achieve the goal. |
-    | 🚀 Done | We have achieved the goal! |
-    | ☠️ Cancelled | We are no longer pursuing this goal. |
-  - Description of concrete progress that has been made since the last weekly update.
-  - Clear next steps and owners.
-  - Any other helpful information (ex: risks, requests for help).
-- VP Product and VP Eng review and ask questions async and then anything that needs discussion is added to [VP team sync agenda](../team/index.md#vp-team-sync).
+The DRI (directly responsible individaul) for each OKR is responsible for posting an update to the associated tracking issue by 19:00 UTC each Friday. To post an update, create a new comment with the following details:
+  - Forecasted grade for the KR at the end of the quarter: 🟢, ⚠️, 🛑.
+  - Short description of why the forecast is what it is. Here are some example questions to consider (not every question here is relevant to every update):
+    - What gives us confidence we're on track?
+    - What recent progress have we made? 
+    - For numeric goals, what is the current state of the metric and the trend line?
+    - What has slowed us down?
+    - What are the risks looking ahead?
+    - What are next steps (and who is owning those steps)?
+    - What can be done to get this KR back on track?


### PR DESCRIPTION
Updating the documentation here to provide clarity on how we think about and grade objectives and KRs at the end of the quarter.

Clarifications
* We orient around how we are going to grade things at the end of the quarter.
* Mid-quarter status updates are simply our forecasted grade at the end of the quarter.
* Simplify states (KRs that are done will be represented as 🟢  and KRs that would be marked as ☠️  should either get deleted or will be marked as 🛑).