### PR TITLE
Adding how to enable Closed Caption on Zoom meetings.

### DIFF
--- a/content/company-info-and-process/communication/zoom.md
+++ b/content/company-info-and-process/communication/zoom.md
@@ -63,13 +63,6 @@ Zoom has a auto-generated closed captions feature, but it's disabled by the defa
 
 <img width="918" alt="Settings" src="https://user-images.githubusercontent.com/64257673/173246420-9594bf2a-9dd4-4f75-b383-349cc0e9aca2.png">
 
-Now The “Cc” button is visible in your live meetings. You can activate it on every  meeting that you’re the host of. 
+Now The “Cc” button is visible in your live meetings. You can activate it on every meeting that you’re the host of.
 
 <img width="445" alt="Cc Button" src="https://user-images.githubusercontent.com/64257673/173246442-3847141f-071d-4dbf-81e7-d075e4a2c9ed.png">
-
-
-
-
-
-
-

--- a/content/company-info-and-process/communication/zoom.md
+++ b/content/company-info-and-process/communication/zoom.md
@@ -49,3 +49,27 @@ Choose **Create filter** and set it to forward to the Slack channel email relay 
 Simply join the Zoom meeting URL and it should begin recording automatically. Say hi, and then leave the meeting. Zoom will send you an email with the recording and Gmail will forward it to Slack automatically:
 
 ![image](https://user-images.githubusercontent.com/3173176/86101192-c3100f80-ba6e-11ea-984c-2955860113e3.png)
+
+## Activating Closed Caption on Zoom meetings
+
+Zoom has a auto-generated closed captions feature, but it's disabled by the default. This feature is handy for many Sourcegraphers and make our communication more accessible.
+
+### Enabling live Closed Captions on Zoom
+
+- Access https://sourcegraph.zoom.us/profile/settings
+- Click on “In Meeting (Advanced)”
+- Scroll to “Automated captions”
+- Enable “Automated captions”, “Full Transcipt” and “Save Captions”
+
+<img width="918" alt="Settings" src="https://user-images.githubusercontent.com/64257673/173246420-9594bf2a-9dd4-4f75-b383-349cc0e9aca2.png">
+
+Now The “Cc” button is visible in your live meetings. You can activate it on every  meeting that you’re the host of. 
+
+<img width="445" alt="Cc Button" src="https://user-images.githubusercontent.com/64257673/173246442-3847141f-071d-4dbf-81e7-d075e4a2c9ed.png">
+
+
+
+
+
+
+


### PR DESCRIPTION
Activating Closed Caption on Zoom meetings:
Zoom followed through on its promise to add auto-generated closed captions to all Zoom meetings and make its service more accessible. I guess this feature is handy for many Sourcegraphers.