### PR TITLE
Document new processes for repo-management & IAM

### DIFF
--- a/content/departments/engineering/teams/iam/index.md
+++ b/content/departments/engineering/teams/iam/index.md
@@ -64,20 +64,20 @@ The IAM team works alongside several other teams at Sourcegraph. You can find mo
 
 We work in 2 week cycles.
 
-*Week 1*
+_Week 1_
 
-| Monday | Tuesday | Wednesday | Thursday | Friday |
-|--------|---------|-----------|-----------|-------|
-|  | 45min Retrospective | | | |
-|  | 45min Planning | | | |
-|  | Company meeting | | | |
-|  30min sync | Demo Day | 30min sync | 30min sync | |
+| Monday     | Tuesday             | Wednesday  | Thursday   | Friday |
+| ---------- | ------------------- | ---------- | ---------- | ------ |
+|            | 45min Retrospective |            |            |        |
+|            | 45min Planning      |            |            |        |
+|            | Company meeting     |            |            |        |
+| 30min sync | Demo Day            | 30min sync | 30min sync |        |
 
-*Week 2*
+_Week 2_
 
-| Monday | Tuesday | Wednesday | Thursday | Friday |
-|--------|---------|-----------|-----------|-------|
-| 30min sync + check what's in estimation queue  | 30min sync | 60min Grooming  | 30min sync | |
+| Monday                                        | Tuesday    | Wednesday      | Thursday   | Friday |
+| --------------------------------------------- | ---------- | -------------- | ---------- | ------ |
+| 30min sync + check what's in estimation queue | 30min sync | 60min Grooming | 30min sync |        |
 
 ### Important documents and links
 
@@ -91,38 +91,39 @@ We work in 2 week cycles.
 
 The agenda for the retrospective is this:
 
-* *10min*: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/10Gr8gBVtq939E-v0UKPp_IvAXuyr35qWQYS-uDt7N9I/edit)
-  * What went well?
-  * What could have gone better?
-  * Do you feel supported?
-  * Do you feel like you’re moving into the right direction of your team?
-  * What processes/other things should we revisit/refine/propose?
-  * Other thoughts/questions?
-* *5min*: celebrate what went well (read out all items)
-* *2min*: vote on items
-* *28min*: talk through items, start with the highest votes
-  * 5min per item, use a timer, be strict
-  * Once 5min are up: ask if 2 more minutes
-  * If possible: collect action items
+- _10min_: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/10Gr8gBVtq939E-v0UKPp_IvAXuyr35qWQYS-uDt7N9I/edit)
+  - What went well?
+  - What could have gone better?
+  - Do you feel supported?
+  - Do you feel like you’re moving into the right direction of your team?
+  - What processes/other things should we revisit/refine/propose?
+  - Other thoughts/questions?
+- _5min_: celebrate what went well (read out all items)
+- _2min_: vote on items
+- _28min_: talk through items, start with the highest votes
+  - 5min per item, use a timer, be strict
+  - Once 5min are up: ask if 2 more minutes
+  - If possible: collect action items
 
 ### Grooming
 
 **Goal**: The goal for the grooming session is to as many items in our backlog
-*prioritized* and *estimated*. We estimate together enough tickets so that we’re
+_prioritized_ and _estimated_. We estimate together enough tickets so that we’re
 all on the same page on how to implement something and how long it will take, so
 that we can plan it in future sprint
 
 Requirements for the meeting:
-* DRI for a project prepares by creating tickets as much as possible
-* Product comes in with requirements from customers and tickets
+
+- DRI for a project prepares by creating tickets as much as possible
+- Product comes in with requirements from customers and tickets
 
 Agenda for the grooming meeeting:
 
