### PR TITLE
Create InfoSec roles & responsbilities policy

### DIFF
--- a/content/company-info-and-process/policies/information-security-roles-and-responsibilities.md
+++ b/content/company-info-and-process/policies/information-security-roles-and-responsibilities.md
@@ -1,15 +1,14 @@
 # **Information Security Roles and Responsibilities Policy**
+
 ## **Objective**
 
-This policy and associated guidance establish the roles and responsibilities within Sourcegraph, which is critical for effective communication of information security policies and standards. Roles are required within the organization to provide clearly defined responsibilities and an understanding of how the protection of information is to be accomplished. Their purpose is to clarify, coordinate activity, and actions necessary to disseminate security policy, standards, and implementation. 
-
+This policy and associated guidance establish the roles and responsibilities within Sourcegraph, which is critical for effective communication of information security policies and standards. Roles are required within the organization to provide clearly defined responsibilities and an understanding of how the protection of information is to be accomplished. Their purpose is to clarify, coordinate activity, and actions necessary to disseminate security policy, standards, and implementation.
 
 ## **Applicability**
 
 This policy is applicable to all Sourcegraph employees and contractors who are involved with the Information Security Program. This policy applies to all other agents of Sourcegraph with access to Sourcegraph information and network. This includes, but not limited to partners, affiliates, contractors, temporary employees, trainees, guests, and volunteers. The titles will be referred to collectively hereafter as the “Sourcegraph community”.
 
-## **Roles & Responsibilities**  
-
+## **Roles & Responsibilities**
 
 <table>
   <tr>
@@ -39,7 +38,7 @@ This policy is applicable to all Sourcegraph employees and contractors who are i
 
 <li>Solid understand of security risks and potential weak points
 
-<li>Continuously evaluate Sourcegraph’s risk appetite against potential threats 
+<li>Continuously evaluate Sourcegraph’s risk appetite against potential threats
 
 <li>Incorporate security into the company strategy
 
@@ -60,7 +59,7 @@ This policy is applicable to all Sourcegraph employees and contractors who are i
 
 <li>Defines and runs the security program across the organization
 
-<li>Create a in-depth risk and maturity profile for Sourcegraph and utilize it to plan initiatives 
+<li>Create a in-depth risk and maturity profile for Sourcegraph and utilize it to plan initiatives
 
 <li>Responsible for oversight of security policies
 
@@ -122,9 +121,9 @@ This policy is applicable to all Sourcegraph employees and contractors who are i
    <td>
 <ul>
 
-<li>Acting at all times in a manner which does not place at risk Sourcegraph’s assets 
+<li>Acting at all times in a manner which does not place at risk Sourcegraph’s assets
 
-<li>Helping to identify risk as part of the risk management process and implement remediations 
+<li>Helping to identify risk as part of the risk management process and implement remediations
 
 <li>Adhering to company policies and standards of conduct
 
@@ -135,18 +134,16 @@ This policy is applicable to all Sourcegraph employees and contractors who are i
   </tr>
 </table>
 
-
-
 ## **Policy Compliance**
 
-Sourcegraph will measure and verify compliance to this policy through various methods, including but not limited to, business tool reports, and both internal and external audits. 
+Sourcegraph will measure and verify compliance to this policy through various methods, including but not limited to, business tool reports, and both internal and external audits.
 
 ## **Violations & Enforcement**
 
 Any known violations of this policy should be reported to report-policy-violation@sourcegraph.com. Failure to follow this policy can result in disciplinary action, up to and including termination.
 
-
 ### **History**
+
 <table>
   <tr>
    <td><strong>Version</strong>
@@ -197,4 +194,3 @@ Any known violations of this policy should be reported to report-policy-violatio
    </td>
   </tr>
 </table>
-

