### PR TITLE
Update homepage card icons to use storage bucket

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -10,35 +10,35 @@ Want to join our team? See [open roles](https://about.sourcegraph.com/jobs/).
 
 <div class="blocks">
   <a href="company-info-and-process/about-sourcegraph/index.md" class="block">
-    <img src="/static/icons/about.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/about.svg">
     About Sourcegraph
   </a>
   <a href="strategy-goals/strategy/index.md" class="block">
-    <img src="/static/icons/strategy.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/strategy.svg">
     Strategy
   </a>
   <a href="departments/index.md" class="block">
-    <img src="/static/icons/departments.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/departments.svg">
     Departments
   </a>
   <a href="https://docs.google.com/document/d/1WqyffCTaPKp9G1kpPFryEi2eiPZzwfF7Gmo2mAjSq40/edit#heading=h.kso9gsaecr0b" class="block">
-    <img src="/static/icons/the-git-down.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/the-git-down.svg">
     The Git Down
   </a>
   <a href="team/index.md" class="block">
-    <img src="/static/icons/bios.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/bios.svg">
     Teammate Bios
   </a>
   <a href="handbook/editing/index.md" class="block">
-    <img src="/static/icons/handbook.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/handbook.svg">
     Handbook Basics
   </a>
   <a href="benefits-pay-perks/benefits-perks/index.md" class="block">
-    <img src="/static/icons/pay-and-benefits.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/pay-and-benefits.svg">
     Pay and Benefits
   </a>
   <a href="company-info-and-process/index.md" class="block">
-    <img src="/static/icons/policies.svg">
+    <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/icons/policies.svg">
     Company Processes
   </a>
 </div>


### PR DESCRIPTION
Fix the homepage card icons by using the assets storage bucket