### PR TITLE
Add generated team page from BambooHR API

### DIFF
--- a/src/lib/fetchTeam.ts
+++ b/src/lib/fetchTeam.ts
@@ -1,0 +1,65 @@
+export interface TeamMember {
+    name: string
+    reports: TeamMember[]
+}
+
+interface BambooEmployee {
+    displayName: string
+    preferredName: string
+    firstName: string
+    lastName: string
+    supervisor: string
+}
+
+interface BambooEmployeeWithReports extends BambooEmployee {
+    reports: BambooEmployeeWithReports[]
+}
+
+interface BambooDirectoryResponse {
+    employees: BambooEmployee[]
+}
+
+export async function fetchTeam(): Promise<BambooEmployee[]> {
+    const authorizationHeader = Buffer.from(`${process.env.BAMBOO_API_KEY ?? ''}:x`).toString('base64')
+    const response = await fetch('https://api.bamboohr.com/api/gateway.php/sourcegraph/v1/employees/directory', {
+        method: 'GET',
+        headers: {
+            accept: 'application/json',
+            authorization: `Basic ${authorizationHeader}`,
+        },
+    })
+
+    const body = (await response.json()) as BambooDirectoryResponse
+
+    return body.employees
+}
+
+export async function getTeamMemberTree(): Promise<TeamMember> {
+    const employees = await fetchTeam()
+    const rootEmployee = employees.find(employee => employee.supervisor === '')
+
+    if (!rootEmployee) {
+        throw new Error('No root employee found')
+    }
+
+    const supervisorMap = new Map<string, BambooEmployee>()
+    for (const employee of employees) {
+        supervisorMap.set(employee.displayName, employee)
+    }
+
+    function addReports(employee: BambooEmployee): BambooEmployeeWithReports {
+        const reports = employees.filter(e => e.supervisor === employee.displayName)
+        return { ...employee, reports: reports.map(addReports) }
+    }
+
+    const employeeTreeWithReports = addReports(rootEmployee)
+
+    function convertEmployeeTreeToTeamMembers(employee: BambooEmployeeWithReports): TeamMember {
+        return {
+            name: `${employee.preferredName ?? employee.firstName} ${employee.lastName}`,
+            reports: employee.reports.map(convertEmployeeTreeToTeamMembers),
+        }
+    }
+
+    return convertEmployeeTreeToTeamMembers(employeeTreeWithReports)
+}

--- a/src/pages/generated-team.tsx
+++ b/src/pages/generated-team.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { getTeamMemberTree, TeamMember } from '../lib/fetchTeam'
+
+interface Props {
+    teamMemberTree: TeamMember
+}
+
+function TeamMemberListItem({ teamMember }: { teamMember: TeamMember }): JSX.Element {
+    return (
+        <li>
+            {teamMember.name}
+            <ul>
+                {teamMember.reports.map(t => (
+                    <TeamMemberListItem key={t.name} teamMember={t} />
+                ))}
+            </ul>
+        </li>
+    )
+}
+
+export default function GeneratedPage({ teamMemberTree }: { teamMemberTree: TeamMember }): JSX.Element {
+    return (
+        <div className="container">
+            <section id="content">
+                <h1>Team</h1>
+                <ul>
+                    <TeamMemberListItem teamMember={teamMemberTree} />
+                </ul>
+            </section>
+        </div>
+    )
+}
+
+export async function getStaticProps(): Promise<{ props: Props }> {
+    const teamMemberTree = await getTeamMemberTree()
+    return { props: { teamMemberTree } }
+}


### PR DESCRIPTION
This is a quick prototype to pull the team from BambooHR.

It would solve the problem of having to edit the handbook manually every time a change happens.

The prototype just displays a full tree

Need an new API token called `BAMBOO_API_TOKEN` to use the API, so this won't work directly from this PR / preview deploy. Run it locally with the token.

If completed this would close #5164 

