### PR TITLE
Add outline of 5.0.0 Accepted CVEs handbook page

### DIFF
--- a/content/departments/security/tooling/trivy/5-0-0.md
+++ b/content/departments/security/tooling/trivy/5-0-0.md
@@ -1,0 +1,17 @@
+# Accepted CVEs for Sourcegraph 4.5.0
+
+| CVE ID                                                                                       | Affected Images                                                                                                                                                  | CVE Severity | CVSS Base Score                                                 | [Sourcegraph Assessment](../../../engineering/dev/policies/vulnerability-management-policy.md#severity-levels) | CVSS Environmental Score                                                   | Details                                                                                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| | | | | | | |
+
+
+# Known false positives for Sourcegraph 5.0.0
+
+The following CVEs may be detected in our images by some scanners due to package version matching. These issues have been patched and confirmed no longer vulnerable by an independent third-party.
+
+**CVE ID**|**Affected Image**|**Reason for False Positive**
+:-----:|:-----:|:-----:
+CVE-2022-31107|sourcegraph/grafana|Patched by independent third-party
+CVE-2022-31123|sourcegraph/grafana|Patched by independent third-party
+CVE-2022-31130|sourcegraph/grafana|Patched by independent third-party
+CVE-2022-39201|sourcegraph/grafana|Patched by independent third-party

--- a/content/departments/security/tooling/trivy/5-0-0.md
+++ b/content/departments/security/tooling/trivy/5-0-0.md
@@ -1,17 +1,16 @@
 # Accepted CVEs for Sourcegraph 4.5.0
 
-| CVE ID                                                                                       | Affected Images                                                                                                                                                  | CVE Severity | CVSS Base Score                                                 | [Sourcegraph Assessment](../../../engineering/dev/policies/vulnerability-management-policy.md#severity-levels) | CVSS Environmental Score                                                   | Details                                                                                                                                                                                                                                                                                                                                                                                                  |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| | | | | | | |
-
+| CVE ID | Affected Images | CVE Severity | CVSS Base Score | [Sourcegraph Assessment](../../../engineering/dev/policies/vulnerability-management-policy.md#severity-levels) | CVSS Environmental Score | Details |
+| ------ | --------------- | ------------ | --------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------ | ------- |
+|        |                 |              |                 |                                                                                                                |                          |         |
 
 # Known false positives for Sourcegraph 5.0.0
 
 The following CVEs may be detected in our images by some scanners due to package version matching. These issues have been patched and confirmed no longer vulnerable by an independent third-party.
 
-**CVE ID**|**Affected Image**|**Reason for False Positive**
-:-----:|:-----:|:-----:
-CVE-2022-31107|sourcegraph/grafana|Patched by independent third-party
-CVE-2022-31123|sourcegraph/grafana|Patched by independent third-party
-CVE-2022-31130|sourcegraph/grafana|Patched by independent third-party
-CVE-2022-39201|sourcegraph/grafana|Patched by independent third-party
+|   **CVE ID**   | **Affected Image**  |   **Reason for False Positive**    |
+| :------------: | :-----------------: | :--------------------------------: |
+| CVE-2022-31107 | sourcegraph/grafana | Patched by independent third-party |
+| CVE-2022-31123 | sourcegraph/grafana | Patched by independent third-party |
+| CVE-2022-31130 | sourcegraph/grafana | Patched by independent third-party |
+| CVE-2022-39201 | sourcegraph/grafana | Patched by independent third-party |


### PR DESCRIPTION
This adds a 5.0.0 Accepted CVEs page, which includes a false positive table