### PR TITLE
Modify the region for fetching dogfood credentials

### DIFF
--- a/content/departments/engineering/dev/tools/scaletesting.md
+++ b/content/departments/engineering/dev/tools/scaletesting.md
@@ -133,7 +133,7 @@ To make changes to images, environment variables or other configuration, all upd
 First, authenticate yourself to the cluster using the following command:
 
 ```shell
-gcloud container clusters get-credentials dogfood --region us-central1 --project sourcegraph-dogfood
+gcloud container clusters get-credentials dogfood --region us-central1-f --project sourcegraph-dogfood
 ```
 
 Then check that you have the Sourcegraph Helm chart installed:


### PR DESCRIPTION
When trying the original command, I get the following error
```
gcloud container clusters get-credentials dogfood --region us-central1 --project sourcegraph-dogfood
Fetching cluster endpoint and auth data.
ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=404, message=Not found: projects/sourcegraph-dogfood/locations/us-central1/clusters/dogfood.
Could not find [dogfood] in [us-central1].
Did you mean [dogfood] in [us-central1-f]?
```