### PR TITLE
Update dogfood links

### DIFF
--- a/content/departments/technical-success/support/process/p4-enablement.md
+++ b/content/departments/technical-success/support/process/p4-enablement.md
@@ -1,6 +1,6 @@
 # Dogfood Perforce server
 
-Perforce is a version control system like Git, subversion, or mercurial. While git is based on a distributed, decentralised model, Perforce is centralised. For testing purposes, you may use our [Perforce dogfood server](https://k8s.sgdev.org/github.com/sourcegraph/infrastructure/-/tree/dogfood/kubernetes/tooling/perforce).
+Perforce is a version control system like Git, subversion, or mercurial. While git is based on a distributed, decentralised model, Perforce is centralised. For testing purposes, you may use our [Perforce dogfood server](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/infrastructure/-/tree/dogfood/kubernetes/tooling/perforce).
 
 ## Setting up
 


### PR DESCRIPTION
Change k8s link to S2 link because [k8s is no longer the primary dogfooding instance](https://handbook.sourcegraph.com/departments/engineering/dev/process/deployments/instances/#k8ssgdevorg)