### PR TITLE
remove coaching cats, add calibration

### DIFF
--- a/content/departments/people-talent/people-ops/process/teammate-sentiment/impact-reviews/index.md
+++ b/content/departments/people-talent/people-ops/process/teammate-sentiment/impact-reviews/index.md
@@ -375,11 +375,7 @@ We hold a high and consistent bar for Impact Review calibrations to ensure they 
 
 **What to expect:**
 
-The People Partners will facilitate three calibration sessions in each review period:
-
-- **1. Performance Calibration:** all Managers in the department will meet to calibrate team performance and ratings. In this discussion, they will leverage the Talent Assessment Framework (9-box) to finalize Teammate Performance Reviews and Ratings. In addition, the Executive and Recruiting Director of that department will attend and the People Partner will facilitate the meeting. Everyone will work together to review current Teammate ratings and justify the rating given to each Teammate. After the calibration, Managers will finalize and submit Impact Reviews and Ratings for each team member.
-- **2. Promotion Calibration:** after the submission of team performance reviews and ratings, the Managers, Department Executive and People Partners will meet to finalize promotion recommendations. The People Partner will facilitate the meeting and is responsible for submitting the promotion docs.
-- **3. Compensation Calibration:** the Managers, Department Executive and People Partners will meet to finalize merit recommendations. The People Partner will facilitate the meeting and is responsible for submitting the compensation docs.
+The People Partners will facilitate calibration sessions. [Learn more about how to prepare for calibration meetings](../../compensation-and-leveling/preparing-for-calibrations.md)
 
 ### Delivering the review to Teammates
 
@@ -387,19 +383,9 @@ Each People Partner will coach Managers on how to deliver Teammate reviews.
 
 **Nothing should be a surprise:** Performance and development topics (and more) should regularly be addressed in weekly 1:1s or other casual check-ins, meaning none of the topics discussed during a Teammate’s review should be a surprise. Teammates should have a good idea of what to expect and know Impact Reviews and calibration conversations improve the fairness of performance scores, so they can approach these conversations calmly and with an open mind.
 
-### How we coach Teammates based on performance
+### Teammate development & coaching
 
-Coaching categories help our Managers work with Teammates to create tailored career growth plans. We all have our own unique career goals and interests, and coaching categories help align those career goals and interests to the work we do now. An important part of being a Manager at Sourcegraph is engaging in career growth-focused conversations with Teammates, and working together to create actionable career growth plans. How Managers engage in those conversations depends on Teammate performance, values alignment, and personal goals. Coaching categories are guides to meaningful career-oriented conversations.
-
-We’ll continue to “build muscle” around individual career development plans over the next year or so by incrementally adding tools Managers and Teammates can use to foster meaningful career conversations.
-
-The coaching categories are:
-
-- **Motivate:** focus on ways in which Teammates who are superior performers can continue to strive to model our values in an exceptional way.
-- **Empower:** create opportunities for our highest performing Teammates to step into, or elevate, their leadership presence at Sourcegraph.
-- **Guide:** foster and engage in meaningful career growth conversations with Teammates, and give growth opportunities in roles that allow for opportunities to stretch skills, and demonstrate superior performance.
-- **PIP Eligible:** Teammates in this category must focus on immediate improvement. They engage in our values in a meaningful way, but may struggle to meet expectations. They work closely with their Manager to improve immediately.
-- **Immediate PIP:** used for Teammates who do not exemplify our values, and who do not meet performance expectations. These Teammates must focus on immediate improvement.
+At Sourcegraph, we empower high performers. [Learn more about Teammate Development at Sourcegraph.] (../company-info-and-process/working-at-sourcegraph/teammate-development.md)
 
 ## RESOURCES FOR PEOPLE TEAM
 


### PR DESCRIPTION
Removing coaching categories, which we have agreed not to use. Adding info on calibration meetings in the calibration section (currently at the bottom of page under helpful links)