### PR TITLE
Add growth marketing page

### DIFF
--- a/content/departments/marketing/growth-marketing/index.md
+++ b/content/departments/marketing/growth-marketing/index.md
@@ -1,0 +1,34 @@
+# Growth Marketing
+
+_Note: This page is a work in progress for the newly-created Growth Marketing team. For an overview of our kickoff, see [Growth team 2022-10](https://docs.google.com/document/d/1DOMS-soiiuprWlNRhsujsPCNBeY2y-1s-QtxlMRfQGc/edit)._
+
+## Table of contents
+
+- [Growth marketing](#growth-marketing)
+  - [Table of contents](#table-of-contents)
+  - [About Growth Marketing](#about-growth-marketing)
+  - [Team vision and principles](#team-vision-and-principles)
+  - [How we work](#how-we-work)
+
+## About Growth Marketing
+
+_For devs, by devs_
+
+The Growth Marketing team focuses on product-oriented features that generate inbound traffic and lead to qualified cloud trials. We inform our priorities and achieve our goals by partnering with [Community](../../cto/community/index.md), [Product Marketing](../product-marketing/index.md), [Data & Analytics](../../data-analytics/index.md), and [Design](../../engineering/design/index.md).
+
+## Team vision and principles
+
+- We drive qualified trials by talking to devs _as devs_. Our voice should always be a dev voice, whether we’re engaging ICs, engineering managers, or directors. They’re devs too.
+- We understand that devs learn and get excited by playing, not pitching. That’s why we showcase the power of Sourcegraph by providing value instead of giving the hard sell.
+- We only do things that we could proudly and publicly state that we’re doing. No gross growth. No spam.
+- Everything we do is in the interest of driving qualified trials. Sometimes our ideas for how to do that will fail; if they don’t, that means we aren’t being ambitious or fast enough.
+
+## How we work
+
+- For every change we make, we have one metric that is clear, trackable, and links to a dashboard. We discipline ourselves with one very good metric to avoid fuzziness. If we make an exception to this rule, we document our rationale and share it publicly.
+- Every effort has a defined end deliverable. We don’t get bogged down in ongoing work.
+- We prioritize rigorously to make sure our projects have a clear deliverable, a clear level of effort, and a clear metric. We need everyone's input on this, but Quinn Slack and Taylor Sperry will be the decision-makers. This lets us move quickly and decisively by protecting us from analysis paralysis. We accept the risk that sometimes we'll make the right call, and sometimes we won't, but that's how we'll learn what's working.
+- If we have an instinct that something is wrong and no persuasive data to the contrary, we will assume our instinct is correct and hold ourselves accountable with new data. It’s more important for us to be data-informed than data-driven.
+- We will make small, quick changes without design so that they can support us (and other teams) with bigger projects.
+- When in doubt about whether an idea appeals to devs, we run it by #dev-chat, #ask-a-dev, or in very quick surveys of external developers.
+- We work in the open in #growth. We use #growth-marketing-internal for housekeeping and post weekly updates in #progress, which holds us accountable to moving quickly and sharing widely.

--- a/content/departments/marketing/index.md
+++ b/content/departments/marketing/index.md
@@ -2,6 +2,7 @@
 
 - Slack channel: #marketing
 - [Product Marketing](product-marketing/index.md): Product launches, product messaging and positioning, pricing and packaging, customer stories, Customer Advisory Board, and analyst relations. (#customer-advisory-board, #pricing, #release-post)
+- [Growth Marketing](growth-marketing/index.md)
 - Communications: We communicate and amplify Sourcegraph's messages with external and internal audiences. Partner with us on building PR pitches, securing press coverage, communicting announcements and initatives internally with the Sourcegraph team, sharing content at the bi-weekly company meeting, and promoting content on Sourcegraph's social media accounts.
   - [Internal Comms Plan Template](https://docs.google.com/document/d/1oIljeqkrJJQm4FCeOodHTFU4yb3RYTbn2HqemrSgz18/edit)
   - #comms-team-internal, #internal-comms


### PR DESCRIPTION
Still need to flesh this out (with teammates, for example), but I wanted to get something up ASAP for the Growth Marketing handbook page. @sqs Will you let me know if you think there's anything I should add (or remove) before we put it up? 