### PR TITLE
fix @leonore email to match slack

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -2092,7 +2092,7 @@ leo_papaloizos:
   reports_to: engineering_manager_code_insights
   location: London, UK 🇬🇧
   github: leonore
-  email: leo.p@sourcegraph.com
+  email: leo.papaloizos@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/leonore-p-99bb0b170/)'
   description: 'Leo grew up in France and studied Computer Science in Glasgow, and is now based in London. Outside of work, she enjoys podcasts, collecting fun facts, playing football, and more recently, knitting.'
 


### PR DESCRIPTION
Build-tracker had some trouble to locate @leonore SlackID and would print `<@>`. After some digging I saw that the team.yml and what is in slack do not match 😄 