### PR TITLE
Fix timezone offsets for quarter parsing

### DIFF
--- a/src/lib/dateHighlighter.ts
+++ b/src/lib/dateHighlighter.ts
@@ -27,7 +27,7 @@ function formatDateTime(dateTime: string): string {
 
     // Handle MM-DD reference
     if (/^\d\d-\d\d$/.test(dateTime)) {
-        return new Date(`${new Date().getFullYear()}-${dateTime}`).toLocaleString(undefined, {
+        return new Date(`${new Date().getFullYear()}-${dateTime}T00:00:00`).toLocaleString(undefined, {
             month: 'long',
             day: 'numeric',
         })


### PR DESCRIPTION
There was a bug that caused "Q1" to display an end date of April 29 in timezones west of UTC (such as the US).