### PR TITLE
Re-arranged our heading

### DIFF
--- a/content/strategy-goals/strategy/enablement/index.md
+++ b/content/strategy-goals/strategy/enablement/index.md
@@ -18,7 +18,7 @@ With each initiative we undertake we expect to learn more about what the right s
 
 ### Developer Happiness & Efficacy
 
-One of the keys to effectively putting valuable product into our customer's hands is a reliable CI pipeline. We are currently working on stateless agents and reducing flakey tasks to ensure CI pipeline stability. Having a fast and reliable CI is only half the battle in giving engineers confidence in shipping code. We need to work on improving our software testing philosophy, development standards and frameworks to all work together with an improved CI.
+One of the keys to putting valuable product into our customer's hands is a reliable CI pipeline. We are currently working on stateless agents and reducing flakey tasks to ensure CI pipeline stability. Having a fast and reliable CI is only half the battle in giving engineers confidence in shipping code. We need to work on improving our software testing philosophy, development standards and frameworks to all work together with an improved CI.
 Throughout this year we will work to refine Sourcegraph’s software testing philosophy, set clear testing development standards, standarde our test tooling and measure and monitor test effectiveness.
 
 ### Customer Driven Quality

--- a/content/strategy-goals/strategy/enablement/index.md
+++ b/content/strategy-goals/strategy/enablement/index.md
@@ -10,11 +10,11 @@ We also support Marketing, Sales, and all Sourcegraph employees that contribute 
 
 ## Vision
 
-We want to reduce friction through better processes and tooling such that Sourcegraph’s teammates can provide greater value to our customers more reliably and with improved quality.  Realizing this vision is vital in enabling other teams at Sourcegraph to deliver on our Product/Engineering strategy.
+We want to reduce friction through better processes and tooling such that Sourcegraph’s teammates can provide greater value to our customers more reliably and with improved quality. Realizing this vision is vital in enabling other teams at Sourcegraph to deliver on our Product/Engineering strategy.
 
 ## Strategy
 
-With each initiative we undertake we expect to learn more about what the right solution looks like at Sourcegraph and therefore will put extra emphasis on capturing and understanding what the data tells us to ensure we don’t just blindly follow our roadmap.  The two key themes we are focused on in Enablement are Developer Happiness & Efficacy & Customer driven quality.
+With each initiative we undertake we expect to learn more about what the right solution looks like at Sourcegraph and therefore will put extra emphasis on capturing and understanding what the data tells us to ensure we don’t just blindly follow our roadmap. The two key themes we are focused on in Enablement are Developer Happiness & Efficacy & Customer driven quality.
 
 ### Developer Happiness & Efficacy
 

--- a/content/strategy-goals/strategy/enablement/index.md
+++ b/content/strategy-goals/strategy/enablement/index.md
@@ -10,37 +10,20 @@ We also support Marketing, Sales, and all Sourcegraph employees that contribute 
 
 ## Vision
 
-We want to reduce friction through better processes and tooling such that Sourcegraph’s teammates can provide greater value to our customers more reliably and with improved quality.
-
-Realizing this vision is vital in enabling other teams at Sourcegraph to deliver on our Product/Engineering strategy.
-
-### Focus for FY23
-
-Our business startegy and focus on the enterprise customer has highlighted key areas of focus to provide Sourcegraph's teams with better tools, processes, and services that will allow us to provide value to our customer faster and with improved quality.
-
-To deliver on this focus our aim is to make the following true by the end of FY23:
-
-- The Sourcegraph application, its runtime environment, and build and deploy pipelines are easily observable.
-- Our CI pipeline is fast and consistent.
-- Our code authoring and review processes ensures we raise the bar for shipping high quality code.
-- Our codebase, testing processes, and development tooling is more consistent and well understood.
-- Our codebase is easy to onboard, easy to navigate, and reflects the boundaries of general work streams.
-- Sourcegraph teammates can easily contribute to our website through our content management system
+We want to reduce friction through better processes and tooling such that Sourcegraph’s teammates can provide greater value to our customers more reliably and with improved quality.  Realizing this vision is vital in enabling other teams at Sourcegraph to deliver on our Product/Engineering strategy.
 
 ## Strategy
 
-To achieve the outcomes we want to see in FY23 we will undertake initiatives across the themes listed below.
-
-With each initiative we undertake we expect to learn more about what the right solution looks like at Sourcegraph and therefore will put extra emphasis on capturing and understanding what the data tells us from each of these initiatives to ensure we don’t just blindly follow our roadmap, but treat each initiative as a decision point to re-evaluate the path forward.
+With each initiative we undertake we expect to learn more about what the right solution looks like at Sourcegraph and therefore will put extra emphasis on capturing and understanding what the data tells us to ensure we don’t just blindly follow our roadmap.  The two key themes we are focused on in Enablement are Developer Happiness & Efficacy & Customer driven quality.
 
 ### Developer Happiness & Efficacy
 
-One of the keys to reliably pushing code into the wild is a reliable CI pipeline. We are currently working on stateless agents and reducing flakey tasks to ensure CI pipeline stability. Having a fast and reliable CI is only half the battle in giving engineers confidence in shipping code. We need to work on improving our software testing philosophy, development standards and frameworks to all work together with an improved CI.
+One of the keys to effectively putting valuable product into our customer's hands is a reliable CI pipeline. We are currently working on stateless agents and reducing flakey tasks to ensure CI pipeline stability. Having a fast and reliable CI is only half the battle in giving engineers confidence in shipping code. We need to work on improving our software testing philosophy, development standards and frameworks to all work together with an improved CI.
 Throughout this year we will work to refine Sourcegraph’s software testing philosophy, set clear testing development standards, standarde our test tooling and measure and monitor test effectiveness.
 
 ### Customer Driven Quality
 
-When our customers interact with our product as an end user or administrator they immediately feel the impact of our core development practices and framework. We want to ensure our customer's experience with our product is the best it can be and therefore we rely heavily on having quality engineering practices. This year we are focused on improving in the following three key areas.
+When our customers interact with our product as an end user or administrator they immediately feel the impact of our core development practices and framework. We want to ensure our customers experience the best of our product and therefore we rely heavily on having quality engineering practices. This year we are focused on improving in the following three key areas.
 
 #### Observability Improvements
 
@@ -53,6 +36,19 @@ Code host connectivity, scalability, and reliability underpin all other features
 #### Accessibility
 
 Today, the Sourcegraph web application does not comply with current WCAG guidelines. Ensuring our web application becomes--and stays--compliant is essential not just because we have current contractual obligations to do so, but also because: 1) We believe in the value of making our application compliant in furthering our mission 2) Compliance be a requirement of future clients and can be a unique selling point.
+
+## Focus for FY23
+
+Our focus on the enterprise customer has highlighted key areas we will focus in FY23 to provide Sourcegraph teammates with better tools, processes, and services, enabling us to provide value to our customer faster and with improved quality.
+
+To deliver on this focus our aim is to make the following true by the end of FY23:
+
+- The Sourcegraph application, its runtime environment, and build and deploy pipelines are easily observable.
+- Our CI pipeline is fast and consistent.
+- Our code authoring and review processes ensures we raise the bar for shipping high quality code.
+- Our codebase, testing processes, and development tooling is more consistent and well understood.
+- Our codebase is easy to onboard, easy to navigate, and reflects the boundaries of general work streams.
+- Sourcegraph teammates can easily contribute to our website through our content management system
 
 ## Team specific pages
 


### PR DESCRIPTION
Updated this  page so it starts at the broadest framing around mission & vision and then narrows into what we are specifically doing this year to move the needle on that strategy.