### PR TITLE
scaletesting: bump helm chart commit

### DIFF
--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -124,6 +124,7 @@ Then, merge your changes via a pull request, and run the following from the base
 ```bash
 helm upgrade --install --values ./helm/sourcegraph/values.yaml --version 4.1.2-insiders.40464aa sourcegraph insiders/sourcegraph -n scaletesting`
 ```
+
 ### Scale the infrastructure down when not in use
 
 To ensure the cluster is not left running, set the `node_count` to `0` in the [`terraform` config](https://github.com/sourcegraph/infrastructure/blob/main/scaletesting/main.tf#L39)

--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -111,10 +111,19 @@ Below you can find a subset of the common tasks and how to complete them:
 
 To make changes to images, environment variables or other configuration, all udpates should be made in [values.yaml](https://github.com/sourcegraph/deploy-sourcegraph-scaletesting/blob/main/helm/sourcegraph/values.yaml)
 
-Merge your changes via a pull request, and run the following from the base of the `deploy-sourcegraph-scaletesting` repository:
+First, ensure that you have the sourcegraph helm chart installed:
 
-`helm upgrade --install --values ./helm/sourcegraph/values.yaml --version 4.1.2-insiders.cbf797a sourcegraph insiders/sourcegraph -n scaletesting`
+```bash
+helm repo add insiders https://helm.sourcegraph.com/insiders
+helm repo update
+helm search repo insiders --devel
+```
 
+Then, merge your changes via a pull request, and run the following from the base of the `deploy-sourcegraph-scaletesting` repository:
+
+```bash
+helm upgrade --install --values ./helm/sourcegraph/values.yaml --version 4.1.2-insiders.40464aa sourcegraph insiders/sourcegraph -n scaletesting`
+```
 ### Scale the infrastructure down when not in use
 
 To ensure the cluster is not left running, set the `node_count` to `0` in the [`terraform` config](https://github.com/sourcegraph/infrastructure/blob/main/scaletesting/main.tf#L39)


### PR DESCRIPTION
Bumps commit to https://github.com/sourcegraph/deploy-sourcegraph-helm/commit/40464aa6babf2be35ed4184113f247db3bbcef27

Also adds prerequisite helm chart installation instructions from https://sourcegraph.slack.com/archives/C040LV3PS4C/p1668449594165329?thread_ts=1668446705.030069&cid=C040LV3PS4C