### PR TITLE
chore: remove one accidental character

### DIFF
--- a/content/departments/engineering/dev/process/engineering_ownership.md
+++ b/content/departments/engineering/dev/process/engineering_ownership.md
@@ -96,7 +96,7 @@ If you see an area that is missing, [figure out](../../product/process/feedback/
 - sourcegraph/lsif-go
 - sourcegraph/lsif-node
 - sourcegraph/lsif-java
-- sourcegraph/lsif-clang\
+- sourcegraph/lsif-clang
 - sourcegraph/lsif-test
 
 ## [Content Platform](../../teams/content-platform/index.md)


### PR DESCRIPTION
I think this is a mis-hit while hitting the <kbd>enter</kbd>.