### PR TITLE
NPS widget collects use cases, has two channels

### DIFF
--- a/content/departments/engineering/product/process/feedback/user_stakeholder_feedback.md
+++ b/content/departments/engineering/product/process/feedback/user_stakeholder_feedback.md
@@ -92,9 +92,9 @@ See [How to reference customer names in public tickets](../prioritize_and_build/
 
 #### NPS Survey
 
-- **Purpose:** We prompt customers to provide NPS ratings from within the Sourcegraph UI.
+- **Purpose:** We prompt customers to provide NPS ratings from within the Sourcegraph UI. On Sourcegraph version 3.41 and above, we also prompt about use cases.
 - **Owner:** The product manager on [feedback rotation](product_feedback_rotation.md) owns responding to or forwarding NPS feedback.
-- **Pipeline:** This is powered by a [Zap](https://zapier.com/app/editor/64689250). Submissions that have written feedback (as opposed to only a rating), are saved as a productboard note. In addition, if the feedback contains obvious keywords (eg. 'Code Insights'), the PM of the relevant area will be automatically @-mentioned on slack. The CE and AE owners of the deal are also mentioned if they have added their handle to [this spreadhseet](https://docs.google.com/spreadsheets/d/1RPiuhuyEpqJ6MHFyzf5WOfx1DA00iW6_mEgAHbJffeQ/edit#gid=334520408). This is based on account ownership as available in this [look](https://sourcegraph.looker.com/looks/1301).
+- **Pipeline:** This is powered by two Zaps: one for [Sourcegraph 3.40 and below](https://zapier.com/app/editor/64689250), and another for [Sourcegraph 3.41 and above](https://zapier.com/editor/160211136/published/160211136) that also handles use cases data submissions. Submissions that have written feedback (as opposed to only a rating), are saved as a productboard note and posted in #feedback. Submissions with only a score are posted in #feedback-nps. In addition, if the feedback contains obvious keywords (eg. 'Code Insights'), the PM of the relevant area will be automatically @-mentioned on slack. The CE and AE owners of the deal are also mentioned if they have added their handle to [this spreadhseet](https://docs.google.com/spreadsheets/d/1RPiuhuyEpqJ6MHFyzf5WOfx1DA00iW6_mEgAHbJffeQ/edit#gid=334520408). This is based on account ownership as available in this [look](https://sourcegraph.looker.com/looks/1301).
 
 #### Happiness widget
 


### PR DESCRIPTION
* from Sourcegraph 3.41, the NPS widget collects use case data
* NPS scores are posted in #feedback-nps, longer submissions in #feedback