### PR TITLE
remove extraneous asterisk

### DIFF
--- a/content/departments/product-engineering/product/roles/index.md
+++ b/content/departments/product-engineering/product/roles/index.md
@@ -12,7 +12,7 @@ Product Managers work with engineering, sales, marketing, and design to plan, sh
 
 ### Responsibilities
 
-You will **own an area of the product**\* and:
+You will **own an area of the product** and:
 
 - Significantly grow usage and engagement of that area and Sourcegraph as a whole.
 - Collaborate with, support, and motivate their team to plan and build the solutions to customer problems.


### PR DESCRIPTION
Pretty sure this was a mistake? There is no "fine print" that the asterisk refers to, and PMs do own an area of the product, so I'm not clear what limitation would be placed on that statement. Therefore I think the extra asterisk was a mistake.