### PR TITLE
Add dev-chat and dev-urandom to Engineering Slack channels

### DIFF
--- a/content/departments/engineering/index.md
+++ b/content/departments/engineering/index.md
@@ -57,6 +57,8 @@ The following functional teams work across the above dev teams:
 - #eng-leads
 - #ask-engineering
 - #buildkite-main
+- #dev-chat
+- #dev-urandom
 
 ## Processes
 


### PR DESCRIPTION
Just read this and thought I'd add two more.

I'm pretty sure that all members of Engineering are in these two channels, so let's add them here too.