### PR TITLE
preprod: remove references

### DIFF
--- a/content/departments/engineering/dev/process/engineering_ownership.md
+++ b/content/departments/engineering/dev/process/engineering_ownership.md
@@ -170,7 +170,7 @@ If you see an area that is missing, [figure out](../../product/process/feedback/
 - GCP cost savings
 - Production support and on-call of DotCom environment
 - Observability tooling for DotCom environment
-- Dogfood/Pre-prod and other test environments
+- Dogfood/Scale testing and other test environments
 - Code host QA instances
 - DNS
 

--- a/content/departments/engineering/teams/devops/dotcom-postgres.md
+++ b/content/departments/engineering/teams/devops/dotcom-postgres.md
@@ -1,8 +1,7 @@
 # Cloud Postgres
 
 This serves as an informal description of changes to the Postgres database for
-Sourcegraph.com and why the change was made. Most changes should be made on the
-pre-prod environment before being made on the production environment.
+Sourcegraph.com and why the change was made.
 
 ## Changes
 


### PR DESCRIPTION
- Part of https://github.com/sourcegraph/deploy-sourcegraph-cloud/issues/17723

Missed some references due to the dash in `pre-prod`.