### PR TITLE
Update release_post_process with changelog items script

### DIFF
--- a/content/departments/marketing/product-marketing/release_post_process.md
+++ b/content/departments/marketing/product-marketing/release_post_process.md
@@ -20,7 +20,7 @@ You can tell when the release is cut by following along in #progress.
 
 - The marketing release post owner adds the changelog to the release post file.
 
-  - They run the command to generate the changelog (being sure to replace the version number in the command), and then pastes the output at the end of the release post ([loom guide](https://www.loom.com/share/59da6bc1784a48e9b6af4d9e620ee4df)): `go run ./bin/generate_changelog_items.go -versions 3.28 -i ../sourcegraph/CHANGELOG.md`.
+  - They run the command to generate the changelog (being sure to replace the version number in the command), and then pastes the output at the end of the release post ([loom guide](https://www.loom.com/share/59da6bc1784a48e9b6af4d9e620ee4df)): `go run ./scripts/generateChangelogItems.go -versions 3.43.1 -i ../sourcegraph/CHANGELOG.md`.
   - Make sure that you get the latest in the Sourcegraph repo before running this command. If your repo is in a different location than `../sourcegraph`, you'll need to update the command line above.
   - If for some reason the version number isn't added yet and you need to capture the "Unreleased" then passing it the literal string match for the "Unreleased" heading, usually `Unreleased`, in place of a version number works)
 


### PR DESCRIPTION
Updates the process with new script name/location for generating changelog items for release posts.