### PR TITLE
[iam] Remove admin experience from IAM team

### DIFF
--- a/content/departments/engineering/teams/iam/index.md
+++ b/content/departments/engineering/teams/iam/index.md
@@ -16,13 +16,11 @@ Service management is a broad area of ownership. To provide more clarity into wh
 
 The IAM team is responsible for both authentication and authorization to Sourcegraph, including login, sign-in and sign-up pages and user management for on-prem and managed instances.
 
-The IAM team also owns code-level authorization, which is enforced based on the repository permissions on the code host level. It is coupled with administration experience and team management, which created close collaboration between both teams.
+The IAM team also owns code-level authorization, which is enforced based on the repository permissions on the code host level or with explicit permissions API.
 
-#### Administration experience and teams management
+#### Teams management
 
-Capabilities that provide customers with transparency and access control to how Sourcegraph is used within their organizations. This includes but is not limited to team management, role-based access control, and other features targeted towards admins on our customer’s side.
-
-In addition to the organization-level management capabilities, we are also responsible for individual users' administration experience.
+Capabilities that provide customers with transparency and access control to how Sourcegraph is used within their organizations. This includes but is not limited to organization/team management, role-based access control, and other features targeted towards admins on our customer’s side.
 
 #### Subscription management
 


### PR DESCRIPTION
Removed admin experience from supported features. Admin experience is owned by all teams of sourcegraph that have site-admin content, not only by us.

Also clarified the wording in the teams management section a bit as a follow-up.