### PR TITLE
Use flag for mg sync for v1.0 instances

### DIFF
--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -545,12 +545,12 @@ eval $(mg --customer <CUSTOMER> workon)
 export NEW_DEPLOYMENT=$OLD_DEPLOYMENT
 ```
 
+Note: `eval ...` command will change directory to `$CUSTOMER`.
+
 Then set up a branch for your changes:
 
 ```sh
 git checkout -b $CUSTOMER/upgrade-v<MAJOR.MINOR.PATCH>
-# all the below steps are documented assuming you are in the customer deployment directory
-cd $CUSTOMER
 ```
 
 ### 1) Make DB read-only
@@ -586,7 +586,8 @@ cd $NEW_DEPLOYMENT/docker-compose && rm docker-compose.yaml && ln -s ../../../go
 ### 5) Sync files to customer instance
 
 ```sh
-go run ../util/cmd/ sync
+# if instance is v1.0, add flag: --v1.0
+go run ../util/cmd/ sync [--v1.0]
 git add . && git commit -m "$CUSTOMER: update docker-compose.yaml symlink"
 ```
 

--- a/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
+++ b/content/departments/product-engineering/engineering/cloud/devops/managed/upgrade_process.md
@@ -541,7 +541,7 @@ Only use this approach for low-risk patch upgrades or docker-compose container r
 ### 0) Upgrade setup
 
 ```sh
-eval $(mg --customer <CUSTOMER> workon)
+eval $(go run ./util/cmd/ --customer <CUSTOMER> workon)
 export NEW_DEPLOYMENT=$OLD_DEPLOYMENT
 ```
 


### PR DESCRIPTION
Added @sanderginn proposal with `--v1.0` flag for mg sync cmmand to be backward-compatible.
[PR](https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/600)