### PR TITLE
devx: update sections about devx operated instances

### DIFF
--- a/content/departments/engineering/dev/process/deployments/instances.md
+++ b/content/departments/engineering/dev/process/deployments/instances.md
@@ -83,3 +83,10 @@ This deployment is a [managed instance](../../../../cloud/index.md) used by Dist
 - [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-dev)
 - [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/main/dev)
 - [Operations](../../../../cloud/technical-docs/operations.md)
+
+### sourcegraph.sourcegraph.com (S2)
+- [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-sg)
+- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/main/sg)
+- [Operations](../../../../cloud/technical-docs/operations.md)
+- Deployment schedule: every hour on between 8am and 10pm UTC on weekdays.
+

--- a/content/departments/engineering/dev/process/deployments/instances.md
+++ b/content/departments/engineering/dev/process/deployments/instances.md
@@ -85,8 +85,8 @@ This deployment is a [managed instance](../../../../cloud/index.md) used by Dist
 - [Operations](../../../../cloud/technical-docs/operations.md)
 
 ### sourcegraph.sourcegraph.com (S2)
+
 - [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-sg)
 - [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/main/sg)
 - [Operations](../../../../cloud/technical-docs/operations.md)
 - Deployment schedule: every hour on between 8am and 10pm UTC on weekdays.
-

