### PR TITLE
Add plg-trial tag to license documentation

### DIFF
--- a/content/departments/technical-success/ce/process/license_keys.md
+++ b/content/departments/technical-success/ce/process/license_keys.md
@@ -45,7 +45,7 @@ The CE should first create a Sourcegraph.com user account for the prospect/custo
    1. Fill out the license subscription plan name. See the [plans](#plans) section.
    1. Fill out the licensed number of users. Note that if you added the `true-up` tag, the customer will be able to exceed this count, but administrators will see a warning.
    1. Fill out the number of days the license should be valid for. Most typically this should match the end date of the contract itself.
-   1. Fill in the appropriate license tags. For tags, see the [License Key Tags](#license-key-tags) section. Remember: Tags must be separated by commas. You can see a list of tags generated under the tags input. If a tag is not recognized, it will be red and a warning will appear.
+   1. Fill in the appropriate license tags. For tags, see the [License Key Tags](#license-key-tags) section. Note that licenses for Cloud trial managed instance requests should inclue the `plg-trial` tag. Remember: Tags must be separated by commas. You can see a list of tags generated under the tags input. If a tag is not recognized, it will be red and a warning will appear.
 6. Click **Generate license**.
 7. Finally, copy the license key, and send it to the relevant contact at the company. You can link them to the following docs for instructions on where to add the key: [Updating your license key](https://docs.sourcegraph.com/admin/subscriptions#updating-your-license-key)
 
@@ -106,6 +106,7 @@ First the tags that relate to license itself:
 - `mau` to indicate that the company is on a monthly usage-based billing model.
   > Note: For any MAU-based customers, the `true-up` tag must also be added as we do not have the ability to hard-cap MAU-based plans.
 - `trial` to show an indicate in Sourcegraph that the company is on a trial.
+- `plg-trial` to indicate that a Cloud trial managed instance has been requested through signup.sourcegraph.com.
 - `dev` for internal developer licenses
 - `internal` for licenses used for internal sites (dotcom, k8s, etc.)
 


### PR DESCRIPTION
In order to properly track Cloud trial managed instances that have been requested through signup.sourcegraph.com, the license requested by the CE as [part of this flow](https://handbook.sourcegraph.com/departments/cloud/trial_mi/#cloud-trial-requests-from-signupsourcegraphcom) needs to include the `plg-trial` tag. 