### PR TITLE
release guild faq updates

### DIFF
--- a/content/departments/engineering/guilds/release_guild.md
+++ b/content/departments/engineering/guilds/release_guild.md
@@ -1,8 +1,7 @@
 # Release guild
 
 The release guild is a collection of teammates that serve as [release captain](../dev/process/releases/index.md#release-captain) for Sourcegraph releases. The guild
-was formed to establish a cross-team working group of engineers that own the release process. The guild is currently
-chartered to act through Q1 and Q2 of FY23; however, there is no current sunset date for the guild.
+was formed to establish a cross-team working group of engineers that own the release process.
 
 The release guild can be found in the slack channel #release-guild.
 
@@ -25,7 +24,6 @@ The current schedule is shown below:
 - Ensure release captains are identified for minor and patch releases
 - Organizing and adminstrating the release guild, such as establishing policies, procedures, and documenting how we work
 - Being a point of contact for the guild, and being responsible for overall communications to the rest of the guild
-- Regular updates to engineering leadership. Currently, weekly updates to the [release OKR](https://github.com/sourcegraph/engineering-tracker/issues/66)
 
 ## FAQ
 
@@ -36,26 +34,6 @@ There probably isn’t any “best person” for this guild. The skills needed a
 ### Approximately how much time should I expect to dedicate to release?
 
 Typically, a release takes place over a few days (2-3). The ticket template has all the steps required to perform a release. It can be hard to estimate how much time it will take because it is hard to gauge the size of the release beforehand. We do not impose any limitations on what can be included
-
-### Approximately how much time should I plan to spend doing targeted improvements to the release process?
-
-To be decided
-
-### How much support would I get from the delivery team as I’m rolling onto this?
-
-The Delivery team is happy to answer questions, give guidance, and provide more clarity on best ways to perform release captain duties. Additionally, they will help when there are infrastructure problems, configuration issues, etc. Think of them as a contributor to a release vs owners of the release
-
-### How many engineers would be a part of the guild, and how much can we expect to split the load?
-
-At bare minimum 3 engineers (one per release per quarter). It would be good to have 6 so every release captain has a partner. We will evaluate this number over time as required.
-
-### Is there a clear sunset date for the guild?
-
-No. The current proposal will run through Q1 & Q2, with weekly check-ins (OKR check in) to make sure we have set ourselves up for success. We may discover that this doesn’t work and we need a different solution. We could also discover this is way more effective and we want to continue for the rest of the year.
-
-### Will guild members rotate in and out?
-
-Sure. The important aspect of the guild is to have a “bottoms up” way to tackle a hard department level problem. If the members want to rotate out and we still have our minimum coverage (3 engineers)
 
 ### I don't know whether my team can afford to lose that time?
 


### PR DESCRIPTION
The release guild page was nearly a year old with a lot of old and irrelevant information. This PR just removes some of the crusty bits.