### PR TITLE
Tweak the incident reporting process

### DIFF
--- a/content/departments/security/security-incident-response.md
+++ b/content/departments/security/security-incident-response.md
@@ -26,7 +26,7 @@ This policy covers all information security or data privacy events or incidents.
 If a Sourcegraph employee, contractor, user, or customer becomes aware of any
 possible information security event or incident, unauthorized access, policy violation,
 security weakness, or suspicious activity, they can report the incident by emailing
-security@sourcegraph.com.
+security-team@sourcegraph.com.
 
 If there is strong reason to believe that the possible security incident is ongoing and
 could have significant impact to data or systems belonging to Sourcegraph or its


### PR DESCRIPTION
Use `security-team@` instead of `security@` for manual reports – the entire organisation
can read emails sent to security@, which is not ideal for dealing with incidents
that have privacy implications, or might tip off an attacker with some level of
existing access