### PR TITLE
Update ownership of sign-in / up pages

### DIFF
--- a/content/departments/engineering/dev/admin-exp/iam/index.md
+++ b/content/departments/engineering/dev/admin-exp/iam/index.md
@@ -18,9 +18,7 @@ Service management is a broad area of ownership. To provide more clarity into wh
 
 #### Identity and access management
 
-The IAM team is responsible for both authentication and authorization to Sourcegraph, including login and user management for on-prem and managed instances.
-
-While the IAM team owns the underliying layer for authentication and authorization, Integrations and Growth teams are responsible for the UI and UX for sign-in and sign-up. Integrations and Growth teams also work on the [new user experience](../../../process/new-user-experience.md) using our [cross-team collaboration principles](../../../process/cross-team-collab.md).
+The IAM team is responsible for both authentication and authorization to Sourcegraph, including login, sign-in and sign-up pages and user management for on-prem and managed instances.
 
 Code-level authorization is enforced based on the repository permissions on the code host level and the Repository Management team owns this area. It is coupled with administration experience and team management, which created close collaboration between both teams.
 


### PR DESCRIPTION
Changes ownership of sign-in and sign-up pages to the IAM team. This was previously owned by growth.