### PR TITLE
Add escalation engineering schedule

### DIFF
--- a/content/departments/engineering/dev/process/escalation-engineer-rotation.md
+++ b/content/departments/engineering/dev/process/escalation-engineer-rotation.md
@@ -10,11 +10,11 @@ Discuss escalation engineering rotation in #escalation-engineering.
 
 ## Rotations
 
-| Rotation | Engineers |
-| - | - |
+| Rotation                 | Engineers                                                                                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2022-08-10 to 2022-09-06 | [@nicksnyder](https://github.com/nicksnyder), [@keegancsmith](https://github.com/keegancsmith), [@BolajiOlajide](https://github.com/BolajiOlajide) |
 | 2022-09-07 to 2022-10-09 | [@nicksnyder](https://github.com/nicksnyder), [@keegancsmith](https://github.com/keegancsmith), [@valerybugakov](https://github.com/valerybugakov) |
-| 2022-10-12 to 2022-??-?? | TBD |
+| 2022-10-12 to 2022-??-?? | TBD                                                                                                                                                |
 
 ## Benefits
 

--- a/content/departments/engineering/dev/process/escalation-engineer-rotation.md
+++ b/content/departments/engineering/dev/process/escalation-engineer-rotation.md
@@ -4,7 +4,17 @@ The escalation engineers (EEs) temporarily rotate onto our Customer Engineering 
 
 ## Contact
 
-@escalation-engineers on Slack
+Tag @escalation-engineers on Slack for help.
+
+Discuss escalation engineering rotation in #escalation-engineering.
+
+## Rotations
+
+| Rotation | Engineers |
+| - | - |
+| 2022-08-10 to 2022-09-06 | [@nicksnyder](https://github.com/nicksnyder), [@keegancsmith](https://github.com/keegancsmith), [@BolajiOlajide](https://github.com/BolajiOlajide) |
+| 2022-09-07 to 2022-10-09 | [@nicksnyder](https://github.com/nicksnyder), [@keegancsmith](https://github.com/keegancsmith), [@valerybugakov](https://github.com/valerybugakov) |
+| 2022-10-12 to 2022-??-?? | TBD |
 
 ## Benefits
 


### PR DESCRIPTION
I penciled in `2022-10-09` for the end date of rotation #2 to make them end on a Friday and start on a Monday (cc @keegancsmith @valerybugakov).