### PR TITLE
add cross link to free tier docs

### DIFF
--- a/content/departments/product-engineering/engineering/code-graph/code-insights/go_to_market.md
+++ b/content/departments/product-engineering/engineering/code-graph/code-insights/go_to_market.md
@@ -31,6 +31,8 @@ You can use these as a starting point for Code Insights presentations.
 
 ### Pricing
 
+#### [Free tier of Code Insights](https://docs.sourcegraph.com/code_insights/references/license#limited-access)
+
 #### [Primary pricing document for AEs](https://docs.google.com/document/d/11Y5ZDIT_nCwkobGzVgseM7vgmk5Hkt-4UZHvivHwN7A/edit#) _internal_
 
 The go-to place when you need to price Code Insights for a proposal: includes how to price, common FAQs, and a running list of closed sales.


### PR DESCRIPTION
Users (CE/AEs) [suggest](https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1653579403044459?thread_ts=1653509266.274709&cid=C014ZCKMCAV) this is the place they would go looking for this info first, so cross-linking it!