### PR TITLE
cloud: add managed SMTP documentation

### DIFF
--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -19,7 +19,7 @@ Managed SMTP is currently only available for Cloud v1.1 - see [the guide here](.
 ## Vendor management
 
 - **Account**
-  - Okta: Accounts are provisioned via Okta SSO via Entitle. Accounts should generally only be granted [Reporting access to a single subaccount](https://support.sparkpost.com/docs/user-guide/managing-users) at a time by default.
+  - Okta: Accounts are provisioned via Okta SSO via Entitle. Accounts should generally only be granted only [Reporting access](https://support.sparkpost.com/docs/user-guide/managing-users) by default.
   - Root account credentials: [Cloud Team - SparkPost](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=team-sourcegraph.1password.com&i=k5oim4jlnqnuqsqsjrs344nhsi&v=qxzajcksgc3givogl3r6qjbimu) (note that you must log in via [SparkPost EU](https://app.eu.sparkpost.com))
 - **Billing**: [Airbase Virtual Corporate Card](https://dashboard.airbase.io/services/323464)
   - We are billed based on emails delivered according to our usage plan, included currently up to 250,000 (as of Dec 2022), after which we are billed for overages.

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -1,0 +1,89 @@
+# Managed SMTP
+
+> NOTE: **Managed SMTP is currently an opt-in feature**, and is undergoing a gradual rollout. For more details, refer to [RFC 705](https://docs.google.com/document/d/1eaShaXlpMEezawuwTZ26nuo5g_1MjQmjpp8VvQTokzw/edit) and [the tracking issue](https://github.com/sourcegraph/customer/issues/1408). The goal is to eventually provide managed SMTP to all instances by default.
+
+Managed SMTP allows Sourcegraph Cloud instances to have email delivery services configured out-of-the-box.
+SMTP services are currently backed by [SparkPost EU](https://app.eu.sparkpost.com).
+
+In this document:
+
+- [Enabling managed SMTP for a Cloud instance](#enabling-managed-smtp-for-a-cloud-instance) - links to guides
+- [Vendor management](#vendor-management) - management details for the SMTP vendor
+- [Monitoring](#monitoring) - monitoring SMTP capabilities
+- [Vendor integration](#vendor-integration) - high-level overview of how the integration with the vendor works
+
+## Enabling managed SMTP for a Cloud instance
+
+Managed SMTP is currently only available for Cloud v1.1 - see [the guide here](../v1.1/mi1-1_managed_smtp.md).
+
+## Vendor management
+
+- **Account**:
+  - Okta: WIP
+  - Root account credentials: [Cloud Team - SparkPost](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=team-sourcegraph.1password.com&i=k5oim4jlnqnuqsqsjrs344nhsi&v=qxzajcksgc3givogl3r6qjbimu) (note that you must log in via [SparkPost EU](https://app.eu.sparkpost.com))
+- **Billing**: [Airbase Virtual Corporate Card](https://dashboard.airbase.io/services/323464)
+  - We are billed based on emails delivered according to our usage plan, included currently up to 250,000 (as of Dec 2022), after which we are billed for overages.
+- **API Keys**: [list](https://app.eu.sparkpost.com/account/api-keys) - see [vendor integration](#vendor-integration) for more details
+
+## Monitoring
+
+### Application-side
+
+- Alerting: [frontend: email_delivery_failures](https://docs.sourcegraph.com/admin/observability/alerts#frontend-email-delivery-failures)
+- Dashboards: [Frontend: Email delivery](https://docs.sourcegraph.com/admin/observability/dashboards#frontend-email-delivery)
+- [Multi-instance dashboard](../observability/index.md#multi-instance-dashboard): [Frontend: Total emails successfully delivered every 5 minutes](https://monitoring.sgdev.org/d/multi-instance-overviews/multi-instance-overviews?orgId=1)
+
+### Vendor-side
+
+Dashboards are available [in the SparkPost web application](https://app.eu.sparkpost.com/signals/analytics?range=day&timezone=America/Vancouver&precision=hour&metrics%5B0%5D=count_targeted&metrics%5B1%5D=count_rendered&metrics%5B2%5D=count_accepted&metrics%5B3%5D=count_bounce&report=summary). Relevant metrics to look at:
+
+- Accepted count: we are billed for this based on our usage plans, up to 250,000 (as of Dec 2022).
+- Bounce rates: this indicates emails that are being rejected by recipients due to misconfiguration (invalid recipients) or spam filters.
+  - Note that the Sourcegraph application and features should be responsible for ensuring recipients are valid, for example via confirmation emails.
+  - High bounce rates at high email volumes may impact our sender reputation. We may be able to reduce the impact of an customer's email delivery patterns by:
+    - Disabling managed SMTP for the account.
+    - Provisioning a [custom sending domain](#custom-sending-domains) or [dedicated IP pool](#dedicated-ip-pools).
+
+For MI 1.1, `mi check` will also report some statistics - see [MI 1.1 managed SMTP](../v1.1/mi1-1_managed_smtp.md).
+
+## Vendor integration
+
+A reference implementation for MI v1.1 is available under `mi sync smtp`.
+
+All integrations will send emails from the same sending domain, `@cloud.sourcegraph.com`, and default IP pool provided by SparkPost.
+
+Operations are managed with the API key named `managed-smtp-operator`. This is available in `sourcegraph-secrets` GSM under `SPARKPOST_API_KEY`, and [the account's 1Password entry](#vendor-management). It only has the following permissions:
+
+- `Metrics: Read-only`
+- `Subaccounts: Read/Write`
+- `Sending Domains: Read/Write`
+
+For each Cloud instance, we create the following in Sparkpost:
+
+- A [subaccount](https://support.sparkpost.com/docs/user-guide/subaccounts) corresponding to the instance
+- An API key named `send_key` associated with the subaccount, with only 1 permission: `Send via SMTP`
+
+The Cloud instance is then configured with the following:
+
+1. A default sender address, `noreply+$CUSTOMER@cloud.sourcegraph.com`, and [SMTP configuration](https://app.eu.sparkpost.com/account/smtp)
+2. A GSM entry in the instance project to store the `send_key`
+
+## Future features
+
+These are unimplemented, but are noted here as potential starting points for accomodating additional features and/or requests.
+
+### Vendor-side alerting
+
+Vendor-side alerting can be set up by spinning up a service that can receive and process [SparkPost webhook events](https://developers.sparkpost.com/api/webhooks/).
+
+### Data privacy
+
+We can list recipients and delete all data associated with the [SparkPost data privacy API](https://developers.sparkpost.com/api/data-privacy/). Note that SparkPost has limited retention for most data - see its [GDPR compliance documentation](https://www.sparkpost.com/gdpr/) and [events data retention](https://developers.sparkpost.com/api/events/#header-data-retention).
+
+### Custom sending domains
+
+Additional sending domains can be provisioned following [this guide](https://support.sparkpost.com/docs/getting-started/setting-up-domains). These domains can be assigned to specific subaccounts, which can be configured to use them as needed.
+
+### Dedicated IP pools
+
+*Very* high-volume senders can impact the default sender's deliverability (see [monitoring](#monitoring)). They can be created following [this guide](https://support.sparkpost.com/docs/deliverability/dedicated-ip-pools) (note caveats such as reputation warm-up), and subaccounts can be configured to use them as needed.

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -18,7 +18,7 @@ Managed SMTP is currently only available for Cloud v1.1 - see [the guide here](.
 
 ## Vendor management
 
-- **Account**:
+- **Account**
   - Okta: WIP
   - Root account credentials: [Cloud Team - SparkPost](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=team-sourcegraph.1password.com&i=k5oim4jlnqnuqsqsjrs344nhsi&v=qxzajcksgc3givogl3r6qjbimu) (note that you must log in via [SparkPost EU](https://app.eu.sparkpost.com))
 - **Billing**: [Airbase Virtual Corporate Card](https://dashboard.airbase.io/services/323464)
@@ -74,7 +74,7 @@ These are unimplemented, but are noted here as potential starting points for acc
 
 ### Vendor-side alerting
 
-Vendor-side alerting can be set up by spinning up a service that can receive and process [SparkPost webhook events](https://developers.sparkpost.com/api/webhooks/).
+Vendor-side alerting can be set up by spinning up a service that can receive and process [SparkPost webhook events](https://developers.sparkpost.com/api/webhooks/), or a cron job to [query deliverability metrics](https://developers.sparkpost.com/api/metrics/#metrics) (also see [monitoring](#monitoring)).
 
 ### Data privacy
 

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -46,6 +46,8 @@ Dashboards are available [in the SparkPost web application](https://app.eu.spark
 
 For MI 1.1, `mi check` will also report some statistics - see [MI 1.1 managed SMTP](../v1.1/mi1-1_managed_smtp.md).
 
+No alerting is available yet - see [future work: vendor-side alerting](#vendor-side-alerting).
+
 ## Vendor integration
 
 A reference implementation for MI v1.1 is available under `mi sync smtp`.
@@ -95,7 +97,7 @@ Vendor-side alerting can be set up by spinning up a service that can receive and
 
 ### Data privacy requests
 
-We can list recipients and delete all data associated with the [SparkPost data privacy API](https://developers.sparkpost.com/api/data-privacy/). Note that SparkPost has limited retention for most data - see [security: email contents](#email-contents)
+We can list recipients and delete all data associated with the [SparkPost data privacy API](https://developers.sparkpost.com/api/data-privacy/). Note that SparkPost has limited retention and access for most data - see [security](#security).
 
 ### Custom sending domains
 

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -19,8 +19,9 @@ Managed SMTP is currently only available for Cloud v1.1 - see [the guide here](.
 ## Vendor management
 
 - **Account**
-  - Okta: Accounts are provisioned via Okta SSO via Entitle. Accounts should generally only be granted only [Reporting access](https://support.sparkpost.com/docs/user-guide/managing-users) by default.
+  - Okta and Entitle: Accounts are provisioned via Okta SSO via Entitle. Accounts should generally only be granted only [Reporting access](https://support.sparkpost.com/docs/user-guide/managing-users) by default.
   - Root account credentials: [Cloud Team - SparkPost](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=team-sourcegraph.1password.com&i=k5oim4jlnqnuqsqsjrs344nhsi&v=qxzajcksgc3givogl3r6qjbimu) (note that you must log in via [SparkPost EU](https://app.eu.sparkpost.com))
+    - This account will be removed when the Entitle workflow has been finalized ([#1676](https://github.com/sourcegraph/customer/issues/1676))
 - **Billing**: [Airbase Virtual Corporate Card](https://dashboard.airbase.io/services/323464)
   - We are billed based on emails delivered according to our usage plan, included currently up to 250,000 (as of Dec 2022), after which we are billed for overages.
 - **API Keys**: [list](https://app.eu.sparkpost.com/account/api-keys) - see [vendor integration](#vendor-integration) for more details

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -19,7 +19,7 @@ Managed SMTP is currently only available for Cloud v1.1 - see [the guide here](.
 ## Vendor management
 
 - **Account**
-  - Okta: WIP
+  - Okta: Accounts are provisioned via Okta SSO via Entitle. Accounts should generally only be granted [Reporting access to a single subaccount](https://support.sparkpost.com/docs/user-guide/managing-users) at a time by default.
   - Root account credentials: [Cloud Team - SparkPost](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&h=team-sourcegraph.1password.com&i=k5oim4jlnqnuqsqsjrs344nhsi&v=qxzajcksgc3givogl3r6qjbimu) (note that you must log in via [SparkPost EU](https://app.eu.sparkpost.com))
 - **Billing**: [Airbase Virtual Corporate Card](https://dashboard.airbase.io/services/323464)
   - We are billed based on emails delivered according to our usage plan, included currently up to 250,000 (as of Dec 2022), after which we are billed for overages.
@@ -68,6 +68,23 @@ The Cloud instance is then configured with the following:
 1. A default sender address, `noreply+$CUSTOMER@cloud.sourcegraph.com`, and [SMTP configuration](https://app.eu.sparkpost.com/account/smtp)
 2. A GSM entry in the instance project to store the `send_key`
 
+## Security
+
+SparkPost is a [SOC2-certified provider](https://www.sparkpost.com/policies/security/), and leverages a variety of security practices that our security team has deemed satisfactory - for more details, refer to the [SparkPost DPA](https://www.sparkpost.com/policies/dpa/).
+
+Additionally, SparkPost has limited retention for most data - see its [GDPR compliance documentation](https://www.sparkpost.com/gdpr/) and [events data retention (10 days)](https://developers.sparkpost.com/api/events/#header-data-retention). Support for [data privacy requests](#data-privacy-requests) is also available.
+
+### Email data access
+
+[Reporting access](https://support.sparkpost.com/docs/user-guide/managing-users) (also see [vendor management](#vendor-management)) via the web application and the [message events API](https://developers.sparkpost.com/api/events/#header-event-types) can be used to access:
+
+- Aggregate numbers (deliveries, bounces, etc)
+- Specific email events, including receipients, subjects, message sizes, and other diagnostic data (but **not** email contents)
+
+### Account isolation
+
+Our [vendor integration](#vendor-integration) is designed such that all usage and access can be constrolled on a per-subaccount (i.e. per-customer) basis. API tokens distributed to Cloud instances are scoped to individual subaccounts with very limited permissions, and can be disabled individually.
+
 ## Future features
 
 These are unimplemented, but are noted here as potential starting points for accomodating additional features and/or requests.
@@ -76,9 +93,9 @@ These are unimplemented, but are noted here as potential starting points for acc
 
 Vendor-side alerting can be set up by spinning up a service that can receive and process [SparkPost webhook events](https://developers.sparkpost.com/api/webhooks/), or a cron job to [query deliverability metrics](https://developers.sparkpost.com/api/metrics/#metrics) (also see [monitoring](#monitoring)).
 
-### Data privacy
+### Data privacy requests
 
-We can list recipients and delete all data associated with the [SparkPost data privacy API](https://developers.sparkpost.com/api/data-privacy/). Note that SparkPost has limited retention for most data - see its [GDPR compliance documentation](https://www.sparkpost.com/gdpr/) and [events data retention](https://developers.sparkpost.com/api/events/#header-data-retention).
+We can list recipients and delete all data associated with the [SparkPost data privacy API](https://developers.sparkpost.com/api/data-privacy/). Note that SparkPost has limited retention for most data - see [security: email contents](#email-contents)
 
 ### Custom sending domains
 

--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -86,4 +86,4 @@ Additional sending domains can be provisioned following [this guide](https://sup
 
 ### Dedicated IP pools
 
-*Very* high-volume senders can impact the default sender's deliverability (see [monitoring](#monitoring)). They can be created following [this guide](https://support.sparkpost.com/docs/deliverability/dedicated-ip-pools) (note caveats such as reputation warm-up), and subaccounts can be configured to use them as needed.
+_Very_ high-volume senders can impact the default sender's deliverability (see [monitoring](#monitoring)). They can be created following [this guide](https://support.sparkpost.com/docs/deliverability/dedicated-ip-pools) (note caveats such as reputation warm-up), and subaccounts can be configured to use them as needed.

--- a/content/departments/cloud/technical-docs/v1.1/index.md
+++ b/content/departments/cloud/technical-docs/v1.1/index.md
@@ -38,6 +38,7 @@ The following processes only apply to Managed Instances v1.1:
 - [Enable Executors](./mi1-1_enable_executors_process.md)
 - [Deploy a hotpatch](./mi1-1_hotpatch_process.md)
 - [On-prem to Cloud data migration](./mi1-1_onprem_data_migration.md)
+- [Enabling managed SMTP](./mi1-1_managed_smtp.md)
 
 [cloud sql]: https://cloud.google.com/sql/postgresql
 [google cloud storage]: https://cloud.google.com/storage

--- a/content/departments/cloud/technical-docs/v1.1/mi1-1_managed_smtp.md
+++ b/content/departments/cloud/technical-docs/v1.1/mi1-1_managed_smtp.md
@@ -18,4 +18,4 @@ See [managed SMTP](../managed-smtp/index.md) for more details.
 
 14-day vendor-side deliverability statistics are reported by `mi check`.
 
-For more details, see [managed SMTP: monitoring](managed-../managed-smtp/index.md#monitoring).
+For more details, see [managed SMTP: monitoring](../managed-smtp/index.md#monitoring).

--- a/content/departments/cloud/technical-docs/v1.1/mi1-1_managed_smtp.md
+++ b/content/departments/cloud/technical-docs/v1.1/mi1-1_managed_smtp.md
@@ -1,0 +1,21 @@
+# MI 1.1 Managed SMTP
+
+See [managed SMTP](../managed-smtp/index.md) for more details.
+
+## Enabling managed SMTP
+
+1. Set `disableManagedSMTP: false` in the instance configuration.
+2. Run `mi sync smtp -test-send`.
+   1. If any errors arise, follow remediation steps that get raised and re-run `mi sync smtp -test-send`.
+3. Test emails are sent to `cloud-team+test_emails@sourcegraph.com` from `noreply+$INSTANCE@cloud.sourcegraph.com` by default - check your inbox to verify that the test email has been received.
+
+## Disabling managed SMTP
+
+1. Set `disableManagedSMTP: true`
+2. Run `mi sync smtp` (as above, this is safe to re-run)
+
+## Health check
+
+14-day vendor-side deliverability statistics are reported by `mi check`.
+
+For more details, see [managed SMTP: monitoring](managed-../managed-smtp/index.md#monitoring).


### PR DESCRIPTION
Initial documentation for https://github.com/sourcegraph/customer/issues/1408.

Closes https://github.com/sourcegraph/customer/issues/1672, closes https://github.com/sourcegraph/customer/issues/1527

Preview: https://deploy-preview-5722--sourcegraph-handbook.netlify.app/departments/cloud/technical-docs/managed-smtp/