### PR TITLE
Put customer interview notes in a single folder

### DIFF
--- a/content/departments/engineering/product/process/user_stakeholder_feedback.md
+++ b/content/departments/engineering/product/process/user_stakeholder_feedback.md
@@ -110,6 +110,10 @@ See [How to reference customer names in public tickets](prioritizing.md#how-to-r
 
 We aggregate all of this feedback in [productboard](https://sourcegraph.productboard.com/). This lets us look at all of the sources of feedback to better understand which features will have the biggest impact on the product. It helps with prioritization and making sure we're building the next most important thing. It also helps us maintain a long-term source of truth for feedback: some of our sources of feedback are subject to removal over time due to retention policies, so adding specific insights to productboard captures it for the future.
 
+In case you have longer google docs (eg. customer discovery notes) that don't fit in productboard cards:
+- put the doc in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `Customer Year - <notes>` eg. `ACME Corp 2022 - code security notes`.
+- create snippets for key insights into Productboard
+
 ### Adding feedback to productboard
 
 All of the above sources of feedback (with the exception of HubSpot forms) require the team help forward that data into productboard using an available integration:

--- a/content/departments/engineering/product/process/user_stakeholder_feedback.md
+++ b/content/departments/engineering/product/process/user_stakeholder_feedback.md
@@ -111,6 +111,7 @@ See [How to reference customer names in public tickets](prioritizing.md#how-to-r
 We aggregate all of this feedback in [productboard](https://sourcegraph.productboard.com/). This lets us look at all of the sources of feedback to better understand which features will have the biggest impact on the product. It helps with prioritization and making sure we're building the next most important thing. It also helps us maintain a long-term source of truth for feedback: some of our sources of feedback are subject to removal over time due to retention policies, so adding specific insights to productboard captures it for the future.
 
 In case you have longer google docs (eg. customer discovery notes) that don't fit in productboard cards:
+
 - put the doc in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `Customer Year - <notes>` eg. `ACME Corp 2022 - code security notes`.
 - create snippets for key insights into Productboard
 

--- a/content/departments/engineering/product/process/user_stakeholder_feedback.md
+++ b/content/departments/engineering/product/process/user_stakeholder_feedback.md
@@ -112,7 +112,7 @@ We aggregate all of this feedback in [productboard](https://sourcegraph.productb
 
 In case you have longer google docs (eg. customer discovery notes) that don't fit in productboard cards:
 
-- put the doc in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `Customer Year - <notes>` eg. `ACME Corp 2022 - code security notes`.
+- put the doc (or a [shortcut](https://support.google.com/drive/answer/9700156?)) in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `Customer Year - <notes>` eg. `ACME Corp 2022 - code security notes`.
 - create snippets for key insights into Productboard
 
 ### Adding feedback to productboard

--- a/content/departments/engineering/product/process/user_stakeholder_feedback.md
+++ b/content/departments/engineering/product/process/user_stakeholder_feedback.md
@@ -112,7 +112,7 @@ We aggregate all of this feedback in [productboard](https://sourcegraph.productb
 
 In case you have longer google docs (eg. customer discovery notes) that don't fit in productboard cards:
 
-- put the doc (or a [shortcut](https://support.google.com/drive/answer/9700156?)) in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `Customer Year - <notes>` eg. `ACME Corp 2022 - code security notes`.
+- put the doc (or a [shortcut](https://support.google.com/drive/answer/9700156?)) in the [customer feedback notes](https://drive.google.com/drive/folders/1suKSsUTTJlEyRaiunNtzJUMwrP_ZPWYG) folder, using the following naming convention `YYYYMMDD - Customer - Subject` (e.g. `20222806 - Acme - Code security`).
 - create snippets for key insights into Productboard
 
 ### Adding feedback to productboard


### PR DESCRIPTION
Today, long customer interview transcripts don't fit in productboard cards. So longer interview stay in a personal drive and there's no way to find them.
Productboard is the SoT for feedback, but it benefits everybody to put long google docs in the same folder so that they don't get lost.
[Thread](https://sourcegraph.slack.com/archives/C0W2E592M/p1656104783143769?thread_ts=1654708469.429829&cid=C0W2E592M)