### PR TITLE
Add handbook homepage cards

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -10,35 +10,35 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
 <div class="blocks">
   <a href="company-info-and-process/about-sourcegraph/index.md" class="block">
-    <img src="/static/icons/about.svg">
+    <img src="static/icons/about.svg">
     About Sourcegraph
   </a>
   <a href="strategy-goals/strategy/index.md" class="block">
-    <img src="/static/icons/strategy.svg">
+    <img src="static/icons/strategy.svg">
     Strategy
   </a>
   <a href="departments/index.md" class="block">
-    <img src="/static/icons/departments.svg">
+    <img src="static/icons/departments.svg">
     Departments
   </a>
   <a href="https://docs.google.com/document/d/1WqyffCTaPKp9G1kpPFryEi2eiPZzwfF7Gmo2mAjSq40/edit#heading=h.kso9gsaecr0b" class="block">
-    <img src="/static/icons/the-git-down.svg">
+    <img src="static/icons/the-git-down.svg">
     The Git Down
   </a>
   <a href="team/index.md" class="block">
-    <img src="/static/icons/bios.svg">
+    <img src="static/icons/bios.svg">
     Teammate Bios
   </a>
   <a href="handbook/editing/index.md" class="block">
-    <img src="/static/icons/handbook.svg">
+    <img src="static/icons/handbook.svg">
     Handbook Basics
   </a>
   <a href="benefits-pay-perks/benefits-perks/index.md" class="block">
-    <img src="/static/icons/pay-and-benefits.svg">
+    <img src="static/icons/pay-and-benefits.svg">
     Pay and Benefits
   </a>
   <a href="company-info-and-process/index.md" class="block">
-    <img src="/static/icons/policies.svg">
+    <img src="static/icons/policies.svg">
     Company Processes
   </a>
 </div>

--- a/content/index.md
+++ b/content/index.md
@@ -10,7 +10,7 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
 <div class="blocks">
   <a href="company-info-and-process/about-sourcegraph/index.md" class="block">
-    <img src="static/icons/about.svg">
+    <img src="/static/icons/about.svg">
     About Sourcegraph
   </a>
   <a href="strategy-goals/strategy/index.md" class="block">

--- a/content/index.md
+++ b/content/index.md
@@ -8,6 +8,41 @@ The Sourcegraph handbook describes how Sourcegraph team members work together at
 
 Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
+<div class="blocks">
+  <a href="/company-info-and-process/about-sourcegraph/index.md" class="block">
+    <img src="/static/icons/about.svg">
+    About Sourcegraph
+  </a>
+  <a href="/strategy-goals/strategy/index.md" class="block">
+    <img src="/static/icons/strategy.svg">
+    Strategy
+  </a>
+  <a href="departments/index.md" class="block">
+    <img src="/static/icons/departments.svg">
+    Departments
+  </a>
+  <a href="https://docs.google.com/document/d/1WqyffCTaPKp9G1kpPFryEi2eiPZzwfF7Gmo2mAjSq40/edit#heading=h.kso9gsaecr0b" class="block">
+    <img src="/static/icons/the-git-down.svg">
+    The Git Down
+  </a>
+  <a href="team/index.md" class="block">
+    <img src="/static/icons/bios.svg">
+    Teammate Bios
+  </a>
+  <a href="handbook/editing/index.md" class="block">
+    <img src="/static/icons/handbook.svg">
+    Handbook Basics
+  </a>
+  <a href="benefits-pay-perks/benefits-perks/index.md" class="block">
+    <img src="/static/icons/pay-and-benefits.svg">
+    Pay and Benefits
+  </a>
+  <a href="company-info-and-process/index.md" class="block">
+    <img src="/static/icons/policies.svg">
+    Company Processes
+  </a>
+</div>
+
 ## Company information
 
 - [About Sourcegraph](company-info-and-process/about-sourcegraph/index.md)

--- a/content/index.md
+++ b/content/index.md
@@ -9,11 +9,11 @@ The Sourcegraph handbook describes how Sourcegraph team members work together at
 Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
 <div class="blocks">
-  <a href="/company-info-and-process/about-sourcegraph/index.md" class="block">
+  <a href="company-info-and-process/about-sourcegraph/index.md" class="block">
     <img src="/static/icons/about.svg">
     About Sourcegraph
   </a>
-  <a href="/strategy-goals/strategy/index.md" class="block">
+  <a href="strategy-goals/strategy/index.md" class="block">
     <img src="/static/icons/strategy.svg">
     Strategy
   </a>

--- a/content/index.md
+++ b/content/index.md
@@ -14,31 +14,31 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
     About Sourcegraph
   </a>
   <a href="strategy-goals/strategy/index.md" class="block">
-    <img src="static/icons/strategy.svg">
+    <img src="/static/icons/strategy.svg">
     Strategy
   </a>
   <a href="departments/index.md" class="block">
-    <img src="static/icons/departments.svg">
+    <img src="/static/icons/departments.svg">
     Departments
   </a>
   <a href="https://docs.google.com/document/d/1WqyffCTaPKp9G1kpPFryEi2eiPZzwfF7Gmo2mAjSq40/edit#heading=h.kso9gsaecr0b" class="block">
-    <img src="static/icons/the-git-down.svg">
+    <img src="/static/icons/the-git-down.svg">
     The Git Down
   </a>
   <a href="team/index.md" class="block">
-    <img src="static/icons/bios.svg">
+    <img src="/static/icons/bios.svg">
     Teammate Bios
   </a>
   <a href="handbook/editing/index.md" class="block">
-    <img src="static/icons/handbook.svg">
+    <img src="/static/icons/handbook.svg">
     Handbook Basics
   </a>
   <a href="benefits-pay-perks/benefits-perks/index.md" class="block">
-    <img src="static/icons/pay-and-benefits.svg">
+    <img src="/static/icons/pay-and-benefits.svg">
     Pay and Benefits
   </a>
   <a href="company-info-and-process/index.md" class="block">
-    <img src="static/icons/policies.svg">
+    <img src="/static/icons/policies.svg">
     Company Processes
   </a>
 </div>

--- a/src/scripts/check-links.mjs
+++ b/src/scripts/check-links.mjs
@@ -38,6 +38,8 @@ for (const filePath of filePaths) {
     const results = await checkMarkdownLinks(content, {
         baseUrl: pathToFileURL(path.dirname(absoluteFilePath)).href,
         ignorePatterns: [
+            // Ignore assets in public static directory
+            { pattern: /^\/static/ },
             {
                 // Ignore external links as they would cause irreproducable builds
                 // Exception: our Google Cloud Storage URLs, as only admins are allowed to delete files so the chance of builds breaking is low.

--- a/src/styles/cards.scss
+++ b/src/styles/cards.scss
@@ -1,0 +1,23 @@
+.blocks {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+}
+
+a.block {
+    border: 2px solid var(--gray-05);
+    background-color: white;
+    border-radius: 9px;
+    text-align: center;
+    padding: 1rem;
+    margin: 1rem;
+    width: 150px;
+    flex: 0 0 auto;
+    display: block;
+}
+
+.block img {
+    display: block;
+    margin: 10px auto;
+    width: 50%;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -20,3 +20,4 @@ $text-muted: var(--gray-05);
 @import './content.scss';
 
 @import './badges.scss';
+@import './cards.scss';


### PR DESCRIPTION
Add quick links to the homepage of the handbook for some of the most frequently used handbook pages.

<img width="835" alt="Screen Shot 2023-02-09 at 4 40 28 PM" src="https://user-images.githubusercontent.com/602886/217861125-04f9f0b2-5c8e-418c-b7f3-2c673fb5ad22.png">
