### PR TITLE
cloud: Fix typo in command for zsh users

### DIFF
--- a/content/departments/cloud/technical-docs/operations.md
+++ b/content/departments/cloud/technical-docs/operations.md
@@ -28,7 +28,7 @@ Below we will install `mg` CLI. `mg` simlifies operation on MI and releases the 
 mkdir -p ~/.bin
 export GOBIN=$HOME/.bin
 
-# ZSH users: echo "export \$PATH=\$HOME/.bin:\$PATH" >> ~/.zshrc
+# ZSH users: echo "export PATH=\$HOME/.bin:\$PATH" >> ~/.zshrc
 # you need ensure our `mg` binary has the highest priority in $PATH
 # otherwise if will conflict with the `mg` emacs editor 😢
 echo "export PATH=\$HOME/.bin:\$PATH" >> ~/.bashrc


### PR DESCRIPTION
An extra $ that shouldn't be there.