### PR TITLE
cloud: add queries to show blocking queries

### DIFF
--- a/content/departments/engineering/dev/process/incidents/playbooks/index.md
+++ b/content/departments/engineering/dev/process/incidents/playbooks/index.md
@@ -398,7 +398,6 @@ To determine which service is blocking the migrator, run the following query:
    WHERE NOT blocked_locks.GRANTED;
 ```
 
-
 ### Redis interactions
 
 ### Connecting to the Redis databases in production


### PR DESCRIPTION
Add queries to list indexing and/or blocking services to unblock `migrator`. 

