### PR TITLE
Updated some of the wording and reasoning

### DIFF
--- a/content/departments/people-talent/email-changes.md
+++ b/content/departments/people-talent/email-changes.md
@@ -6,16 +6,22 @@ The Tech Ops team is responsible for creating and managing teammate emails. This
 
 Prior to a new teammate's first day at Sourcegraph, the Tech Ops team will create their email address using this standard naming convention: _PreferredFirstName.PreferredSurname@sourcegraph.com_.
 
-Emails are typically created on the Wednesday before a new hire's start date. This email will be used to create the new Okta user, which allows access to all of our tools/systems.
+Emails are typically created on the Wednesday before a new hire's start date. This email will be used to create the new Okta user, which allows access to all of our tools/systems. 
 
 ### Reasons to change an email
 
-There are ocassionally times that a teammate needs to change their email. Typically, this happens when:
+There are occasionally times that a teammate needs to change their email after it has been created. This is not an easy change to make because it requires manually changing user information in all applications where the email is used. Therefore, reasons for changing an email are limited. Typically, this happens when:
 
-- A teammate gets married and/or changes their last name
-- A teammate changes their first name
+- A teammate legally changes their first or last name
+- A teammate needs to change their email for security reasons 
+
+### Reasons to request an email alias be created
+
+An alias is an alternative Sourcegraph email address that you can use for sending and receiving emails. This is an easy processes as long as the name is available. Having an email alias created will not change your username for accessing other systems we use including Okta, Slack, etc. Typically, an email alias is created for a teammate when:
+
 - The first or last name of a teammate is longer than average and/or has a difficult spelling
+- You have a nickname that you would like to use
 
-### How to request a change to your email
+### How to request a change to your email or have an alias created
 
 If you'd like to request a change to your email, please fill out this [Google form](https://docs.google.com/forms/d/e/1FAIpQLSezBf7e0GSSyFajWvYEjsiVGrE6GrEzgoQC3B5A2bGqugAqCg/viewform?usp=sf_link). Tech Ops will review the request and reach out to you via Slack with more information about whether the request has been approved.

--- a/content/departments/people-talent/email-changes.md
+++ b/content/departments/people-talent/email-changes.md
@@ -6,14 +6,14 @@ The Tech Ops team is responsible for creating and managing teammate emails. This
 
 Prior to a new teammate's first day at Sourcegraph, the Tech Ops team will create their email address using this standard naming convention: _PreferredFirstName.PreferredSurname@sourcegraph.com_.
 
-Emails are typically created on the Wednesday before a new hire's start date. This email will be used to create the new Okta user, which allows access to all of our tools/systems. 
+Emails are typically created on the Wednesday before a new hire's start date. This email will be used to create the new Okta user, which allows access to all of our tools/systems.
 
 ### Reasons to change an email
 
 There are occasionally times that a teammate needs to change their email after it has been created. This is not an easy change to make because it requires manually changing user information in all applications where the email is used. Therefore, reasons for changing an email are limited. Typically, this happens when:
 
 - A teammate legally changes their first or last name
-- A teammate needs to change their email for security reasons 
+- A teammate needs to change their email for security reasons
 
 ### Reasons to request an email alias be created
 


### PR DESCRIPTION
I wanted to make it clear that we will not do email changes unless there is a very good reason for doing so however requesting an alias is far simpler