### PR TITLE
Fix outdated handbook contributors link

### DIFF
--- a/content/handbook/editing/index.md
+++ b/content/handbook/editing/index.md
@@ -9,7 +9,7 @@ The handbook consists of Markdown files in the Git repository at [github.com/sou
 We don't expect everyone on the team to figure this out on their own. Other teammates are happy to help!
 
 - Any engineer at Sourcegraph can help. (The _code_ that engineers write at Sourcegraph also consists of files in a Git repository, so engineers are very familiar with making these kinds of edits.)
-- [Teammates who have already made a handbook change](https://sourcegraph.com/github.com/sourcegraph/about/-/stats/contributors?path=handbook%2F) can help.
+- [Teammates who have already made a handbook change](https://sourcegraph.com/github.com/sourcegraph/handbook/-/stats/contributors) can help.
 - **Handbook support**: Ask the @handbook-support group in Slack (formerly called "handbook heroes") for handbook help (via DM, #handbook, or #any-question). They volunteered to help anyone with anything handbook-related! _If you too want to be part of handbook support, simply join the @handbook-support group in Slack_
 - Ask in #handbook: "Who can screen-share with me to help me make an edit to the handbook?"
 - Don't be afraid of breaking anything! It is very easy for any engineer on the team to roll back to the previous version of the handbook if you make a mistake.


### PR DESCRIPTION
The link for "Teammates who have already made a handbook change" referred to
the old location for the handbook code. This commit updates it to use the new
`handbook` repo.
