### PR TITLE
Moved stevey to bottom of team.yml

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -11,17 +11,6 @@ quinn_slack:
   links: '[slack.org](https://slack.org), [@sqs](https://twitter.com/sqs), [LinkedIn](https://www.linkedin.com/in/quinnslack)'
   description: 'Quinn loves programming and wants to make it so everyone can code. Prior to Sourcegraph, he co-founded [Blend](https://blend.com/) (IPO in 2021), wrote code inside the top 2 US banks at Palantir, studied Computer Science at Stanford, built TLS password auth for curl and other open-source projects, and was the first employee and engineer at Bleacher Report.'
 
-steve_yegge:
-  name: Steve Yegge
-  reports_to: ceo
-  role: Head of Engineering
-  manager_role_slug: eng_lead
-  hide_on_team_page: true
-  github: steveyegge
-  pronouns: he/him
-  links: '[@Steve_Yegge](https://twitter.com/Steve_Yegge), [LinkedIn](https://www.linkedin.com/in/steveyegge), [Medium](https://steve-yegge.medium.com/), [blogs](https://sites.google.com/site/steveyegge2/blog-rants?pli=1), [definitions](https://www.urbandictionary.com/define.php?term=Yegge)'
-  description: 'Steve joined Sourcegraph in 2020 and wants to make it so everyone can play ukulele, though for now we are focusing on coding skills. Steve plays guitar, piano, and uke, as does his shih tzu, Mozart. Steve lives in Kirkland, Washington, voted #3 nicest city in the US for no particularly good reason. When is not coding, Steve loves spending time with his lovely wife Linh, binging horror series and kdramas.'
-
 interim_marketing_lead:
   name: Quinn Slack
   reports_to: ceo
@@ -2151,3 +2140,15 @@ James Ghaedi:
   email: james.ghaedi@sourcegraph.com
   role: Account Executive, EMEA
   reports_to: regional_director_sales_emea
+ 
+steve_yegge:
+  name: Steve Yegge
+  reports_to: ceo
+  role: Head of Engineering
+  manager_role_slug: eng_lead
+  hide_on_team_page: true
+  github: steveyegge
+  pronouns: he/him
+  links: '[@Steve_Yegge](https://twitter.com/Steve_Yegge), [LinkedIn](https://www.linkedin.com/in/steveyegge), [Medium](https://steve-yegge.medium.com/), [blogs](https://sites.google.com/site/steveyegge2/blog-rants?pli=1), [definitions](https://www.urbandictionary.com/define.php?term=Yegge)'
+  description: 'Steve joined Sourcegraph in 2020 and wants to make it so everyone can play ukulele, though for now we are focusing on coding skills. Steve plays guitar, piano, and uke, as does his shih tzu, Mozart. Steve lives in Kirkland, Washington, voted #3 nicest city in the US for no particularly good reason. When is not coding, Steve loves spending time with his lovely wife Linh, binging horror series and kdramas.'
+

--- a/data/team.yml
+++ b/data/team.yml
@@ -2140,7 +2140,7 @@ James Ghaedi:
   email: james.ghaedi@sourcegraph.com
   role: Account Executive, EMEA
   reports_to: regional_director_sales_emea
- 
+
 steve_yegge:
   name: Steve Yegge
   reports_to: ceo
@@ -2151,4 +2151,3 @@ steve_yegge:
   pronouns: he/him
   links: '[@Steve_Yegge](https://twitter.com/Steve_Yegge), [LinkedIn](https://www.linkedin.com/in/steveyegge), [Medium](https://steve-yegge.medium.com/), [blogs](https://sites.google.com/site/steveyegge2/blog-rants?pli=1), [definitions](https://www.urbandictionary.com/define.php?term=Yegge)'
   description: 'Steve joined Sourcegraph in 2020 and wants to make it so everyone can play ukulele, though for now we are focusing on coding skills. Steve plays guitar, piano, and uke, as does his shih tzu, Mozart. Steve lives in Kirkland, Washington, voted #3 nicest city in the US for no particularly good reason. When is not coding, Steve loves spending time with his lovely wife Linh, binging horror series and kdramas.'
-


### PR DESCRIPTION
This is an attempt to get me to show up in the handbook team page. Not sure why I was at the top before in the yaml file, but it was invisible in the rendered output in any case.