### PR TITLE
Remove duplicated link

### DIFF
--- a/content/departments/product-engineering/engineering/code-graph/search/core.md
+++ b/content/departments/product-engineering/engineering/code-graph/search/core.md
@@ -95,7 +95,6 @@ Our team is geographically and timezone diverse. The handbook has a [large page 
   - https://www.youtube.com/watch?v=_-KTAvgJYdI
   - https://about.sourcegraph.com/blog/tackling-the-long-tail-of-tiny-repos-with-shard-merging/
   - https://about.sourcegraph.com/blog/zoekt-memory-optimizations-for-sourcegraph-cloud/
-  - https://swtch.com/~rsc/regexp/regexp4.html
   - https://github.blog/2021-12-15-a-brief-history-of-code-search-at-github/
 
 Our private resources are available [in the Google doc](https://docs.google.com/document/d/10SNzhuA5dmRJ5Na3PMnuShlPmtGGVIz3P2GA4RtfaGo/edit)


### PR DESCRIPTION
Duplicated link to https://swtch.com/~rsc/regexp/regexp4.html in "Zoekt Bedtime Reading":
- https://github.com/sourcegraph/handbook/blob/main/content/departments/product-engineering/engineering/code-graph/search/core.md?plain=1#L93
- https://github.com/sourcegraph/handbook/blob/main/content/departments/product-engineering/engineering/code-graph/search/core.md?plain=1#L98