### PR TITLE
Removed link to Marketing Ops

### DIFF
--- a/content/departments/sales/demand-gen/index.md
+++ b/content/departments/sales/demand-gen/index.md
@@ -24,10 +24,6 @@ The **Campaigns group** is primarily responsible for the strategy and activation
 - [Account-Based Experiences](./account_based_experience.md) aka ABX
 - [Digital Marketing Programs](./digital_marketing_programs.md)
 
-The **Operations group** is responsible for systems and analytics which support the marketing organization.
-
-- [Marketing Operations](./marketing_operations.md)
-
 ## Meet the team
 
 {{generator:reporting_structure.director_demand_generation}}


### PR DESCRIPTION
Now under Sales Ops team / section