### PR TITLE
scale-testing: add a section covering the internals

### DIFF
--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -350,7 +350,7 @@ This section covers where to find the code behind the ScaleTesting initiative.
 
 While not implemented at this stage, creating a runner is very similar to how the end-to-end test runner is working on the main repo, you set up your client and reach the instance to perform your requests.
 
-There are a few various approaches, depending on what you want to test:
+Depending on what you want to test, there are a few approaches you can take:
 
 - You could simply work at the API level, by creating a GraphQL client
   - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/codeintel-qa).

--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -337,3 +337,22 @@ A small tool named [Synthforce](https://github.com/sourcegraph/synthforce) has b
 The following repositories are available to test against repositories with a massive amount of commits:
 
 - `https://gitlab.sgdev.org/sgtest/megarepo1` (>700k commits)
+
+## Scaletesting internals
+
+This section covers where to find the code behind the ScaleTesting initiative. 
+
+- [Deployments](https://github.com/sourcegraph/deploy-sourcegraph-scaletesting)
+- [Tools](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/scaletesting) 
+- [Scratch Logs](https://sourcegraph.com/github.com/sourcegraph/devx-scratch/-/blob/2022/scaletesting/log.snb.md) 
+
+### Creating a scenario runner
+
+While not implemented at this stage, creating a runner is very similar to how the end-to-end test runner is working on the main repo, you set up your client and reach the instance to perform your requests. 
+
+There are a few various approaches, depending on what you want to test: 
+
+- You could simply work at the API level, by creating a GraphQL client 
+  - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/codeintel-qa).
+- You can work at the browser level, by mimicking what we do in smoke-tests and end-to-end tests. 
+  - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/smoke-tests) and [example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-cloud/-/blob/smoke-tests/run-infra.sh) 

--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -340,19 +340,19 @@ The following repositories are available to test against repositories with a mas
 
 ## Scaletesting internals
 
-This section covers where to find the code behind the ScaleTesting initiative. 
+This section covers where to find the code behind the ScaleTesting initiative.
 
 - [Deployments](https://github.com/sourcegraph/deploy-sourcegraph-scaletesting)
-- [Tools](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/scaletesting) 
-- [Scratch Logs](https://sourcegraph.com/github.com/sourcegraph/devx-scratch/-/blob/2022/scaletesting/log.snb.md) 
+- [Tools](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/scaletesting)
+- [Scratch Logs](https://sourcegraph.com/github.com/sourcegraph/devx-scratch/-/blob/2022/scaletesting/log.snb.md)
 
 ### Creating a scenario runner
 
-While not implemented at this stage, creating a runner is very similar to how the end-to-end test runner is working on the main repo, you set up your client and reach the instance to perform your requests. 
+While not implemented at this stage, creating a runner is very similar to how the end-to-end test runner is working on the main repo, you set up your client and reach the instance to perform your requests.
 
-There are a few various approaches, depending on what you want to test: 
+There are a few various approaches, depending on what you want to test:
 
-- You could simply work at the API level, by creating a GraphQL client 
+- You could simply work at the API level, by creating a GraphQL client
   - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/codeintel-qa).
-- You can work at the browser level, by mimicking what we do in smoke-tests and end-to-end tests. 
-  - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/smoke-tests) and [example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-cloud/-/blob/smoke-tests/run-infra.sh) 
+- You can work at the browser level, by mimicking what we do in smoke-tests and end-to-end tests.
+  - [Example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/smoke-tests) and [example](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph-cloud/-/blob/smoke-tests/run-infra.sh)


### PR DESCRIPTION
Adds some docs and pointers about the internal so that others working with this code during the job-fair have a starting point. 

cc @chwarwick, @Piszmog 