### PR TITLE
Update CODENOTIFY to remove outdated usernames

### DIFF
--- a/content/company-info-and-process/CODENOTIFY
+++ b/content/company-info-and-process/CODENOTIFY
@@ -1,4 +1,4 @@
 # See https://github.com/sourcegraph/codenotify for documentation
 
-values.md @christinaforney @nicksnyder @sqs
-strategy.md @christinaforney @nicksnyder @sqs
+values.md @sqs
+strategy.md @sqs

--- a/content/strategy-goals/strategy/CODENOTIFY
+++ b/content/strategy-goals/strategy/CODENOTIFY
@@ -1,3 +1,0 @@
-# See https://github.com/sourcegraph/codenotify for documentation
-
-**/* @christinaforney


### PR DESCRIPTION
Noticed the notification in another PR. Nick and Christina are no longer at Sourcegraph, so we can remove from `CODENOTIFY` files.