--- a/content/company-info-and-process/policies/information-security-roles-and-responsibilities.md
+++ b/content/company-info-and-process/policies/information-security-roles-and-responsibilities.md
@@ -1,0 +1,200 @@
+# **Information Security Roles and Responsibilities Policy**
+## **Objective**
+
+This policy and associated guidance establish the roles and responsibilities within Sourcegraph, which is critical for effective communication of information security policies and standards. Roles are required within the organization to provide clearly defined responsibilities and an understanding of how the protection of information is to be accomplished. Their purpose is to clarify, coordinate activity, and actions necessary to disseminate security policy, standards, and implementation. 
+
+
+## **Applicability**
+
+This policy is applicable to all Sourcegraph employees and contractors who are involved with the Information Security Program. This policy applies to all other agents of Sourcegraph with access to Sourcegraph information and network. This includes, but not limited to partners, affiliates, contractors, temporary employees, trainees, guests, and volunteers. The titles will be referred to collectively hereafter as the “Sourcegraph community”.
+
+## **Roles & Responsibilities**  
+
+
+<table>
+  <tr>
+   <td><strong>Roles</strong>
+   </td>
+   <td><strong>Responsibilities</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Board of Directors</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Oversight/understanding of cyber security risks and matters across Sourcegraph
+
+<li>Consults with Exec team to understand risk appetite and security maturity  
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Executive Leadership</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Solid understand of security risks and potential weak points
+
+<li>Continuously evaluate Sourcegraph’s risk appetite against potential threats 
+
+<li>Incorporate security into the company strategy
+
+<li>Communication path of security matters to Sourcegraph Board of Directors
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Security Lead</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Aligns Information Security policies and practises based on Sourcegraph’s mission, strategic objectives and risk appetite
+
+<li>Serves as security ambassador across Sourcegraph and external engagements (i.e. liaison to the exec team, Board of Directors, client facing engagements for security matters)
+
+<li>Defines and runs the security program across the organization
+
+<li>Create a in-depth risk and maturity profile for Sourcegraph and utilize it to plan initiatives 
+
+<li>Responsible for oversight of security policies
+
+<li>Responsible for monitoring security risks and creating remediation plans
+
+<li>Communicates information security risks to executive leadership
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Compliance Manager</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Works with applicable executive leadership to establish an information security framework and awareness program
+
+<li>Build and maintain an Enterprise Risk Management Framework
+
+<li>Serves as liaison to the Board of Directors, Law Enforcement, Internal Audit and General Council. 
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Control Owners</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Control design in collaboration with the compliance and security team
+
+<li>Control evidence gathering and submission for review
+
+<li>Control maintenance (i.e. as company processes change any dependable controls need to be adjusted)
+
+<li>Control representation for any internal and external audits
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>System Owners</strong>
+   </td>
+   <td>
+<ul>
+
+<li>Manage the confidentiality, integrity and availability of the information systems for which they are responsible in compliance with Sourcegraph policies on information security and privacy.
+
+<li>Approval of technical access and change requests for non-standard access (annual reviews)
+</li>
+</ul>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Sourcegraph Employees, Contractors, temporary workers, etc.</strong> 
+   </td>
+   <td>
+<ul>
+
+<li>Acting at all times in a manner which does not place at risk Sourcegraph’s assets 
+
+<li>Helping to identify risk as part of the risk management process and implement remediations 
+
+<li>Adhering to company policies and standards of conduct
+
+<li>Reporting incidents and observed anomalies or weaknesses
+</li>
+</ul>
+   </td>
+  </tr>
+</table>
+
+
+
+## **Policy Compliance**
+
+Sourcegraph will measure and verify compliance to this policy through various methods, including but not limited to, business tool reports, and both internal and external audits. 
+
+## **Violations & Enforcement**
+
+Any known violations of this policy should be reported to report-policy-violation@sourcegraph.com. Failure to follow this policy can result in disciplinary action, up to and including termination.
+
+
+### **History**
+<table>
+  <tr>
+   <td><strong>Version</strong>
+   </td>
+   <td><strong>Date</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Author</strong>
+   </td>
+   <td><strong>Approved by</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>1.0
+   </td>
+   <td>23-Sept-2021
+   </td>
+   <td>First Version
+   </td>
+   <td>Nicky Van Maanen
+   </td>
+   <td>Diego Comas
+   </td>
+  </tr>
+  <tr>
+   <td>1.1
+   </td>
+   <td>27-JAN-2022
+   </td>
+   <td>Minor updates
+   </td>
+   <td>Diego Comas
+   </td>
+   <td>Diego Comas
+   </td>
+  </tr>
+  <tr>
+   <td>2.0
+   </td>
+   <td>09-Jun-2022
+   </td>
+   <td>Updated Roles & Resp matrix 
+   </td>
+   <td>Dora Grgic
+   </td>
+   <td>Diego Comas
+   </td>
+  </tr>
+</table>
+


### PR DESCRIPTION
updated the policy and moved it from google doc into the handbook - google doc link: https://docs.google.com/document/d/1lW8bdjeuefI4HLDwzgPxpejh5D020MWj/edit#heading=h.wtmbgjpr18lv