### PR TITLE
Hide sub-navigation on mobile to stop screen flickering while scrolling

### DIFF
--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -66,8 +66,14 @@
     > li > ul {
         padding-left: 0;
 
-        ul:not(.active) {
+        ul {
             display: none;
+            
+            @media (min-width: 900px) {
+                &.active {
+                    display: block;
+                }
+            }
         }
     }
 

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -68,7 +68,6 @@
 
         ul {
             display: none;
-            
             @media (min-width: 900px) {
                 &.active {
                     display: block;


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/handbook/issues/3666

The sidebar appears above the content on screen sizes below 900px wide.

As we scroll down the page, sub-menus in the sidebar become active.

This pushes content down which deactivates the sub-menu, causing a loop.

An alternative solution would be to always display sub-navigation on screens below 900px, but this pushes content way down pages with many nav items, which is probably not ideal.