### PR TITLE
incidents: update post-mortem flow to ensure GitHub issues are linked

### DIFF
--- a/content/departments/engineering/dev/process/incidents/index.md
+++ b/content/departments/engineering/dev/process/incidents/index.md
@@ -107,13 +107,14 @@ Some common scenarios:
 
 After the incident is resolved, the incident lead:
 
-1. Update the incident status and close.
+1. Updates the incident status and closes it.
 2. Confirms that the messenger updated any customer communication channels, internal threads, or channels (outside of the incident channel) and social media posts (with marketing’s approval and if necessary) with the latest information.
-3. Update and close and relevant public GitHub issues.
+3. Updates and closes any relevant public GitHub issues.
 4. [Generate a postmortem](https://docs.incident.io/generating-a-postmortem), documents details and publish it in the [Incidents folder in Google Drive](https://drive.google.com/drive/u/0/folders/1aWKkaSyuLfAP35mPe1pe8niBF4oh0M8F).
-5. Create GitHub issues for any appropriate followup work.
-6. Schedule a [retrospective](../../../../../company-info-and-process/communication/retrospectives.md) if you think it would be valuable.
-7. Archive the incident channel.
+   1. Schedule a [retrospective](../../../../../company-info-and-process/communication/retrospectives.md) if you think it would be valuable.
+5. Create [follow-ups in incident.io](https://app.incident.io/follow-ups) from the "Follow-ups" tab in the incident page. For each follow-up, attach a GitHub issue from the overflow menu (you can choose to have one be created, or link an existing one).
+   1. Attaching a GitHub issue makes it easier to ensure a follow-up item is addressed - if the GitHub issue is closed, the follow-up is marked as Resolved in incident.io.
+6. Archive the incident channel.
 
 #### Past incident post-mortems
 


### PR DESCRIPTION
This is in response to [a recent request that all follow-ups in incident.io are checked to be resolved](https://sourcegraph.slack.com/archives/C02KZ941RNX/p1655726416453319) - the process does not yet make it clear that follow-ups should be created and should be tied to GitHub issues that can be synchronized by incident.io.