### PR TITLE
Remove mention of "business need" in IC5 description

### DIFF
--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -409,9 +409,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td colspan="3" class="tbd">
-        <p>
-          Rather than being solely defined through proficiency, execution and teamwork, IC5 is differentiated from levels 1-4 by a specific <strong>business need</strong> for the role. The creation of an IC5 role is contingent on the existence of this business need, and the business need will bring an associated set of expectations for proficiency, execution and teamwork.
-        </p>
       </td>
     </tr>
     <!-- IC6 -->


### PR DESCRIPTION
This is an outcome of an IC5 sync: we remove the last mention of "business need" in relation to IC5.