### PR TITLE
Update who I report to in org chart

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -153,7 +153,7 @@ thorsten_ball:
   name: Thorsten Ball
   pronouns: he/him
   role: Software Engineer
-  reports_to: engineering_manager_code_intelligence
+  reports_to: eng_lead
   location: Aschaffenburg, Bavaria, Germany 🇩🇪
   github: mrnugget
   email: thorsten@sourcegraph.com


### PR DESCRIPTION
Noticed that I was still listed under Code Intel in the org chart.