### PR TITLE
Format NOTE block quotes deeper in the tree

### DIFF
--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -171,7 +171,7 @@ const remarkSpecialNoteBlocks: Plugin<[], MdastRoot> = () =>
     function (tree) {
         visit(tree, (node, index, parent) => {
             if (isSpecialNoteBlockquote(node)) {
-                console.log("Should work..")
+                console.log('Should work..')
                 // TODO: This overwrites the `hProperties` to add the class
                 // name. Improve it by adding the class name while respecting
                 // existing `hProperties` or existing classes.
@@ -200,13 +200,13 @@ function isSpecialNoteBlockquote(node: MdastContent): boolean {
         return false
     }
     const child = node.children[0]
-    console.log("Is blockquote")
+    console.log('Is blockquote')
     if (child.type === 'paragraph') {
-        console.log("Is paragraph")
+        console.log('Is paragraph')
         const text = child.children[0]
         console.log(text)
         if (text.type === 'text') {
-            console.log("Is text")
+            console.log('Is text')
             return text.value.startsWith('NOTE:')
         }
     }

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -171,13 +171,10 @@ const remarkSpecialNoteBlocks: Plugin<[], MdastRoot> = () =>
     function (tree) {
         visit(tree, (node, index, parent) => {
             if (isSpecialNoteBlockquote(node)) {
-                console.log('Should work..')
                 // TODO: This overwrites the `hProperties` to add the class
                 // name. Improve it by adding the class name while respecting
                 // existing `hProperties` or existing classes.
-                console.log(node)
                 node.data = { ...node.data, hName: 'aside', hProperties: { class: 'note' } }
-                console.log(node)
             }
         })
     }
@@ -200,13 +197,9 @@ function isSpecialNoteBlockquote(node: MdastContent): boolean {
         return false
     }
     const child = node.children[0]
-    console.log('Is blockquote')
     if (child.type === 'paragraph') {
-        console.log('Is paragraph')
         const text = child.children[0]
-        console.log(text)
         if (text.type === 'text') {
-            console.log('Is text')
             return text.value.startsWith('NOTE:')
         }
     }

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -169,14 +169,17 @@ const rehypeExtractTitleFromH1: Plugin = () =>
  */
 const remarkSpecialNoteBlocks: Plugin<[], MdastRoot> = () =>
     function (tree) {
-        for (const node of tree.children) {
+        visit(tree, (node, index, parent) => {
             if (isSpecialNoteBlockquote(node)) {
+                console.log("Should work..")
                 // TODO: This overwrites the `hProperties` to add the class
                 // name. Improve it by adding the class name while respecting
                 // existing `hProperties` or existing classes.
+                console.log(node)
                 node.data = { ...node.data, hName: 'aside', hProperties: { class: 'note' } }
+                console.log(node)
             }
-        }
+        })
     }
 
 /**
@@ -197,9 +200,13 @@ function isSpecialNoteBlockquote(node: MdastContent): boolean {
         return false
     }
     const child = node.children[0]
+    console.log("Is blockquote")
     if (child.type === 'paragraph') {
+        console.log("Is paragraph")
         const text = child.children[0]
+        console.log(text)
         if (text.type === 'text') {
+            console.log("Is text")
             return text.value.startsWith('NOTE:')
         }
     }


### PR DESCRIPTION
Currently, any block quotes that start with `NOTE:` are only formatted as an info block if they are a direct child of the tree root (i.e. anything indented is not formatted). This PR visits the full tree instead to also format any children further down the tree.