### PR TITLE
clean up handbook index

### DIFF
--- a/content/company-info-and-process/about-sourcegraph/general-office-info.md
+++ b/content/company-info-and-process/about-sourcegraph/general-office-info.md
@@ -1,16 +1,16 @@
-# General office information
+# Contact, business, and general office information
 
 ### Contact information
 
 Address (for all mail, contracts, and paperwork): 548 Market St PMB 20739, San Francisco, CA 94104-5401
 
-Phone Number: (650) 273-5591
+Phone number: (650) 273-5591
 
 ### Business information
 
-DUNS Number: 117775232
+DUNS number: 117775232
 
-Tax ID: For the Tax ID, refer to Sourcegraph W9
+Tax ID: For the Tax ID, refer to your Sourcegraph W-9.
 
 NAICS code: 541512
 

--- a/content/departments/people-talent/talent/process/recruitment_branding.md
+++ b/content/departments/people-talent/talent/process/recruitment_branding.md
@@ -16,7 +16,7 @@ Sourcegraph will share the top priority roles we're hiring for via LinkedIn and 
   - We are building a team of brilliant dreamers around the globe. Join my team at Sourcegraph! [https://srcgr.ph/32pe8gC](https://srcgr.ph/32pe8gC)
   - At Sourcegraph we are developing the world's most advanced code search navigation platform alongside some pretty awesome people. Check it out: https://srcgr.ph/32pe8gC
   - More [post examples](https://drive.google.com/drive/u/0/folders/1wE3IGJ5WF5fYIm7h6BOA9z_kUAieInsE) to provide inspiration!
-  - Use these editable ['We're Hiring' Figma templates](https://www.figma.com/file/XXHx1E5zptZXvVXhf4YHAW/Hiring-social-imagery-templates?node-id=623%3A54) ([Loom Tutorial](https://www.loom.com/share/f03bdf8745af411481fa51e3a5a0f54d))
+  - Use these editable ['We're hiring' Figma templates](https://www.figma.com/file/XXHx1E5zptZXvVXhf4YHAW/Hiring-social-imagery-templates?node-id=623%3A54) ([Loom Tutorial](https://www.loom.com/share/f03bdf8745af411481fa51e3a5a0f54d))
   - [LinkedIn content library](https://docs.google.com/spreadsheets/d/1j8mzReq4FTNrxFC8-4moSWunwPynUpgllo2_dshcwCQ/edit#gid=0) (Talent team only)
 
 #### LinkedIn posting best practices
@@ -31,7 +31,7 @@ Sourcegraph will share the top priority roles we're hiring for via LinkedIn and 
 - Copy options for Twitter
   - Click to tweet: https://ctt.ac/k23tL
   - Click to tweet: https://ctt.ac/dxqE5
-  - Use these editable ['We're Hiring' Figma templates](https://www.figma.com/file/XXHx1E5zptZXvVXhf4YHAW/Hiring-social-imagery-templates?node-id=623%3A54) ([Loom Tutorial](https://www.loom.com/share/f03bdf8745af411481fa51e3a5a0f54d))
+  - Use these editable ['We're hiring' Figma templates](https://www.figma.com/file/XXHx1E5zptZXvVXhf4YHAW/Hiring-social-imagery-templates?node-id=623%3A54) ([Loom Tutorial](https://www.loom.com/share/f03bdf8745af411481fa51e3a5a0f54d))
 
 ### Content to share:
 

--- a/content/handbook/index.md
+++ b/content/handbook/index.md
@@ -1,13 +1,8 @@
----
-title: How to use the handbook
-description: Guidance on how to get the most out of the Sourcegraph handbook
----
+# Handbook usage
 
-# Handbook Usage & Principles
+## What is the handbook?
 
-## What is the Handbook?
-
-The Sourcegraph Handbook is centralized documentation system for how we work. We are a [handbook-first company](#what-does-it-mean-to-be-handbook-first) because:
+The Sourcegraph handbook is centralized documentation system for how we work. We are a [handbook-first company](#what-does-it-mean-to-be-handbook-first) because:
 
 1. A written process is followed more closely and frequently than an informal one, which leads to more people and iterations to improve it.
 1. We believe anyone can and should propose improvements to a written-down process. Learn [how to propose an edit the handbook](editing/index.md).
@@ -21,7 +16,7 @@ The Sourcegraph Handbook is centralized documentation system for how we work. We
 - **The Handbook is maintained by every Sourcegraph teammate.** At Sourcegraph, we work as a team. No one person is responsible for keeping our content updated, it falls on all of us. Editing and updating pages should be quick and well documented.
 - **The Handbook is a source of truth** at Sourcegraph, and information there is expected to be accurate and up-to-date.
 
-### Intended Audience
+### Intended audience
 
 Sourcegraph is an [open company](../company-info-and-process/about-sourcegraph/index.md#sourcegraph-open-product-open-company-open-source) and we value [transparency](../company-info-and-process/values/index.md#open-and-transparent). As such, we keep the Handbook public.
 
@@ -31,7 +26,7 @@ The **secondary** intended audience for the Handbook is Sourcegraph candidates.
 
 Content intended for users of the Sourcegraph product should be part of [Sourcegraph Docs](https://docs.sourcegraph.com/).
 
-## What does it mean to be Handbook-first?
+## What does it mean to be handbook-first?
 
 Being handbook-first means using the handbook as the source of truth for answers and processes.
 
@@ -41,7 +36,7 @@ To be handbook-first, we must:
 - Default to the handbook when looking for information about a business process or policy, not just when we read about it the first time, but as a habit every time because we expect it to keep evolving.
 - Share responsibility for keeping the handbook accurate and up-to-date. If you notice something is missing or inaccurate, it is your responsibility to propose a change. This takes a lot more time than just doing things and not writing things down. But being handbook-first is worth it because it yields better processes and helps us work together efficiently as we grow.
 
-## Handbook Usage
+## Handbook usage
 
 - Most content in this handbook is meant to help rather than being absolute rules (unless stated).
 - For any process to be in force, it must be documented in the handbook. A Google Doc or pending PR to the handbook is not sufficient because using those reduces the effectiveness of the handbook as a trusted source of knowledge. Further, if you never need to merge your change to bring it into force, we aren't encouraging making small, iterative improvements. This is a rule required for us to truly be a handbook-first company.
@@ -63,7 +58,7 @@ The handbook consists of Markdown files in the Git repository at github.com/sour
 1. Many handbook changes require updating references and mentions across multiple pages. In wikis and Google Docs, there is no easy way to propose a _group_ of changes to multiple sections or pages, which means people making and reviewing edits can easily miss other places that need to be updated. This format allows grouped multi-page changes and collaboration. This is more complicated than wikis or Google Docs, but we commit to help every teammate [learn how to edit this handbook](editing/index.md).
 1. Many handbook changes are collaborative and need to be reviewed, revised, and commented on by other teammates. Git makes this possible, with comments and code reviews. Wikis don't make this easy or possible, and Google Docs has very limited review and no revision capabilities.
 
-## Handbook Support
+## Handbook support
 
 ### Slack
 

--- a/content/index.md
+++ b/content/index.md
@@ -4,69 +4,37 @@ description: The Sourcegraph handbook describes how Sourcegraph works.
 
 # Sourcegraph handbook
 
-The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's publicly visible because we are an [open company](company-info-and-process/about-sourcegraph/index.md#open-company). The table of contents below details what you can find in the handbook.
-
-The handbook is a living document and we expect every teammate to propose improvements, changes, additions, and fixes to keep it continuously up-to-date and accurate. Learn more about the handbook [here](handbook/index.md).
+The Sourcegraph handbook describes how Sourcegraph team members work together at Sourcegraph. It's publicly visible because we are an [open company](company-info-and-process/about-sourcegraph/index.md#open-company). We all [use and edit the handbook](handbook/index.md) regularly.
 
 Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
-## Benefits, pay, perks
-
-- [Overview](benefits-pay-perks/benefits-perks/index.md)
-- [Compensation](benefits-pay-perks/pay-expenses/compensation/index.md)
-- [Submitting expenses](benefits-pay-perks/pay-expenses/expenses/index.md)
-  - [Spending company money - what's covered](benefits-pay-perks/benefits-perks/spending-company-money.md)
-- [Travel benefits](benefits-pay-perks/benefits-perks/travel/index.md)
-- [Time off](benefits-pay-perks/benefits-perks/time-off/index.md)
-  - [Company holidays](company-info-and-process/working-at-sourcegraph/holidays.md)
-- [Mental health](benefits-pay-perks/benefits-perks/mental-health/index.md)
-
-## Team
-
-- [Org chart](team/org_chart.md)
-- [Team bios](team/index.md)
-- [CEO](team/ceo/index.md)
-
-## [Strategy](strategy-goals/index.md)
-
-- [Strategy](strategy-goals/strategy/index.md)
-- [Goals/OKRs](strategy-goals/goals/index.md)
-- [Cross-functional projects](strategy-goals/cross-functional-projects/index.md)
-
-## Company information and processes
+## Company information
 
 - [About Sourcegraph](company-info-and-process/about-sourcegraph/index.md)
-- [General office information](company-info-and-process/about-sourcegraph/general-office-info.md)
-- [All-remote](company-info-and-process/remote/index.md)
-- [Values](company-info-and-process/values/index.md)
-- [Diversity, Equity, and Inclusion](company-info-and-process/diversity-equity-and-inclusion/index.md)
-  - [Gender Diversity Allies and ERG](company-info-and-process/diversity-equity-and-inclusion/gender-diversity.md)
-  - [Queer and Trans ERG](company-info-and-process/diversity-equity-and-inclusion/queer.md)
-- [Mentorship](company-info-and-process/mentorship/index.md)
+  - [Values](company-info-and-process/values/index.md)
+  - [All-remote](company-info-and-process/remote/index.md)
+- [Strategy](strategy-goals/strategy/index.md)
+- [Cross-functional projects](strategy-goals/cross-functional-projects/index.md)
 - [Communication](company-info-and-process/communication/index.md)
   - [Content guidelines](company-info-and-process/communication/content_guidelines/index.md)
-  - [RFCs](company-info-and-process/communication/rfcs/index.md)
   - [Asynchronous communication](company-info-and-process/communication/asynchronous-communication.md)
-- [Community](company-info-and-process/community/index.md)
-- [Policies](company-info-and-process/policies/index.md)
+- [Handbook](handbook/index.md)
+  - [Editing the handbook](handbook/editing/index.md)
+  - [Recent handbook diffs](https://sourcegraph.com/search?q=context:global+repo:^github.com/sourcegraph/handbook%24+type:diff)
+- Team
+  - [Team bios](team/index.md)
+  - [Org chart](team/org_chart.md)
 
-## Using the handbook
-
-- [Editing the handbook](handbook/editing/index.md)
-- [Handbook usage & principles](handbook/index.md)
-- [Handbook feedback](https://docs.google.com/forms/d/e/1FAIpQLSfb0yU9xmnvK2namuUzUEKbB9IqZlNQF2IWw0OpLsGvBiW2oQ/viewform?usp=sf_link)
-- [What's new in the handbook](https://sourcegraph.com/github.com/sourcegraph/about/-/commits) (or [this search](https://sourcegraph.com/search?q=context:global+repo:^github.com/sourcegraph/about%24+type:diff+rev:main) if you'd like to see diffs)
-
-## Information by department
+## Departments
 
 ### [People & Talent](departments/people-talent/index.md)
 
 - [People team](departments/people-talent/index.md)
 
-- [Talent](departments/people-talent/index.md)
+- [Talent team](departments/people-talent/index.md)
   - [Resources for Interns](departments/people-talent/talent/internship/index.md)
   - [Resources for Candidates](departments/people-talent/index.md#resources-for-candidates)
-  - [Resources for Hiring Manager](departments/people-talent/index.md#resources-for-hiring-managers)
+  - [Resources for Hiring Managers](departments/people-talent/index.md#resources-for-hiring-managers)
   - [Resources for Teammates](departments/people-talent/index.md#resources-for-teammates)
   - [Resources for Talent Team](departments/people-talent/index.md#resources-for-talent-team)
 
@@ -114,3 +82,20 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 - [Internal security](departments/tech-ops/process/internal-security/index.md)
 - [Device usage and privacy](departments/tech-ops/process/team_device_usage_privacy.md)
 - [Systems list and guides](departments/tech-ops/tools/index.md)
+
+### [CEO](departments/ceo-team/index.md)
+
+## Other company information
+
+- [Pay and benefits](benefits-pay-perks/benefits-perks/index.md)
+  - [Compensation](benefits-pay-perks/pay-expenses/compensation/index.md)
+  - [Submitting expenses](benefits-pay-perks/pay-expenses/expenses/index.md)
+  - [Spending company money - what's covered](benefits-pay-perks/benefits-perks/spending-company-money.md)
+  - [Travel benefits](benefits-pay-perks/benefits-perks/travel/index.md)
+  - [Time off](benefits-pay-perks/benefits-perks/time-off/index.md)
+  - [Mental health](benefits-pay-perks/benefits-perks/mental-health/index.md)
+- [Community](company-info-and-process/community/index.md)
+- [Diversity, Equity, and Inclusion](company-info-and-process/diversity-equity-and-inclusion/index.md)
+- [Mentorship](company-info-and-process/mentorship/index.md)
+- [Policies](company-info-and-process/policies/index.md)
+- [Contact and business information](company-info-and-process/about-sourcegraph/general-office-info.md)

--- a/content/index.md
+++ b/content/index.md
@@ -9,9 +9,7 @@ The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's pub
 
 The handbook is a living document and we expect every teammate to propose improvements, changes, additions, and fixes to keep it continuously up-to-date and accurate. Learn more about the handbook [here](handbook/index.md).
 
-## We're Hiring!
-
-- View open positions [here](https://about.sourcegraph.com/jobs/)
+Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
 ## Benefits, Pay, Perks
 

--- a/content/index.md
+++ b/content/index.md
@@ -1,9 +1,8 @@
 ---
-title: Sourcegraph Handbook
-description: The Sourcegraph handbook describes how we (Sourcegraph teammates) work.
+description: The Sourcegraph handbook describes how Sourcegraph works.
 ---
 
-# Handbook Home
+# Sourcegraph handbook
 
 The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's publicly visible because we are an [open company](company-info-and-process/about-sourcegraph/index.md#open-company). The table of contents below details what you can find in the handbook.
 
@@ -11,7 +10,7 @@ The handbook is a living document and we expect every teammate to propose improv
 
 Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
-## Benefits, Pay, Perks
+## Benefits, pay, perks
 
 - [Overview](benefits-pay-perks/benefits-perks/index.md)
 - [Compensation](benefits-pay-perks/pay-expenses/compensation/index.md)
@@ -22,19 +21,19 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
   - [Company holidays](company-info-and-process/working-at-sourcegraph/holidays.md)
 - [Mental health](benefits-pay-perks/benefits-perks/mental-health/index.md)
 
-## The Sourcegraph Team
+## Team
 
 - [Org chart](team/org_chart.md)
 - [Team bios](team/index.md)
 - [CEO](team/ceo/index.md)
 
-## [Sourcegraph Strategy and Goals](strategy-goals/index.md)
+## [Strategy](strategy-goals/index.md)
 
 - [Strategy](strategy-goals/strategy/index.md)
 - [Goals/OKRs](strategy-goals/goals/index.md)
 - [Cross-functional projects](strategy-goals/cross-functional-projects/index.md)
 
-## Company Information and Processes
+## Company information and processes
 
 - [About Sourcegraph](company-info-and-process/about-sourcegraph/index.md)
 - [General office information](company-info-and-process/about-sourcegraph/general-office-info.md)
@@ -51,14 +50,14 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 - [Community](company-info-and-process/community/index.md)
 - [Policies](company-info-and-process/policies/index.md)
 
-## Using the Handbook
+## Using the handbook
 
 - [Editing the handbook](handbook/editing/index.md)
 - [Handbook usage & principles](handbook/index.md)
 - [Handbook feedback](https://docs.google.com/forms/d/e/1FAIpQLSfb0yU9xmnvK2namuUzUEKbB9IqZlNQF2IWw0OpLsGvBiW2oQ/viewform?usp=sf_link)
 - [What's new in the handbook](https://sourcegraph.com/github.com/sourcegraph/about/-/commits) (or [this search](https://sourcegraph.com/search?q=context:global+repo:^github.com/sourcegraph/about%24+type:diff+rev:main) if you'd like to see diffs)
 
-## Information by Department
+## Information by department
 
 ### [People & Talent](departments/people-talent/index.md)
 


### PR DESCRIPTION
- Move internal and less commonly viewed pages out of the index TOC or down to the bottom
- Fix some `Title Case -> Sentence case` issues