### PR TITLE
Updates to CPT team page

### DIFF
--- a/content/departments/product-engineering/engineering/enablement/content-platform/index.md
+++ b/content/departments/product-engineering/engineering/enablement/content-platform/index.md
@@ -29,7 +29,6 @@ The Content Platform team has the following customers:
 1. Product department: The docs site
 1. Docs team: The docs site
 
-
 ## Principles
 
 We inherit Sourcegraph's [engineering principles and practices](../../process/principles-and-practices.md) and [Enablement principles and practices](../index.md#principles-and-practices).

--- a/content/departments/product-engineering/engineering/enablement/content-platform/index.md
+++ b/content/departments/product-engineering/engineering/enablement/content-platform/index.md
@@ -20,9 +20,35 @@ The current existing content platforms include:
 - [Handbook](https://handbook.sourcegraph.com)
 - [Docs](https://docs.sourcegraph.com)
 
+### Customers
+
+The Content Platform team has the following customers:
+
+1. Marketing department: The marketing, blog, and learn sites.
+1. Content Platform: The handbook site
+1. Product department: The docs site
+1. Docs team: The docs site
+
+
 ## Principles
 
 We inherit Sourcegraph's [engineering principles and practices](../../process/principles-and-practices.md) and [Enablement principles and practices](../index.md#principles-and-practices).
+
+### Guiding principles
+
+1. **Customer-first:** we exist to enable our customers to succeed against their objectives.
+1. **Empowerment:** we build everything to empower the customer to be self-sufficient in managing the content.
+1. **Forward-thinking:** we execute on our customers’ requests, keeping the overall content ecosystem in mind to drive efficiency and re-use.
+1. **Indexability:** Search engines’ ability to index the content is not an afterthought and is key to success.
+1. **High-quality:** The content platforms are the face of Sourcegraph to the public, and given our developer-focused audience, only the highest quality of engineering will be acceptable.
+
+## Where we are now
+
+We intend to form a self-sufficient engineering team with all the necessary cross-functional roles to deliver on the mission.
+
+We envision driving two workstreams inside of the team, one focused on the more traditional markdown-driven content architecture (handbook, docs) and one around CMS-driven content (marketing, blog, learn). By looking at our platforms from a content-neutral way, we still believe there are many shared elements between all the sites and want to optimize for efficiency. Also, if/when needs of the handbook and docs sites diverge more drastically from the other sites to the point where it causes inefficiency in the team, we will treat it as a signal that it is time to evaluate whether to split the team.
+
+This team will be successful if it can deliver on its customers’ needs to help them achieve their goals. Streamlining the prioritization and delivery of work while enabling self-service ability is essential. Ultimately, meeting the delivery commitments on time will determine the team’s success.
 
 ## Contact
 


### PR DESCRIPTION
1. Moved “Guiding Principles” & “Where we are” Now section from the strategy page to this page
2. Moved the Customers section from the strategy page to the this page