### PR TITLE
updating helm version in deploy command

### DIFF
--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -113,7 +113,7 @@ To make changes to images, environment variables or other configuration, all udp
 
 Merge your changes via a pull request, and run the following from the base of the `deploy-sourcegraph-scaletesting` repository:
 
-`helm upgrade --install --values ./helm/sourcegraph/values.yaml --version 3.43.2-insiders.3e3f9e9 sourcegraph insiders/sourcegraph -n scaletesting`
+`helm upgrade --install --values ./helm/sourcegraph/values.yaml --version 4.1.2-insiders.cbf797a sourcegraph insiders/sourcegraph -n scaletesting`
 
 ### Scale the infrastructure down when not in use
 


### PR DESCRIPTION
Scale testing instance has been updated to 4.1.2 and the helm upgrade command in the docs should reflect this change as well