### PR TITLE
add leadership sponsor section to guilds, add release guild sponsor

### DIFF
--- a/data/guilds.yml
+++ b/data/guilds.yml
@@ -2,4 +2,4 @@ release_guild:
   title: Release Guild
   leader: coury_clark
   leadership_sponsors: [jean_du_plessis]
-  members: [coury_clark, joe_chen, camden_cheek, tomás_senart, keegan_carruthers-smith, mohammad_umer_alam]
+  members: [coury_clark, joe_chen, camden_cheek, keegan_carruthers-smith, mohammad_umer_alam]

--- a/data/guilds.yml
+++ b/data/guilds.yml
@@ -1,4 +1,5 @@
 release_guild:
   title: Release Guild
   leader: coury_clark
+  leadership_sponsors: [jean_du_plessis]
   members: [coury_clark, joe_chen, camden_cheek, tomás_senart, keegan_carruthers-smith, mohammad_umer_alam]

--- a/schema/guilds.schema.json
+++ b/schema/guilds.schema.json
@@ -14,6 +14,12 @@
       },
       "leader": {
         "type": "string"
+      },
+      "leadership_sponsors": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": ["title", "members"]

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -547,6 +547,17 @@ export async function generateGuildRoster(guildReference) {
     const name = teamMembers[memberReference].name
     pageContent += `- [${String(name)}](${String(createBioLink(name))})\n`
   }
+  if (guild.leadership_sponsors) {
+    pageContent += '### Leadership Sponsor'
+    if (guild.leadership_sponsors.length > 1) {
+      pageContent += 's'
+    }
+    pageContent += '\n'
 
-  return pageContent
+    for (const reference of guild.leadership_sponsors) {
+      const name = teamMembers[reference].name
+      pageContent += `- [${String(name)}](${String(createBioLink(name))})\n`
+    }
+  }
+    return pageContent
 }

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -559,5 +559,5 @@ export async function generateGuildRoster(guildReference) {
       pageContent += `- [${String(name)}](${String(createBioLink(name))})\n`
     }
   }
-    return pageContent
+  return pageContent
 }


### PR DESCRIPTION
Adds a new element to the guild page that allows leadership sponsors. The heading text accommodates one versus many sponsors. 

- Adds the new release guild leadership sponsor
![CleanShot 2022-06-03 at 10 44 38@2x](https://user-images.githubusercontent.com/5090588/171918649-b0330b45-4aeb-449d-bb7b-b1542a475b50.png)