-* Open the [IAM board](https://github.com/orgs/sourcegraph/projects/259/views/22)
-* Answer:
-  * What's in the backlog? Something missing?
-  * What's estimated? What's not estimated?
-* Go through top N of unestimated tickets that Product thinks we will work on next
+- Open the [IAM board](https://github.com/orgs/sourcegraph/projects/259/views/22)
+- Answer:
+  - What's in the backlog? Something missing?
+  - What's estimated? What's not estimated?
+- Go through top N of unestimated tickets that Product thinks we will work on next
 
 ### Planning
 
@@ -130,24 +131,24 @@ See the [IAM planning doc](https://docs.google.com/document/d/1PPnQTdWHk3Rhq_ZQe
 
 A good planning meeting should answer the following questions:
 
-* **Bookkeeping**:
-  * What's the availability of everybody for the next 2 weeks?
-  * Is there a release happening? If so, when?
-  * Any other special events? (kickoff meetings, meetups, …)
-  * Who's on Support?
-* **Leftover work**:
-  * Are there things left-over from the last iteration? If so, why?
-* **Planning next 2 weeks**
-  * **Step 1: gather input**:
-    * What does Product need us to do in the next 2 weeks?
-      * _Ideally_ these requests are prioritized and “ready to be implemented”
-    * Are there any customer issues we need to work on?
-    * Other requests from outside?
-  * **Step 2: plan**:
-    * What do we want to work on?
-      * Go through each person, define what they'll work on, what they commit do
-      * Check if it matches their availability
-* What will we demo at the end of the iteration?
+- **Bookkeeping**:
+  - What's the availability of everybody for the next 2 weeks?
+  - Is there a release happening? If so, when?
+  - Any other special events? (kickoff meetings, meetups, …)
+  - Who's on Support?
+- **Leftover work**:
+  - Are there things left-over from the last iteration? If so, why?
+- **Planning next 2 weeks**
+  - **Step 1: gather input**:
+    - What does Product need us to do in the next 2 weeks?
+      - _Ideally_ these requests are prioritized and “ready to be implemented”
+    - Are there any customer issues we need to work on?
+    - Other requests from outside?
+  - **Step 2: plan**:
+    - What do we want to work on?
+      - Go through each person, define what they'll work on, what they commit do
+      - Check if it matches their availability
+- What will we demo at the end of the iteration?
 
 ## Contact
 

--- a/content/departments/engineering/teams/iam/index.md
+++ b/content/departments/engineering/teams/iam/index.md
@@ -107,14 +107,14 @@ The agenda for the retrospective is this:
 
 ### Grooming
 
-**Goal**: The goal for the grooming session is to as many items in our backlog
+**Goal**: The goal for the grooming session is to get as many items in our backlog
 _prioritized_ and _estimated_. We estimate together enough tickets so that we’re
 all on the same page on how to implement something and how long it will take, so
-that we can plan it in future sprint
+that we can plan it in future sprint.
 
 Requirements for the meeting:
 
-- DRI for a project prepares by creating tickets as much as possible
+- DRI for a project prepares by creating as many tickets as possible
 - Product comes in with requirements from customers and tickets
 
 Agenda for the grooming meeeting:
@@ -146,7 +146,7 @@ A good planning meeting should answer the following questions:
     - Other requests from outside?
   - **Step 2: plan**:
     - What do we want to work on?
-      - Go through each person, define what they'll work on, what they commit do
+      - Go through each person, define what they'll work on, what they commit to do
       - Check if it matches their availability
 - What will we demo at the end of the iteration?
 

--- a/content/departments/engineering/teams/iam/index.md
+++ b/content/departments/engineering/teams/iam/index.md
@@ -62,26 +62,101 @@ The IAM team works alongside several other teams at Sourcegraph. You can find mo
 
 ## How we work
 
+We work in 2 week cycles.
+
+*Week 1*
+
+| Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------|---------|-----------|-----------|-------|
+|  | 45min Retrospective | | | |
+|  | 45min Planning | | | |
+|  | Company meeting | | | |
+|  30min sync | Demo Day | 30min sync | 30min sync | |
+
+*Week 2*
+
+| Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------|---------|-----------|-----------|-------|
+| 30min sync + check what's in estimation queue  | 30min sync | 60min Grooming  | 30min sync | |
+
+### Important documents and links
+
+- [IAM board](https://github.com/orgs/sourcegraph/projects/259/views/22)
+- [IAM retrospective](https://docs.google.com/document/d/10Gr8gBVtq939E-v0UKPp_IvAXuyr35qWQYS-uDt7N9I/edit)
+- [IAM planning doc](https://docs.google.com/document/d/1PPnQTdWHk3Rhq_ZQe8Qe-X82BttPaumeJDZWXPbiQPY/edit)
+
+### Retrospective
+
+**Goal**: continuously improve how we work. We do that by using the retrospective to look back at the past 2 weeks. What we want to find out is what went well, what didn't go well, and how we can improve.
+
+The agenda for the retrospective is this:
+
+* *10min*: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/10Gr8gBVtq939E-v0UKPp_IvAXuyr35qWQYS-uDt7N9I/edit)
+  * What went well?
+  * What could have gone better?
+  * Do you feel supported?
+  * Do you feel like you’re moving into the right direction of your team?
+  * What processes/other things should we revisit/refine/propose?
+  * Other thoughts/questions?
+* *5min*: celebrate what went well (read out all items)
+* *2min*: vote on items
+* *28min*: talk through items, start with the highest votes
+  * 5min per item, use a timer, be strict
+  * Once 5min are up: ask if 2 more minutes
+  * If possible: collect action items
+
+### Grooming
+
+**Goal**: The goal for the grooming session is to as many items in our backlog
+*prioritized* and *estimated*. We estimate together enough tickets so that we’re
+all on the same page on how to implement something and how long it will take, so
+that we can plan it in future sprint
+
+Requirements for the meeting:
+* DRI for a project prepares by creating tickets as much as possible
+* Product comes in with requirements from customers and tickets
+
+Agenda for the grooming meeeting:
+
+* Open the [IAM board](https://github.com/orgs/sourcegraph/projects/259/views/22)
+* Answer:
+  * What's in the backlog? Something missing?
+  * What's estimated? What's not estimated?
+* Go through top N of unestimated tickets that Product thinks we will work on next
+
+### Planning
+
+See the [IAM planning doc](https://docs.google.com/document/d/1PPnQTdWHk3Rhq_ZQe8Qe-X82BttPaumeJDZWXPbiQPY/edit) for the specific agenda we use in each planning meeting.
+
+A good planning meeting should answer the following questions:
+
+* **Bookkeeping**:
+  * What's the availability of everybody for the next 2 weeks?
+  * Is there a release happening? If so, when?
+  * Any other special events? (kickoff meetings, meetups, …)
+  * Who's on Support?
+* **Leftover work**:
+  * Are there things left-over from the last iteration? If so, why?
+* **Planning next 2 weeks**
+  * **Step 1: gather input**:
+    * What does Product need us to do in the next 2 weeks?
+      * _Ideally_ these requests are prioritized and “ready to be implemented”
+    * Are there any customer issues we need to work on?
+    * Other requests from outside?
+  * **Step 2: plan**:
+    * What do we want to work on?
+      * Go through each person, define what they'll work on, what they commit do
+      * Check if it matches their availability
+* What will we demo at the end of the iteration?
+
+## Contact
+
 ### How to contact the team and ask for help
 
 - For users with urgent help requests reach out to our support team at [support@sourcegraph.com](mailto:support@sourcegraph.com).
 - For emergencies and incidents, alert the team using Slack command `/genie alert [message] for iam`.
 - For internal Sourcegraph teammates, join us in #iam to ask questions or request help from our team, or ask `@iam-support` directly.
 - For feature requests, please reach out to our product manager, Ryan, at [ryphil@sourcegraph.com](mailto:ryphil@sourcegraph.com) and include `IAM Feature Request:` in your subject line.
-
-### Planning, execution, and issue tracking
-
-The IAM team plans work based on our [long-term roadmap](https://docs.google.com/document/d/1XNrbBtkS8_lsjKxV8zvNfb1sn1Ug9Zhc24LFLCOa-Ic/edit?usp=sharing) and setting [quarterly goals](#goals-and-roadmap). During the quarter, we follow a flavor of the SCRUM process with biweekly sprints. Our cycle starts every second Tuesday with a retrospective, sprint review, and planning meetings. We set goals for each sprint and focus team efforts during the iteration on achieving these goals rather than closing a number of issues. It’s the outcomes and delivered customer value, not the output, that matters.
-
-We are using [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects) as our project tracking tool. The [list view of backlog](https://github.com/orgs/sourcegraph/projects/259/views/10) is publicly available in our team project.
-
-#### How we use GitHub Projects
-
-- The GitHub project for the team is the single source of truth for our backlog. Please use descriptions, comments under GitHub issues, and different categorization options to keep all the issues up to date. Comments are also the best place for asking questions about the issue itself. That way, we keep all the context in a single place.
-- We use GitHub milestones (usually connected with the quarterly goals) and custom fields to group issues for given initiatives/projects into epics, and to track different service or engineering ownership areas. This for example, helps us understand what the cost of operations with each area we own is.
-- We use [keyword or manually](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) linking pull requests to issues automatically in GitHub.
-- We use [planning poker in ZenHub](https://help.zenhub.com/support/solutions/articles/43000620555-planning-poker-in-zenhub) for [groomings and estimation sessions which we run asynchronously](#groomings).
-- You can paste a link to GitHub in any Slack messages to have a rendered attachment automatically.
 
 ### User research
 

--- a/content/departments/engineering/teams/repo-management/processes.md
+++ b/content/departments/engineering/teams/repo-management/processes.md
@@ -94,7 +94,7 @@ The agenda for the retrospective is this:
 **Goal**: The goal for the grooming session is to get as many items in our backlog
 _prioritized_ and _estimated_. We estimate together enough tickets so that we’re
 all on the same page on how to implement something and how long it will take, so
-that we can plan it in future sprint
+that we can plan it in future sprint.
 
 Requirements for the meeting:
 

--- a/content/departments/engineering/teams/repo-management/processes.md
+++ b/content/departments/engineering/teams/repo-management/processes.md
@@ -45,23 +45,23 @@ More involved support requests follow the below process:
 
 We work in 2 week cycles.
 
-*Week 1*
+_Week 1_
+
+| Monday              | Tuesday         | Wednesday | Thursday | Friday |
+| ------------------- | --------------- | --------- | -------- | ------ |
+| 45min Retrospective |                 |           |          |        |
+| 45min Grooming      |                 |           |          |        |
+| 45min Planning      | Company meeting |           |          |        |
+|                     | Demo Day        |           |          |        |
+
+_Week 2_
 
 | Monday | Tuesday | Wednesday | Thursday | Friday |
-|--------|---------|-----------|-----------|-------|
-| 45min Retrospective | | | | |
-| 45min Grooming | | | | |
-| 45min Planning | Company meeting | | | |
-|                | Demo Day | | | |
-
-*Week 2*
-
-| Monday | Tuesday | Wednesday | Thursday | Friday |
-|--------|---------|-----------|-----------|-------|
-|  | | | | |
-|  | | | | |
-|  | | | | |
-|  | | | | |
+| ------ | ------- | --------- | -------- | ------ |
+|        |         |           |          |        |
+|        |         |           |          |        |
+|        |         |           |          |        |
+|        |         |           |          |        |
 
 ### Important documents and links
 
@@ -75,38 +75,39 @@ We work in 2 week cycles.
 
 The agenda for the retrospective is this:
 
-* *10min*: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/1i44vugdH8hRvb3Uc3KSlmCbzbdI1_X5todyg4dQRdpk/edit)
-  * What went well?
-  * What could have gone better?
-  * Do you feel supported?
-  * Do you feel like you’re moving into the right direction of your team?
-  * What processes/other things should we revisit/refine/propose?
-  * Other thoughts/questions?
-* *5min*: celebrate what went well (read out all items)
-* *2min*: vote on items
-* *28min*: talk through items, start with the highest votes
-  * 5min per item, use a timer, be strict
-  * Once 5min are up: ask if 2 more minutes
-  * If possible: collect action items
+- _10min_: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/1i44vugdH8hRvb3Uc3KSlmCbzbdI1_X5todyg4dQRdpk/edit)
+  - What went well?
+  - What could have gone better?
+  - Do you feel supported?
+  - Do you feel like you’re moving into the right direction of your team?
+  - What processes/other things should we revisit/refine/propose?
+  - Other thoughts/questions?
+- _5min_: celebrate what went well (read out all items)
+- _2min_: vote on items
+- _28min_: talk through items, start with the highest votes
+  - 5min per item, use a timer, be strict
+  - Once 5min are up: ask if 2 more minutes
+  - If possible: collect action items
 
 ### Grooming
 
 **Goal**: The goal for the grooming session is to as many items in our backlog
-*prioritized* and *estimated*. We estimate together enough tickets so that we’re
+_prioritized_ and _estimated_. We estimate together enough tickets so that we’re
 all on the same page on how to implement something and how long it will take, so
 that we can plan it in future sprint
 
 Requirements for the meeting:
-* DRI for a project prepares by creating tickets as much as possible
-* Product comes in with requirements from customers and tickets
+
+- DRI for a project prepares by creating tickets as much as possible
+- Product comes in with requirements from customers and tickets
 
 Agenda for the grooming meeeting:
 
-* Open the [repo-management board](https://github.com/orgs/sourcegraph/projects/209/views/1)
-* Answer:
-  * What's in the backlog? Something missing?
-  * What's estimated? What's not estimated?
-* Go through top N of unestimated tickets that Product thinks we will work on next
+- Open the [repo-management board](https://github.com/orgs/sourcegraph/projects/209/views/1)
+- Answer:
+  - What's in the backlog? Something missing?
+  - What's estimated? What's not estimated?
+- Go through top N of unestimated tickets that Product thinks we will work on next
 
 ### Planning
 
@@ -114,24 +115,24 @@ See the [repo-management planning doc](https://docs.google.com/document/d/1DI2Ul
 
 A good planning meeting should answer the following questions:
 
-* **Bookkeeping**:
-  * What's the availability of everybody for the next 2 weeks?
-  * Is there a release happening? If so, when?
-  * Any other special events? (kickoff meetings, meetups, …)
-  * Who's on Support?
-* **Leftover work**:
-  * Are there things left-over from the last iteration? If so, why?
-* **Planning next 2 weeks**
-  * **Step 1: gather input**:
-    * What does Product need us to do in the next 2 weeks?
-      * _Ideally_ these requests are prioritized and “ready to be implemented”
-    * Are there any customer issues we need to work on?
-    * Other requests from outside?
-  * **Step 2: plan**:
-    * What do we want to work on?
-      * Go through each person, define what they'll work on, what they commit do
-      * Check if it matches their availability
-* What will we demo at the end of the iteration?
+- **Bookkeeping**:
+  - What's the availability of everybody for the next 2 weeks?
+  - Is there a release happening? If so, when?
+  - Any other special events? (kickoff meetings, meetups, …)
+  - Who's on Support?
+- **Leftover work**:
+  - Are there things left-over from the last iteration? If so, why?
+- **Planning next 2 weeks**
+  - **Step 1: gather input**:
+    - What does Product need us to do in the next 2 weeks?
+      - _Ideally_ these requests are prioritized and “ready to be implemented”
+    - Are there any customer issues we need to work on?
+    - Other requests from outside?
+  - **Step 2: plan**:
+    - What do we want to work on?
+      - Go through each person, define what they'll work on, what they commit do
+      - Check if it matches their availability
+- What will we demo at the end of the iteration?
 
 ### How we structure our work
 

--- a/content/departments/engineering/teams/repo-management/processes.md
+++ b/content/departments/engineering/teams/repo-management/processes.md
@@ -43,24 +43,95 @@ More involved support requests follow the below process:
 
 ## How we work
 
-We're currently working in a Kanban style. It suits the fact that support work often cannot wait for a new sprint, and so the idea of being able to plan what we be delivered in any period of time is unreliable.
+We work in 2 week cycles.
 
-Kanban means we maintain a backlog of work we want to complete, prioritized in such a way that the team picks up the next highest priority thing.
+*Week 1*
 
-This allows us to be flexible about what's up next, but still protect the sanctity of concentration and focus by avoiding (as much as we can) in-flight work from being dropped in favor of something else.
+| Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------|---------|-----------|-----------|-------|
+| 45min Retrospective | | | | |
+| 45min Grooming | | | | |
+| 45min Planning | Company meeting | | | |
+|                | Demo Day | | | |
 
-For larger pieces of work we utilise [tracking issues](../../dev/process/tracking_issues.md), for [example](https://github.com/sourcegraph/sourcegraph/issues/27916).
+*Week 2*
 
-We work in 2 week cycles, and have the following ceremonies:
+| Monday | Tuesday | Wednesday | Thursday | Friday |
+|--------|---------|-----------|-----------|-------|
+|  | | | | |
+|  | | | | |
+|  | | | | |
+|  | | | | |
 
-1. Planning (biweekly)
-   - This is more of a "line up a queue of work in priority" exercise than it would be with sprints
-   - By default, we make no time-based commitments, instead favouring a balance of strategic (long term) and tactical (short term repsonsive) work
-   - This does not (and isn't intended to) prevent newly identified work from superceding what gets "planned"
-2. Sync (biweekly)
-   - This happens on the weeks we don't have planning, and is a check in on the plans and anything new
-3. Retro (biweekly)
-   - A review of what we did for learing purposes
+### Important documents and links
+
+- [repo-management board](https://github.com/orgs/sourcegraph/projects/209/views/1)
+- [repo-management retrospective](https://docs.google.com/document/d/1i44vugdH8hRvb3Uc3KSlmCbzbdI1_X5todyg4dQRdpk/edit)
+- [repo-management planning doc](https://docs.google.com/document/d/1DI2Ul6tCNNoXi9dq10DlLj1XE5v3bb_mBH5Xhq7f9xQ/edit#heading=h.sjawbxxomzzj)
+
+### Retrospective
+
+**Goal**: continuously improve how we work. We do that by using the retrospective to look back at the past 2 weeks. What we want to find out is what went well, what didn't go well, and how we can improve.
+
+The agenda for the retrospective is this:
+
+* *10min*: fill out the prompts in [this Google Doc](https://docs.google.com/document/d/1i44vugdH8hRvb3Uc3KSlmCbzbdI1_X5todyg4dQRdpk/edit)
+  * What went well?
+  * What could have gone better?
+  * Do you feel supported?
+  * Do you feel like you’re moving into the right direction of your team?
+  * What processes/other things should we revisit/refine/propose?
+  * Other thoughts/questions?
+* *5min*: celebrate what went well (read out all items)
+* *2min*: vote on items
+* *28min*: talk through items, start with the highest votes
+  * 5min per item, use a timer, be strict
+  * Once 5min are up: ask if 2 more minutes
+  * If possible: collect action items
+
+### Grooming
+
+**Goal**: The goal for the grooming session is to as many items in our backlog
+*prioritized* and *estimated*. We estimate together enough tickets so that we’re
+all on the same page on how to implement something and how long it will take, so
+that we can plan it in future sprint
+
+Requirements for the meeting:
+* DRI for a project prepares by creating tickets as much as possible
+* Product comes in with requirements from customers and tickets
+
+Agenda for the grooming meeeting:
+
+* Open the [repo-management board](https://github.com/orgs/sourcegraph/projects/209/views/1)
+* Answer:
+  * What's in the backlog? Something missing?
+  * What's estimated? What's not estimated?
+* Go through top N of unestimated tickets that Product thinks we will work on next
+
+### Planning
+
+See the [repo-management planning doc](https://docs.google.com/document/d/1DI2Ul6tCNNoXi9dq10DlLj1XE5v3bb_mBH5Xhq7f9xQ/edit#heading=h.sjawbxxomzzj) for the specific agenda we use in each planning meeting.
+
+A good planning meeting should answer the following questions:
+
+* **Bookkeeping**:
+  * What's the availability of everybody for the next 2 weeks?
+  * Is there a release happening? If so, when?
+  * Any other special events? (kickoff meetings, meetups, …)
+  * Who's on Support?
+* **Leftover work**:
+  * Are there things left-over from the last iteration? If so, why?
+* **Planning next 2 weeks**
+  * **Step 1: gather input**:
+    * What does Product need us to do in the next 2 weeks?
+      * _Ideally_ these requests are prioritized and “ready to be implemented”
+    * Are there any customer issues we need to work on?
+    * Other requests from outside?
+  * **Step 2: plan**:
+    * What do we want to work on?
+      * Go through each person, define what they'll work on, what they commit do
+      * Check if it matches their availability
+* What will we demo at the end of the iteration?
 
 ### How we structure our work
 

--- a/content/departments/engineering/teams/repo-management/processes.md
+++ b/content/departments/engineering/teams/repo-management/processes.md
@@ -91,14 +91,14 @@ The agenda for the retrospective is this:
 
 ### Grooming
 
-**Goal**: The goal for the grooming session is to as many items in our backlog
+**Goal**: The goal for the grooming session is to get as many items in our backlog
 _prioritized_ and _estimated_. We estimate together enough tickets so that we’re
 all on the same page on how to implement something and how long it will take, so
 that we can plan it in future sprint
 
 Requirements for the meeting:
 
-- DRI for a project prepares by creating tickets as much as possible
+- DRI for a project prepares by creating as many tickets as possible
 - Product comes in with requirements from customers and tickets
 
 Agenda for the grooming meeeting:
@@ -130,7 +130,7 @@ A good planning meeting should answer the following questions:
     - Other requests from outside?
   - **Step 2: plan**:
     - What do we want to work on?
-      - Go through each person, define what they'll work on, what they commit do
+      - Go through each person, define what they'll work on, what they commit to do
       - Check if it matches their availability
 - What will we demo at the end of the iteration?
 


### PR DESCRIPTION
This documents the new grooming, retro, and planning processes for both teams.

This is the bare minimum. I expect us to change it in the future, which is also why it's duplicated between both teams. I expect each team to tune the processes to their requirements.