### PR TITLE
Private Code Hosts - initial part

### DIFF
--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -5,15 +5,15 @@
 
 Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platform.
 
-**Private Code Host** is a code host deployed in a private network (for example AWS EC2 instance within VPC). To connect to this code host a user has to have access to the private network usually via VPC Peering, VPN, or tunneling).
+**Private Code Host** is a code host deployed in a private network (for example AWS EC2 instance within VPC). To connect to this code host a user has to have access to the private network usually via VPC Peering, VPN, or tunneling.
 
-## Managed Instance public IP allowlist solution
+## Managed Instance public IP allowlist solution (recommended)
 
 This solution is recommended by Cloud Team, but only possible if customers' code host can be accessible publically or customer is able to allow incoming traffic from Sourcegraph-owned static IP addresses.
 Cloud Manage Instance is using NAT to ensure only given IP will access customer code hosts.
 If customer is not able to meet these requirements, Sourcegraph can propose [VPN solution for code hosts deployed on AWS](#aws-gcp-site-to-site-vpn-solution)
 
-## AWS GCP site to site VPN solution
+## AWS GCP site to site VPN solution (AWS code hosts only)
 
 ### Architecture
 
@@ -27,14 +27,14 @@ AWS GCP VPN extension is connecting existing Cloud Instance with customer dedica
 
 ```yaml
 spec:
-  privateCodeHost:
-    aws:
-      accountID: <AWS_ACCOUNT_ID>
-      highAvailable: true
-      region: <AWS_REGION>
-    domain: <CUSTOMER_CODE_HOST_PRIVATE_DOMAIN>
-    enabled: true
-    type: awsvpn
+  infrastructure:
+    privateCodeHost:
+      aws:
+        accountID: <AWS_ACCOUNT_ID>
+        highAvailable: true
+        region: <AWS_REGION>
+      enabled: true
+      type: awsvpn
 ```
 
 #### 2. Generate additional terraform stacks
@@ -60,11 +60,48 @@ Creation process detail walkthrough:
 
 For more details, go to [Google documentation](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws)
 
-#### 3. [Optional] Private code host domain
+## [Optional] Private code host domain
 
-If customer code host uses private DNS name, additonal DNS Proxy sidecar is added to Cloud Instance.
+Every Cloud customer using private DNS domain for code hosts requires additional dns-proxy sidecar.
+DNS-proxy is rewriting from private customer domain to public, resolvable A record
+i.e. `private.CUSTOMER.com` -> `public.CUSTOMER.com` where:
 
-**TBD**
+- `private.CUSTOMER.com` is customer code host address, only resolvable inside customer network
+- `public.CUSTOMER.com` - is resolvable to customer code host private IP
+  Dns-proxy sidecar modifies pod `/etc/resolv.conf` file.
+
+1. Configure config.yaml
+
+```yaml
+spec:
+  infrastructure:
+    privateDNS:
+      routes:
+        - source: private.CUSTOMER.com
+          destination: public.CUSTOMER.com
+          # resolverIP: IP_OF_CUSTOM_RESOLVER - optional
+    gke:
+      blue:
+        additionalOauthScopes: # required for each node pool to pull dns-proxy private image from artifact registry
+          - https://www.googleapis.com/auth/devstorage.read_only
+```
+
+1. Generate and apply cdktf
+
+```sh
+mi2 generate cdktf
+# modify GKE node pool and add artifact registry repository with permissions
+mi2 instance tfc deploy -auto-approve
+```
+
+1. Generate dns-proxy sidecars
+
+```sh
+# generate sidecars and copy dns-proxy from control plane project to customer project artifact registry repository
+mi2 generate kustomize
+cd kubernetes
+kustomize build --load-restrictor LoadRestrictionsNone --enable-helm . | kubectl apply -f -
+```
 
 ### Verification
 
@@ -82,31 +119,31 @@ Secction example:
 Get name of GCP VPN router:
 
 ```bash
-export GCP_ROUTER_NAME=$(gcloud compute routers list --project src-404b40e50f4f7b202e4e --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
+export GCP_ROUTER_NAME=$(gcloud compute routers list --project <PROJECT_ID> --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
 ```
 
 Verify GCP router status:
 
 ```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project src-404b40e50f4f7b202e4e  --region europe-west3  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
+gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID>  --region <GCP_REGION>  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
 ```
 
 List VPN tunnels:
 
 ```bash
-gcloud compute vpn-tunnels list --project src-404b40e50f4f7b202e4e
+gcloud compute vpn-tunnels list --project <PROJECT_ID>
 ```
 
 Check tunnel status:
 
 ```bash
-gcloud compute vpn-tunnels describe <TUNNEL_ID> --project src-404b40e50f4f7b202e4e --region europe-west3 --format='flattened(status,detailedStatus)'
+gcloud compute vpn-tunnels describe <TUNNEL_ID> --project <PROJECT_ID> --region <GCP_REGION> --format='flattened(status,detailedStatus)'
 ```
 
 List dynamic routes:
 
 ```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project src-404b40e50f4f7b202e4e --region europe-west3 --format="flattened(result.bestRoutes)"
+gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID> --region <GCP_REGION> --format="flattened(result.bestRoutes)"
 ```
 
 ### AWS Private Link playbook

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -1,0 +1,114 @@
+# Managed Instance Private Code Hosts support
+
+> **Warning**
+> This is still work in progress!
+
+Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platform.
+
+**Private Code Host** is a code host deployed in a private network (for example AWS EC2 instance within VPC). To connect to this code host a user has to have access to the private network usually via VPC Peering, VPN, or tunneling).
+
+## Managed Instance public IP allowlist solution
+
+This solution is recommended by Cloud Team, but only possible if customers' code host can be accessible publically or customer is able to allow incoming traffic from Sourcegraph-owned static IP addresses.
+Cloud Manage Instance is using NAT to ensure only given IP will access customer code hosts.
+If customer is not able to meet these requirements, Sourcegraph can propose [VPN solution for code hosts deployed on AWS](#aws-gcp-site-to-site-vpn-solution)
+
+## AWS GCP site to site VPN solution
+
+### Architecture
+
+[AWS VPN architecture](https://app.excalidraw.com/s/4Dr1S6qmmY7/4L5TAaxiYAy)
+
+### Creation process
+
+AWS GCP VPN extension is connecting existing Cloud Instance with customer dedicated AWS account (maintaned by Cloud Team).
+
+#### 1. Modify `config.yaml` with additional section:
+
+```yaml
+spec:
+  privateCodeHost:
+    aws:
+      accountID: <AWS_ACCOUNT_ID>
+      highAvailable: true
+      region: <AWS_REGION>
+    domain: <CUSTOMER_CODE_HOST_PRIVATE_DOMAIN>
+    enabled: true
+    type: awsvpn
+```
+
+#### 2. Generate additional terraform stacks
+
+```
+mi2 generate cdktf
+```
+
+this will generate `awsvpc` and `awsvpn` stacks.
+
+Creation process detail walkthrough:
+
+1. AWS VPC is created in customer dedicated Sourcegraph AWS Account.
+1. High Available VPN Gateway is created in Managed Instance GCP VPC with 2 public IP intrefaces.
+1. Cloud Router with BGP GCP-side ASN number is created in Managed Instance VPC.
+1. AWS VPN Gateway with BGP AWS-side ASN number is created. It is attached to VPC and uses all VPC route tables propagated.
+1. AWS Customer Gateway tight to GCP VPN Gateway interface is created (uses GCP-side BGP ASN). For high available options 2 gateways are created.
+1. AWS VPN connection is created with 2 tunnel options (every tunnel uses different 32B PreSharedKey). For high available options 2 VPC connections are created.
+1. GCP External VPN Gateway is created with interfaces correspoding for each AWS VPN connection tunnel. For high available options External VPN Gateway has 4 interfaces, for non high-available 2.
+1. For each External VPN Gateway interface GCP VPN Tunnel is created. It uses dedicated PreSharedKey (same in on AWS VPN Connection(s)).
+1. For each GCP VPN Tunnel interface is added to Cloud Router. It uses IP rnage correspoding to AWS VPN Connection tunnel internal address.
+1. For each AWS VPN Connection tunnel internal address BGP peer is added to Cloud Router.
+
+For more details, go to [Google documentation](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws)
+
+#### 3. [Optional] Private code host domain
+
+If customer code host uses private DNS name, additonal DNS Proxy sidecar is added to Cloud Instance.
+
+**TBD**
+
+### Verification
+
+For each customer using private code host, additional section to dashboard.md is added.
+Can be generated on deman via:
+
+```sh
+mi2 instance dashboard --output <FILE_NAME>.md
+```
+
+Secction example:
+
+#### Verify setup from GCP side
+
+Get name of GCP VPN router:
+
+```bash
+export GCP_ROUTER_NAME=$(gcloud compute routers list --project src-404b40e50f4f7b202e4e --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
+```
+
+Verify GCP router status:
+
+```bash
+gcloud compute routers get-status $GCP_ROUTER_NAME --project src-404b40e50f4f7b202e4e  --region europe-west3  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
+```
+
+List VPN tunnels:
+
+```bash
+gcloud compute vpn-tunnels list --project src-404b40e50f4f7b202e4e
+```
+
+Check tunnel status:
+
+```bash
+gcloud compute vpn-tunnels describe <TUNNEL_ID> --project src-404b40e50f4f7b202e4e --region europe-west3 --format='flattened(status,detailedStatus)'
+```
+
+List dynamic routes:
+
+```bash
+gcloud compute routers get-status $GCP_ROUTER_NAME --project src-404b40e50f4f7b202e4e --region europe-west3 --format="flattened(result.bestRoutes)"
+```
+
+### AWS Private Link playbook
+
+**TBD**

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -62,6 +62,49 @@ Creation process detail walkthrough:
 
 For more details, go to [Google documentation](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws)
 
+### VPN Verification
+
+For each customer using private code host, additional section to dashboard.md is added.
+Can be generated on deman via:
+
+```sh
+mi2 instance dashboard --output <FILE_NAME>.md
+```
+
+Secction example:
+
+#### Verify setup from GCP side
+
+Get name of GCP VPN router:
+
+```bash
+export GCP_ROUTER_NAME=$(gcloud compute routers list --project <PROJECT_ID> --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
+```
+
+Verify GCP router status:
+
+```bash
+gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID>  --region <GCP_REGION>  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
+```
+
+List VPN tunnels:
+
+```bash
+gcloud compute vpn-tunnels list --project <PROJECT_ID>
+```
+
+Check tunnel status:
+
+```bash
+gcloud compute vpn-tunnels describe <TUNNEL_ID> --project <PROJECT_ID> --region <GCP_REGION> --format='flattened(status,detailedStatus)'
+```
+
+List dynamic routes:
+
+```bash
+gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID> --region <GCP_REGION> --format="flattened(result.bestRoutes)"
+```
+
 ## [Optional] Private code host domain
 
 Every Cloud customer using private DNS domain for code hosts requires additional dns-proxy sidecar.
@@ -103,49 +146,6 @@ mi2 instance tfc deploy -auto-approve
 mi2 generate kustomize
 cd kubernetes
 kustomize build --load-restrictor LoadRestrictionsNone --enable-helm . | kubectl apply -f -
-```
-
-### Verification
-
-For each customer using private code host, additional section to dashboard.md is added.
-Can be generated on deman via:
-
-```sh
-mi2 instance dashboard --output <FILE_NAME>.md
-```
-
-Secction example:
-
-#### Verify setup from GCP side
-
-Get name of GCP VPN router:
-
-```bash
-export GCP_ROUTER_NAME=$(gcloud compute routers list --project <PROJECT_ID> --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
-```
-
-Verify GCP router status:
-
-```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID>  --region <GCP_REGION>  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
-```
-
-List VPN tunnels:
-
-```bash
-gcloud compute vpn-tunnels list --project <PROJECT_ID>
-```
-
-Check tunnel status:
-
-```bash
-gcloud compute vpn-tunnels describe <TUNNEL_ID> --project <PROJECT_ID> --region <GCP_REGION> --format='flattened(status,detailedStatus)'
-```
-
-List dynamic routes:
-
-```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID> --region <GCP_REGION> --format="flattened(result.bestRoutes)"
 ```
 
 ### AWS Private Link playbook

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -1,7 +1,6 @@
 # Managed Instance Private Code Hosts support
 
-> **Warning**
-> This is still work in progress!
+WARNING: This is still work in progress!
 
 Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platform.
 
@@ -9,13 +8,13 @@ Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platfo
 
 ## Managed Instance NAT IP allowlist solution (recommended)
 
-This solution is recommended by Cloud Team, but only possible if customers' code hosts can be accessible publicly and customer is able to allow incoming traffic from Sourcegraph-owned static IP addresses.
+This solution is recommended by Cloud Team, but only possible if customers' code hosts can be accessible publicly and customer is able to allow incoming traffic from Sourcegraph-owned IP addresses.
 Outgoing traffic of Cloud instances goes through Cloud NAT with stable IPs. All IPs are reservered exclusively on a per customer basis.
 [More informations about IP allowlist](../../index.md#faq-what-is-the-cloud-instance-ip)
 
-If customer is not able to meet these requirements, Sourcegraph can propose [VPN solution for code hosts deployed on AWS](#aws-gcp-site-to-site-vpn-solution)
+## AWS GCP site-to-site VPN solution (AWS code hosts only)
 
-## AWS GCP site to site VPN solution (AWS code hosts only)
+This option is for customers who want to connect to a private code host that is hosted on AWS infrastructure.
 
 ### Architecture
 
@@ -64,46 +63,8 @@ For more details, go to [Google documentation](https://cloud.google.com/network-
 
 ### VPN Verification
 
-For each customer using private code host, additional section to dashboard.md is added.
-Can be generated on deman via:
-
-```sh
-mi2 instance dashboard --output <FILE_NAME>.md
-```
-
-Secction example:
-
-#### Verify setup from GCP side
-
-Get name of GCP VPN router:
-
-```bash
-export GCP_ROUTER_NAME=$(gcloud compute routers list --project <PROJECT_ID> --filter="bgp.advertiseMode: CUSTOM"  --format=json | jq -r '.[0].name')
-```
-
-Verify GCP router status:
-
-```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID>  --region <GCP_REGION>  --format='flattened(result.bgpPeerStatus[].name, result.bgpPeerStatus[].ipAddress, result.bgpPeerStatus[].peerIpAddress)
-```
-
-List VPN tunnels:
-
-```bash
-gcloud compute vpn-tunnels list --project <PROJECT_ID>
-```
-
-Check tunnel status:
-
-```bash
-gcloud compute vpn-tunnels describe <TUNNEL_ID> --project <PROJECT_ID> --region <GCP_REGION> --format='flattened(status,detailedStatus)'
-```
-
-List dynamic routes:
-
-```bash
-gcloud compute routers get-status $GCP_ROUTER_NAME --project <PROJECT_ID> --region <GCP_REGION> --format="flattened(result.bestRoutes)"
-```
+For each customer using private code host, additional section to our generated operation dashboard is added.
+Upon enabling the private code host support, follow the process [to update the dashboard](https://github.com/sourcegraph/cloud/blob/main/prod.dashboard.md#update-all-generated-dashboards)
 
 ## [Optional] Private code host domain
 

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -22,7 +22,7 @@ This option is for customers who want to connect to a private code host that is 
 
 ### Creation process
 
-AWS GCP VPN extension is connecting existing Cloud Instance with customer dedicated AWS account (maintaned by Cloud Team).
+AWS GCP VPN extension connects an existing Cloud Instance with customer dedicated AWS account (maintained by Cloud Team).
 
 #### 1. Modify `config.yaml` with additional section:
 

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -48,14 +48,14 @@ this will generate `awsvpc` and `awsvpn` stacks.
 Creation process detail walkthrough:
 
 1. AWS VPC is created in customer dedicated Sourcegraph AWS Account.
-1. High Available VPN Gateway is created in Managed Instance GCP VPC with 2 public IP intrefaces.
-1. Cloud Router with BGP GCP-side ASN number is created in Managed Instance VPC.
-1. AWS VPN Gateway with BGP AWS-side ASN number is created. It is attached to VPC and uses all VPC route tables propagated.
-1. AWS Customer Gateway tight to GCP VPN Gateway interface is created (uses GCP-side BGP ASN). For high available options 2 gateways are created.
+1. Cloud Router with GCP-side BGP ASN number is created in Managed Instance VPC.
+1. AWS VPN Gateway with BGP AWS-side ASN number is created. It is attached to VPC and uses VPC route tables to propagate BPG sessions.
+1. High Available GCP VPN Gateway is created in Managed Instance GCP VPC with 2 interfaces.
+1. AWS Customer Gateway is created (uses GCP-side BGP ASN). For high available options 2 gateways are created.
 1. AWS VPN connection is created with 2 tunnel options (every tunnel uses different 32B PreSharedKey). For high available options 2 VPC connections are created.
 1. GCP External VPN Gateway is created with interfaces correspoding for each AWS VPN connection tunnel. For high available options External VPN Gateway has 4 interfaces, for non high-available 2.
 1. For each External VPN Gateway interface GCP VPN Tunnel is created. It uses dedicated PreSharedKey (same in on AWS VPN Connection(s)).
-1. For each GCP VPN Tunnel interface is added to Cloud Router. It uses IP rnage correspoding to AWS VPN Connection tunnel internal address.
+1. For each GCP VPN Tunnel interface is added to Cloud Router. It uses IP range correspoding to AWS VPN Connection tunnel internal address.
 1. For each AWS VPN Connection tunnel internal address BGP peer is added to Cloud Router.
 
 For more details, go to [Google documentation](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws)

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -9,7 +9,7 @@ Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platfo
 ## Managed Instance NAT IP allowlist solution (recommended)
 
 This solution is recommended by Cloud Team, but only possible if customers' code hosts can be accessible publicly and customer is able to allow incoming traffic from Sourcegraph-owned IP addresses.
-Outgoing traffic of Cloud instances goes through Cloud NAT with stable IPs. All IPs are reservered exclusively on a per customer basis.
+Outgoing traffic of Cloud instances goes through Cloud NAT with stable IPs. All IPs are reserved exclusively on a per customer basis.
 [More informations about IP allowlist](../../index.md#faq-what-is-the-cloud-instance-ip)
 
 ## AWS GCP site-to-site VPN solution (AWS code hosts only)

--- a/content/departments/cloud/technical-docs/private-code-hosts/index.md
+++ b/content/departments/cloud/technical-docs/private-code-hosts/index.md
@@ -7,10 +7,12 @@ Every [v2.0 Cloud Instance](../v2.0/index.md) is deployed in Google Cloud Platfo
 
 **Private Code Host** is a code host deployed in a private network (for example AWS EC2 instance within VPC). To connect to this code host a user has to have access to the private network usually via VPC Peering, VPN, or tunneling.
 
-## Managed Instance public IP allowlist solution (recommended)
+## Managed Instance NAT IP allowlist solution (recommended)
 
-This solution is recommended by Cloud Team, but only possible if customers' code host can be accessible publically or customer is able to allow incoming traffic from Sourcegraph-owned static IP addresses.
-Cloud Manage Instance is using NAT to ensure only given IP will access customer code hosts.
+This solution is recommended by Cloud Team, but only possible if customers' code hosts can be accessible publicly and customer is able to allow incoming traffic from Sourcegraph-owned static IP addresses.
+Outgoing traffic of Cloud instances goes through Cloud NAT with stable IPs. All IPs are reservered exclusively on a per customer basis.
+[More informations about IP allowlist](../../index.md#faq-what-is-the-cloud-instance-ip)
+
 If customer is not able to meet these requirements, Sourcegraph can propose [VPN solution for code hosts deployed on AWS](#aws-gcp-site-to-site-vpn-solution)
 
 ## AWS GCP site to site VPN solution (AWS code hosts only)


### PR DESCRIPTION
Part of [issue](https://github.com/sourcegraph/customer/issues/1859)

Includes:
- allow list solution
- site-to-stie VPN for AWS
- DNS proxy for private code hosts domain

In separate:
- AWS Private Link
- AWS access/accounts