### PR TITLE
Remove a responsibility from CEO role description

### DIFF
--- a/content/team/ceo/roles.md
+++ b/content/team/ceo/roles.md
@@ -12,4 +12,3 @@ This page lists the roles and responsibilities of the Sourcegraph CEO.
 - Create an environment and a set of processes to support giving teammates a high level of ownership over their work.
 - Lead by example in accountability, continuous improvement, and truth-seeking.
 - Achieve the [current CEO goals](../index.md).
-- Temporary: manage the [customer engineering team](../../departments/ce/index.md) until we hire a VP Customer Engineering.


### PR DESCRIPTION
Given @amenne has been appointed as VP Customer Engineering several months ago it seems managing the CE team can be removed from @sqs CEO responsibilities.