### PR TITLE
Fix EM reference for FPT page

### DIFF
--- a/data/product_teams.yml
+++ b/data/product_teams.yml
@@ -110,7 +110,7 @@ frontend_platform:
   brief: The Frontend Platform team aims to empower all users and Sourcegraph frontend developers to achieve maximum efficiency and effectiveness by enabling and building a first-class web experience.
   strategy_link: /strategy-goals/strategy/frontend-platform
   pm: taylor_sperry
-  em: murat_sutunc
+  em: murat_sutunc_frontend_platform
   design: alicja_suska
   issue_labels:
     - team/frontend-platform


### PR DESCRIPTION
The original reference for Murat rendered out the Growth & Integrations team members, rather than Frontend Platform Team members.