### PR TITLE
Cloud: Add new required step to MI 1.1 teardown

### DIFF
--- a/content/departments/cloud/technical-docs/v1.1/mi1-1_delete_process.md
+++ b/content/departments/cloud/technical-docs/v1.1/mi1-1_delete_process.md
@@ -58,6 +58,10 @@ Clone or navigate to the `sourcegraph/deploy-sourcegraph-managed` repository
 
     - `git checkout -b $CUSTOMER/destroy-managed-instance`
 
+1. Authenticate to the project:
+
+    - `gcloud auth application-default login --project sourcegraph-managed-$CUSTOMER`
+
 ### Navigate to the customer's managed instance directory
 
 ```sh

--- a/content/departments/cloud/technical-docs/v1.1/mi1-1_delete_process.md
+++ b/content/departments/cloud/technical-docs/v1.1/mi1-1_delete_process.md
@@ -58,7 +58,7 @@ Clone or navigate to the `sourcegraph/deploy-sourcegraph-managed` repository
 
     - `git checkout -b $CUSTOMER/destroy-managed-instance`
 
-1. Authenticate to the project:
+1.  Authenticate to the project:
 
     - `gcloud auth application-default login --project sourcegraph-managed-$CUSTOMER`
 


### PR DESCRIPTION
This is required when permissions are granted through Entitle.