### PR TITLE
Prefix timezone offset with "+" if positive

### DIFF
--- a/src/lib/rehypeMarkupDates.ts
+++ b/src/lib/rehypeMarkupDates.ts
@@ -75,7 +75,7 @@ export const rehypeMarkupDates: Plugin = () => root =>
 function formatTimezoneOffset(totalMinutes: number): string {
     const hours = Math.trunc(totalMinutes / 60)
     const minutes = Math.abs(totalMinutes) % 60
-    return `${formatInt(hours, 2)}:${formatInt(minutes, 2)}`
+    return `${totalMinutes >= 0 ? '+' : ''}${formatInt(hours, 2)}:${formatInt(minutes, 2)}`
 }
 
 const fiscalIntervalPattern = new RegExp(`^(?:${fiscalYearPattern.source}|${fiscalQuarterPattern.source})$`)


### PR DESCRIPTION
This fixes positive timezone offsets being rendered without the `+` delimiter

Before:
`<time datetime="00:0000:00">12:00am UTC</time>`

After:
`<time datetime="00:00+00:00">12:00am UTC</time>`

Found e.g. on https://handbook.sourcegraph.com/strategy-goals/cross-functional-projects/#asynchronous-updates