### PR TITLE
managed smtp: update instance handoff, note that managed SMTP is enabled by default

### DIFF
--- a/content/departments/cloud/technical-docs/managed-smtp/index.md
+++ b/content/departments/cloud/technical-docs/managed-smtp/index.md
@@ -1,9 +1,9 @@
 # Managed SMTP
 
-> NOTE: **Managed SMTP is currently an opt-in feature**, and is undergoing a gradual rollout. For more details, refer to [RFC 705](https://docs.google.com/document/d/1eaShaXlpMEezawuwTZ26nuo5g_1MjQmjpp8VvQTokzw/edit) and [the tracking issue](https://github.com/sourcegraph/customer/issues/1408). The goal is to eventually provide managed SMTP to all instances by default.
-
-Managed SMTP allows Sourcegraph Cloud instances to have email delivery services configured out-of-the-box.
+Managed SMTP allows Sourcegraph Cloud instances to have email delivery services configured out-of-the-box, and is enabled on all Sourcegraph Cloud instances by default.
 SMTP services are currently backed by [SparkPost EU](https://app.eu.sparkpost.com).
+
+Customer-facing documentation is available [here](https://docs.sourcegraph.com/cloud#managed-smtp).
 
 In this document:
 

--- a/content/departments/cloud/technical-docs/v1.1/mi1-1_creation_process.md
+++ b/content/departments/cloud/technical-docs/v1.1/mi1-1_creation_process.md
@@ -61,21 +61,30 @@ Customisation is done via:
 
 ### Giving customer access
 
-> NOTE: You can skip this step if the instance is pre-created for the PLG pool
+An automatic password reset email is always sent out for customers:
 
-Generate password reset link for customer:
+1. For standard instances, [managed SMTP](../managed-smtp/index.md) will be configured before a user is created. When the user is created, they will receive an email from the instance to reset their password.
+1. For PLG pre-provisioned instances, currently a custom welcome email is sent with the password reset URL. [Managed SMTP](../managed-smtp/index.md) is only configured after the user is created.
+
+The customer admin can use the delivered password reset link to configure access for themselves.
+
+#cloud usually hands off to CE at this point, they will schedule a call with the customer (including a DevOps team member, if needed) to walk the site admin on the customer's side through performing initial setup of the product including adding the license key, adding repos, configuring SSO, and inviting users. Please notify the CE requested the instance has been created with the following message.
+
+```sh
+Hi,
+
+The instance is ready. The customer admin should have received an email to reset their password.
+```
+
+#### Manual password reset
+
+If the customer takes too long to reset their password, or if they fail to receive the automated email for whatever reason, a manual password reset is required:
 
 ```bash
 mi reset-customer-password --email <customer admin email>
 ```
 
-#cloud usually hands off to CE at this point, they will schedule a call with the customer (including a DevOps team member, if needed) to walk the site admin on the customer's side through performing initial setup of the product including adding the license key, adding repos, configuring SSO, and inviting users. Please notify the CE requested the instance has been created with the following message.
-
-```
-Hi,
-
-The instance is ready. The customer admin should have received an email to reset their password.
-```
+This should generate a link to the password and also send it via email if [managed SMTP](../managed-smtp/index.md) is enabled.
 
 ### Optional: enable "private" mode
 


### PR DESCRIPTION
1. Document how password reset links are sent
2. Update managed SMTP page to note that it is enabled on all instances by default