### PR TITLE
banner: introduce Banners that can be added to subsets of pages

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+/**
+ * Banner generates the appropriate banner(s) for the given slug paths. Banners are
+ * hardcoded in this component.
+ */
+export function Banner({ path }: { path: string }): JSX.Element {
+    // Banners should each be an <aside> with the appropriate className to indicate the
+    // admonition type.
+    const banners: React.ReactElement[] = []
+
+    // Inject warning banners to pages with cloud in the path - this helps us communicate
+    // to customers that for finalized documentation, they should refer elsewhere.
+    if (path.includes('/cloud')) {
+        banners.push(
+            <aside className="warning">
+                <div>
+                    <b>
+                        To learn more about the Sourcegraph Cloud product, please refer to our{' '}
+                        <a href="https://docs.sourcegraph.com/cloud">user-facing documentation</a>.
+                    </b>
+                    The documentation here is meant for internal Sourcegraph use, and may represent unreleased,
+                    incomplete, or out-of-date processes and functionality - it is made public to align with{' '}
+                    <a href="/company-info-and-process/values/#open-and-transparent">our values</a>.
+                </div>
+            </aside>
+        )
+    }
+
+    return banners ? (
+        <div className="markdown-body">
+            <br />
+            {banners}
+        </div>
+    ) : (
+        <></>
+    )
+}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -18,7 +18,7 @@ export function Banner({ path }: { path: string }): JSX.Element {
                     <b>
                         To learn more about the Sourcegraph Cloud product, please refer to our{' '}
                         <a href="https://docs.sourcegraph.com/cloud">user-facing documentation</a>.
-                    </b>
+                    </b>{' '}
                     The documentation here is meant for internal Sourcegraph use, and may represent unreleased,
                     incomplete, or out-of-date processes and functionality - it is made public to align with{' '}
                     <a href="/company-info-and-process/values/#open-and-transparent">our values</a>.

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -5,6 +5,7 @@ import ErrorPage from 'next/error'
 import { useRouter } from 'next/router'
 import React, { useEffect, useRef } from 'react'
 
+import { Banner } from '../components/Banner'
 import { EditSection } from '../components/EditSection'
 import { TableOfContents } from '../components/TableOfContents'
 import { getPageBySlugPath, loadAllPages, LoadedPage } from '../lib/api'
@@ -134,6 +135,7 @@ export default function Page({ page }: PageProps): JSX.Element {
                                     )
                                 })}
                             </nav>
+                            <Banner path={page.path} />
                             <main
                                 className="markdown-body"
                                 data-swiftype-name="body"


### PR DESCRIPTION
There is a risk of customers finding handbook content that does not accurately represent the current state of Sourcegraph Cloud offerings - to mitigate this while remaining open and transparent, we add prominent banners on every page in the `/cloud` path.

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/23356519/206550302-54a41f84-5b34-4b45-aeca-a13fc4a28a39.png">