--- a/content/departments/engineering/teams/dev-experience/index.md
+++ b/content/departments/engineering/teams/dev-experience/index.md
@@ -77,11 +77,14 @@ Read more about [how this team works](./processes.md).
 - [DevX initiatives code insights](https://k8s.sgdev.org/insights/dashboards/ZGFzaGJvYXJkOnsiSWRUeXBlIjoiY3VzdG9tIiwiQXJnIjo3MjcyNTV9)
 - [devx-scratch](processes.md#devx-scratch)
 
-## Growth plan
-
-Come work with us! We're hiring software engineers to join our team in Q3 and Q4 - check out our [careers page](https://about.sourcegraph.com/jobs/)!
-
 ## Tech stack
 
-We primarily build tools and libraries in Go, with a dash of bash scripting in between.
-We also operate [CI infrastructure](../../dev/tools/infrastructure/ci/index.md) with Kubernetes and Terraform.
+- We primarily build tools and libraries in Go, with a dash of bash scripting in between.
+- We also operate [CI infrastructure](../../dev/tools/infrastructure/ci/index.md) with Kubernetes and Terraform.
+- We also maintain various instances of Sourcegraph which include:
+    - [sourcegraph.com (dotCom)](https://sourcegraph.com)
+        - [Continuously deployed](../../dev/process/deployments/index.md#Continuous-Deployment-Continuous) on the following schedule "09:00 UTC on Monday, 05:00 UTC rest of weekdays". To trigger a deployment refer to the [Deploying a code change to DotCom](../devops/deploy-code-change.md) document.
+    - [S2](https://sourcegraph.sourcegraph.com)
+        - Managed instance which is continuously deployed with a [GitHub action](https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/.github/workflows/upgrade-sourcegraph.yaml) that runs every hour on between 8am and 10pm UTC on weekdays.
+    - [k8s](https://k8s.sgdev.com) aka "dogfood" for more information refer to the [Instances document](../../dev/process/deployments/instances.md)
+    - [Scaletesting](https://scaletesting.sgdev.org) for more information see [scaltesting](../../dev/tools/scaletesting.md)

--- a/content/departments/engineering/teams/dev-experience/index.md
+++ b/content/departments/engineering/teams/dev-experience/index.md
@@ -37,6 +37,7 @@ Find out more about the Dev Experience team's mission, vision, and strategic pla
     - [buildkite-job-dispatcher](../../dev/tools/infrastructure/ci/index.md#buildkite-job-dispatcher)
   - [Continuous integration playbook](../../dev/process/incidents/playbooks/ci.md)
 - Other
+  - [Maintaining various instances of Sourcegraph](#sourcegraph-instances-operated-by-us)
   - [Developer experience newsletter](./newsletter.md)
   - [`sg` hack hour](processes.md#sg-hack-hour)
   - GCP cost and cost reduction initiatives
@@ -77,14 +78,17 @@ Read more about [how this team works](./processes.md).
 - [DevX initiatives code insights](https://k8s.sgdev.org/insights/dashboards/ZGFzaGJvYXJkOnsiSWRUeXBlIjoiY3VzdG9tIiwiQXJnIjo3MjcyNTV9)
 - [devx-scratch](processes.md#devx-scratch)
 
+## Sourcegraph instances operated by us
+
+We also maintain various instances of Sourcegraph which include:
+- [sourcegraph.com (dotCom)](https://sourcegraph.com)
+    - [Continuously deployed](../../dev/process/deployments/index.md#Continuous-Deployment-Continuous) on the following schedule "09:00 UTC on Monday, 05:00 UTC rest of weekdays". To trigger a deployment refer to the [Deploying a code change to DotCom](../devops/deploy-code-change.md) document.
+- [S2](https://sourcegraph.sourcegraph.com)
+    - Managed instance which is continuously deployed with a [GitHub action](https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/.github/workflows/upgrade-sourcegraph.yaml) that runs every hour on between 8am and 10pm UTC on weekdays.
+- [k8s](https://k8s.sgdev.com) aka "dogfood" for more information refer to the [Instances document](../../dev/process/deployments/instances.md)
+- [Scaletesting](https://scaletesting.sgdev.org) for more information see [scaltesting](../../dev/tools/scaletesting.md)
+
 ## Tech stack
 
 - We primarily build tools and libraries in Go, with a dash of bash scripting in between.
 - We also operate [CI infrastructure](../../dev/tools/infrastructure/ci/index.md) with Kubernetes and Terraform.
-- We also maintain various instances of Sourcegraph which include:
-    - [sourcegraph.com (dotCom)](https://sourcegraph.com)
-        - [Continuously deployed](../../dev/process/deployments/index.md#Continuous-Deployment-Continuous) on the following schedule "09:00 UTC on Monday, 05:00 UTC rest of weekdays". To trigger a deployment refer to the [Deploying a code change to DotCom](../devops/deploy-code-change.md) document.
-    - [S2](https://sourcegraph.sourcegraph.com)
-        - Managed instance which is continuously deployed with a [GitHub action](https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/.github/workflows/upgrade-sourcegraph.yaml) that runs every hour on between 8am and 10pm UTC on weekdays.
-    - [k8s](https://k8s.sgdev.com) aka "dogfood" for more information refer to the [Instances document](../../dev/process/deployments/instances.md)
-    - [Scaletesting](https://scaletesting.sgdev.org) for more information see [scaltesting](../../dev/tools/scaletesting.md)

--- a/content/departments/engineering/teams/dev-experience/index.md
+++ b/content/departments/engineering/teams/dev-experience/index.md
@@ -81,10 +81,11 @@ Read more about [how this team works](./processes.md).
 ## Sourcegraph instances operated by us
 
 We also maintain various instances of Sourcegraph which include:
+
 - [sourcegraph.com (dotCom)](https://sourcegraph.com)
-    - [Continuously deployed](../../dev/process/deployments/index.md#Continuous-Deployment-Continuous) on the following schedule "09:00 UTC on Monday, 05:00 UTC rest of weekdays". To trigger a deployment refer to the [Deploying a code change to DotCom](../devops/deploy-code-change.md) document.
+  - [Continuously deployed](../../dev/process/deployments/index.md#Continuous-Deployment-Continuous) on the following schedule "09:00 UTC on Monday, 05:00 UTC rest of weekdays". To trigger a deployment refer to the [Deploying a code change to DotCom](../devops/deploy-code-change.md) document.
 - [S2](https://sourcegraph.sourcegraph.com)
-    - Managed instance which is continuously deployed with a [GitHub action](https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/.github/workflows/upgrade-sourcegraph.yaml) that runs every hour on between 8am and 10pm UTC on weekdays.
+  - Managed instance which is continuously deployed with a [GitHub action](https://github.com/sourcegraph/deploy-sourcegraph-managed/blob/main/.github/workflows/upgrade-sourcegraph.yaml) that runs every hour on between 8am and 10pm UTC on weekdays.
 - [k8s](https://k8s.sgdev.com) aka "dogfood" for more information refer to the [Instances document](../../dev/process/deployments/instances.md)
 - [Scaletesting](https://scaletesting.sgdev.org) for more information see [scaltesting](../../dev/tools/scaletesting.md)
 


### PR DESCRIPTION
Added more detail about the instances of sourcegraph devx handles as well as add their deployment cadence