### PR TITLE
scaletesting: fix invalid node count

### DIFF
--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -99,6 +99,6 @@ Merge your changes via a pull request, and run the following from the base of th
 
 ### Scale the cluster down when not in use
 
-To ensure the cluster is not left running, set the `min_num_nodes` and `max_num_nodes` to `0` in the [`terraform` config](https://github.com/sourcegraph/infrastructure/blob/main/scaletesting/main.tf#L39-L40)
+To ensure the cluster is not left running, set the `min_num_nodes` and `max_num_nodes` to `1` in the [`terraform` config](https://github.com/sourcegraph/infrastructure/blob/main/scaletesting/main.tf#L39-L40)
 
 Create a pull request with your changes, and apply them once merged by running `terraform apply` in the `infrastructure/scaletesting` directory.


### PR DESCRIPTION
Sadly, zero is now a valid node count :/ We'll have to find a different way for downscaling this. 