### PR TITLE
Update free tier changeset limit for batch changes

### DIFF
--- a/content/departments/engineering/teams/batch-changes/go-to-market/index.md
+++ b/content/departments/engineering/teams/batch-changes/go-to-market/index.md
@@ -3,7 +3,7 @@
 ## Overview
 
 - **Product name:** Batch Changes (formerly known as Campaigns)
-- **Access and pricing:** Paid add-on for Enterprise customers; all customers can try the product (limit: 5 changesets)
+- **Access and pricing:** Paid add-on for Enterprise customers; all customers can try the product (limit: 10 changesets)
 
 ## Positioning and Use Cases
 


### PR DESCRIPTION
The limit for changesets created by Batch Changes on unlicensed instances has been increased from 5 to 10. This reflects that.