### PR TITLE
Add default hero recommendation

### DIFF
--- a/content/departments/marketing/content/creating_blog_posts.md
+++ b/content/departments/marketing/content/creating_blog_posts.md
@@ -56,6 +56,7 @@ The data between the `---` is called front matter and is used to provide post me
 - As long as `published` is true, your post will be visible, even if the value of `publishDate` is set in the future.
 - The `canonical` field is optional and only required to override the canonical link. Important for cross-posting blogs from personal blogs or published news sites. By default, set to `https://about.sourcegraph.com/blog/the-blog-slug`.
 - The `socialImage` field is optional. Use the full path to image in order to be read properly on Twitter and Facebook. Ideal image size: 1,200 x 628 pixels. <a href="https://sproutsocial.com/insights/social-media-image-sizes-guide/" rel="nofollow" target="_blank">Latest social size guidelines</a>.
+- If you do not have a custom hero or social image, use this [default hero image](https://storage.googleapis.com/sourcegraph-assets/blog/default_hero_social.png).
 
 ## Adding images and other media
 


### PR DESCRIPTION
Fabiana has asked that we use a new default hero instead of the old Sourcegraph logo. Adding this to our template here so we and others can find it easily. 