### PR TITLE
Fix framework table responsiveness, unify style, layout, and voice

### DIFF
--- a/content/departments/engineering/design/career-development.md
+++ b/content/departments/engineering/design/career-development.md
@@ -67,44 +67,44 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="behaviors-row">
       <td class="behaviors">
         <ul>
-          <li>Understand your product</li>
-          <li>Know our competitors, their solutions, and gaps</li>
-          <li>Know Sourcegraph’s target customers and buyer personas</li>
-          <li>Know who’s using your product, their jobs, tasks, use cases, and goals</li>
-          <li>Know the strategy and vision for our company, product, your program, your group, and your team</li>
-          <li>Work toward the vision for your product area</li>
-          <li>Know the metrics and outcomes we aim for in your product area</li>
+          <li>Understands their product</li>
+          <li>Knows our competitors, their solutions, and gaps</li>
+          <li>Knows Sourcegraph’s target customers and buyer personas</li>
+          <li>Knows who’s using their product, their jobs, tasks, use cases, and goals</li>
+          <li>Knows the strategy and vision for our company, product, their program, their group, and their team</li>
+          <li>Works toward the vision for their product area</li>
+          <li>Knows the metrics and outcomes we aim for in their product area</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Learn from team how to understand customer and business problems</li>
-          <li>Ask for and use existing research to inform your solutions</li>
-          <li>Learning about the fundamentals of system design</li>
-          <li>Talk to colleagues inside of your team affected by your work</li>
-          <li>Explore different ways to solve problems</li>
-          <li>Identify pros & cons, questions, implications</li>
-          <li>Use our design system</li>
-          <li>Follow fundamentals of good UI design</li>
-          <li>Seek support to conceptualize a hypothesis that will be tested through a prototype</li>
-          <li>Work closely with engineers to understand and work around constraints</li>
+          <li>Learns from team how to understand customer and business problems</li>
+          <li>Asks for and use existing research to inform their solutions</li>
+          <li>Is learning about the fundamentals of system design</li>
+          <li>Talks to colleagues inside of their team affected by their work</li>
+          <li>Explores different ways to solve problems</li>
+          <li>Identifies pros & cons, questions, implications</li>
+          <li>Uses our design system</li>
+          <li>Follows fundamentals of good UI design</li>
+          <li>Seeks support to conceptualize a hypothesis that will be tested through a prototype</li>
+          <li>Works closely with engineers to understand and work around constraints</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Know and learn to apply our Design principles</li>
-          <li>Understand and apply our company values</li>
-          <li>Actively look for opportunities to learn and develop</li>
-          <li>Build your self-awareness</li>
-          <li>Be optimistic and positive about growth opportunities</li>
-          <li>Build strong relationships within your team</li>
-          <li>Regularly communicate your work and status clearly and coherently</li>
-          <li>Provide rationale for your decisions</li>
-          <li>Actively seek feedback</li>
-          <li>Appreciate and consider all feedback with an open mind</li>
-          <li>Make every day count. Have a bias for effective action.</li>
-          <li>Learn to prioritize what’s important</li>
-          <li>Be part of representing design in your team</li>
+          <li>Knows and learns to apply our Design principles</li>
+          <li>Understands and applies our company values</li>
+          <li>Actively looks for opportunities to learn and develop</li>
+          <li>Builds their self-awareness</li>
+          <li>Is optimistic and positive about growth opportunities</li>
+          <li>Builds strong relationships within their team</li>
+          <li>Regularly communicates their work and status clearly and coherently</li>
+          <li>Provides rationale for their decisions</li>
+          <li>Actively seeks feedback</li>
+          <li>Appreciates and considers all feedback with an open mind</li>
+          <li>Makes every day count. Has a bias for effective action.</li>
+          <li>Learns to prioritize what’s important</li>
+          <li>Is part of representing design in their team</li>
         </ul>
       </td>
     </tr>
@@ -142,44 +142,44 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="behaviors-row">
       <td class="behaviors">
         <ul>
-          <li>Understand your product</li>
-          <li>Know our competitors, their solutions, and gaps</li>
-          <li>Know Sourcegraph’s target customers and buyer personas</li>
-          <li>Know who’s using your product, their jobs, tasks, use cases, and goals</li>
-          <li>Know the strategy and vision for our company, product, your program, your group, and your team</li>
-          <li>Work toward the vision for your product area</li>
-          <li>Know the metrics and outcomes we aim for in your product area</li>
+          <li>Understands their product</li>
+          <li>Knows our competitors, their solutions, and gaps</li>
+          <li>Knows Sourcegraph’s target customers and buyer personas</li>
+          <li>Knows who’s using their product, their jobs, tasks, use cases, and goals</li>
+          <li>Knows the strategy and vision for our company, product, their program, their group, and their team</li>
+          <li>Works toward the vision for their product area</li>
+          <li>Knows the metrics and outcomes we aim for in their product area</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Consistently leverage knowledge of your product area and competition to make decisions</li>
-          <li>Actively seek out new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
-          <li>Leverage knowledge from Sales and Support to better understand and serve customers</li>
-          <li>Actively contribute to your team’s strategy and roadmaps</li>
-          <li>Frame your work to relate back to the long-term goals of the product</li>
-          <li>Consistently focus on driving outcomes, not just outputs</li>
-          <li>Influence how your team defines success metrics</li>
-          <li>Drive adoption for your product</li>
-          <li>Understands the value of makring decisions with data over opinions.</li>
+          <li>Consistently leverages knowledge of their product area and competition to make decisions</li>
+          <li>Actively seeks out new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
+          <li>Leverage knowledges from Sales and Support to better understand and serve customers</li>
+          <li>Actively contributes to their team’s strategy and roadmaps</li>
+          <li>Frames their work to relate back to the long-term goals of the product</li>
+          <li>Consistently focuses on driving outcomes, not just outputs</li>
+          <li>Influences how their team defines success metrics</li>
+          <li>Drives adoption for their product</li>
+          <li>Understands the value of making decisions with data over opinions.</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Know and learn to apply our Design principles</li>
-          <li>Understand and apply our company values</li>
+          <li>Knows and learns to apply our Design principles</li>
+          <li>Understands and applies our company values</li>
           <li>Actively look for opportunities to learn and develop</li>
-          <li>Build your self-awareness</li>
-          <li>Be optimistic and positive about growth opportunities</li>
-          <li>Build strong relationships within your team</li>
-          <li>Regularly communicate your work and status clearly and coherently</li>
-          <li>Provide rationale for your decisions</li>
-          <li>Actively seek feedback</li>
-          <li>Appreciate and consider all feedback with an open mind</li>
-          <li>Make every day count. Have a bias for effective action.</li>
-          <li>Know and prioritize what’s most important</li>
-          <li>Own your work</li>
-          <li>Represent design in your team triad</li>
+          <li>Builds their self-awareness</li>
+          <li>Is optimistic and positive about growth opportunities</li>
+          <li>Builds strong relationships within their team</li>
+          <li>Regularly communicates their work and status clearly and coherently</li>
+          <li>Provides rationale for their decisions</li>
+          <li>Actively seeks feedback</li>
+          <li>Appreciates and considers all feedback with an open mind</li>
+          <li>Makes every day count. Has a bias for effective action.</li>
+          <li>Knows and prioritizes what’s most important</li>
+          <li>Owns their work</li>
+          <li>Represents design in their team triad</li>
         </ul>
       </td>
     </tr>
@@ -192,7 +192,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Growing autonomy, guided as needed</li>
           <li>Proficient across most competencies for their level</li>
           <li>Contributor to team roadmap</li>
-          <li>Co-leading their team with their PM and EM</li>
+          <li>Co-leads their team with their PM and EM</li>
         </ul>
       </td>
     </tr>
@@ -216,70 +216,70 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="behaviors-row">
       <td class="behaviors">
         <ul>
-          <li>Consistently leverage knowledge of your product area and competition to make decisions</li>
-          <li>Actively seek new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
-          <li>Leverage knowledge from Sales and Support to better understand and serve customers</li>
-          <li>Actively contribute to your team’s strategy and roadmaps</li>
-          <li>Frame your work to relate back to the long-term goals of the product</li>
-          <li>Consistently focus on driving outcomes, not just outputs</li>
-          <li>Influence how your team defines success metrics</li>
-          <li>Drive adoption for your product through measurable design decisions</li>
+          <li>Consistently leverages knowledge of their product area and competition to make decisions</li>
+          <li>Actively seeks new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
+          <li>Leverages knowledge from Sales and Support to better understand and serve customers</li>
+          <li>Actively contributes to their team’s strategy and roadmaps</li>
+          <li>Frames their work to relate back to the long-term goals of the product</li>
+          <li>Consistently focuses on driving outcomes, not just outputs</li>
+          <li>Influences how their team defines success metrics</li>
+          <li>Drives adoption for their product through measurable design decisions</li>
           <li>Begins to utilizes metrics to analyze the results of their projects and discover where they can be improved</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Understand the underlying motivations for our customers</li>
-          <li>Challenge and influence your team's understanding of the problem</li>
-          <li>Pair with your researcher, analyst, or PM to do research</li>
-          <li>Talk to your customers regularly</li>
-          <li>Design coherent systems, not just interfaces</li>
-          <li>Integrate your system with our broader product</li>
-          <li>Understand the technical system, work around constraints with engineers</li>
-          <li>Explore a broad range of solutions in Interconcepts and detailed designs</li>
-          <li>Involve cross-functional partners in explorations</li>
-          <li>Narrow down to the best solution using strong rationale</li>
-          <li>Reflect our design principles in your designs</li>
-          <li>Design holistic flows, not individual screens</li>
-          <li>Choose design patterns based on strong rationale</li>
-          <li>Reflect our content design principles in your UX writing</li>
-          <li>Contribute to our design system</li>
-          <li>Use layout, hierarchy, typography, color, and motion based on a strong rationale</li>
-          <li>When appropriate, align your designs with our brand guidelines</li>
-          <li>Create detailed prototypes to test microinteractions</li>
-          <li>Know which prototyping method best suits your situation</li>
-          <li>Evaluate your work by what's shipped, not what's in the design file</li>
-          <li>Work closely with your PM to decide on best way to scope your project</li>
-          <li>Make smart trade-offs that balance quality, speed of delivery, and learning—shipping is only the beginning</li>
+          <li>Understands the underlying motivations for our customers</li>
+          <li>Challenges and influences their team's understanding of the problem</li>
+          <li>Pairs with their researcher, analyst, or PM to do research</li>
+          <li>Talks to their customers regularly</li>
+          <li>Designs coherent systems, not just interfaces</li>
+          <li>Integrates their system with our broader product</li>
+          <li>Understands the technical system, worsk around constraints with engineers</li>
+          <li>Explores a broad range of solutions in Interconcepts and detailed designs</li>
+          <li>Involves cross-functional partners in explorations</li>
+          <li>Narrows down to the best solution using strong rationale</li>
+          <li>Reflects our design principles in their designs</li>
+          <li>Designs holistic flows, not individual screens</li>
+          <li>Chooses design patterns based on strong rationale</li>
+          <li>Reflects our content design principles in their UX writing</li>
+          <li>Contributes to our design system</li>
+          <li>Uses layout, hierarchy, typography, color, and motion based on a strong rationale</li>
+          <li>When appropriate, aligns their designs with our brand guidelines</li>
+          <li>Creates detailed prototypes to test microinteractions</li>
+          <li>Knows which prototyping method best suits their situation</li>
+          <li>Evaluates their work by what's shipped, not what's in the design file</li>
+          <li>Works closely with their PM to decide on best way to scope their project</li>
+          <li>Makes smart trade-offs that balance quality, speed of delivery, and learning—shipping is only the beginning</li>
           <li>Works with the team to define the metrics which can be used to evaluate the success of their efforts</li>
           <li>Analyzes project analytics post release and advocates for iterations which will improve outcomes</li>
-          <li>Consistently move projects forward with data over opinions.</li>
+          <li>Consistently moves projects forward with data over opinions.</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Consistently use the Design principles to make decisions</li>
-          <li>Proficiently run projects with the R&D toolkit</li>
-          <li>Live our values in your work and interactions</li>
-          <li>Consistently seek out opportunities to improve</li>
-          <li>Be resilient when you face setbacks</li>
-          <li>Set learning and personal development goals</li>
-          <li>Improve the health of your product team</li>
-          <li>Proactively share feedback with partners to help them develop</li>
-          <li>Help your team be more inclusive</li>
-          <li>Support recruiting or interviewing efforts where possible</li>
-          <li>Make the complex clear and concise in writing and speaking</li>
-          <li>Persuade and influence others with strong opinions, weakly held</li>
-          <li>Consistently give feedback in a way people can hear and apply</li>
-          <li>Be adaptive to how other people work and communicate</li>
-          <li>Work autonomously but know when to ask for help</li>
-          <li>Be proactive without waiting for direction from others</li>
-          <li>Plan your work, focusing on goals, not tasks</li>
-          <li>Balance effort versus reward</li>
-          <li>Make smart trade-offs</li>
-          <li>Co-lead your product team with your triad</li>
-          <li>Be generous with your time and feedback</li>
-          <li>Manage up</li>
+          <li>Consistently uses the Design principles to make decisions</li>
+          <li>Proficiently runs projects with the R&D toolkit</li>
+          <li>Lives our values in their work and interactions</li>
+          <li>Consistently seeks out opportunities to improve</li>
+          <li>Is resilient when they face setbacks</li>
+          <li>Sets learning and personal development goals</li>
+          <li>Improves the health of their product team</li>
+          <li>Proactively shares feedback with partners to help them develop</li>
+          <li>Helps their team be more inclusive</li>
+          <li>Supports recruiting or interviewing efforts where possible</li>
+          <li>Makes the complex clear and concise in writing and speaking</li>
+          <li>Persuades and influences others with strong opinions, weakly held</li>
+          <li>Consistently gives feedback in a way people can hear and apply</li>
+          <li>Is adaptive to how other people work and communicate</li>
+          <li>Works autonomously but knows when to ask for help</li>
+          <li>Is proactive without waiting for direction from others</li>
+          <li>Plans their work, focusing on goals, not tasks</li>
+          <li>Balances effort versus reward</li>
+          <li>Makes smart trade-offs</li>
+          <li>Co-leads their product team with their triad</li>
+          <li>Is generous with their time and feedback</li>
+          <li>Manages up</li>
         </ul>
       </td>
     </tr>
@@ -294,7 +294,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Manages complex projects mostly autonomously</li>
           <li>Comfortable in solving complex problems</li>
           <li>Major contributor to team roadmap</li>
-          <li>Co-leading their team with their PM and EM</li>
+          <li>Co-leads their team with their PM and EM</li>
           <li>Eligible for entry to the manager track</li>
         </ul>
       </td>
@@ -307,70 +307,70 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Drive execution for business within team
+          Drives execution for business within team
         </div>
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Leading team culture within triad
+          Leads team culture within triad
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
       <td class="behaviors">
         <ul>
-          <li>Show deep understanding of your team’s products and competitors in your solution design</li>
-          <li>Actively seek new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
-          <li>Leverage knowledge from Sales and Support to better understand and serve customers</li>
-          <li>Grow your influence on the future vision for your product area</li>
-          <li>Actively plan for how your designs will help us surpass our competitors</li>
-          <li>Take ownership of your team reaching business outcomes</li>
-          <li>Pair with your Product Marketing Manager to influence how you bring your product to market</li>
+          <li>Shows deep understanding of their team’s products and competitors in their solution design</li>
+          <li>Actively seeks new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
+          <li>Leverages knowledge from Sales and Support to better understand and serve customers</li>
+          <li>Grows their influence on the future vision for their product area</li>
+          <li>Actively plans for how their designs will help us surpass our competitors</li>
+          <li>Takes ownership of their team reaching business outcomes</li>
+          <li>Pairs with their Product Marketing Manager to influence how they bring their product to market</li>
           <li>Effectively uses product analytics to identify how products can be altered to deliver better outcomes for the business</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Understand the underlying motivations for our customers</li>
-          <li>Challenge and influence your team's understanding of the problem</li>
-          <li>Lead quantitative and qualitative research</li>
-          <li>Solve complex system design challenges</li>
-          <li>Diverge and converge quickly and effectively</li>
-          <li>Practice first principles thinking for larger projects or when innovation is a requirement</li>
-          <li>Design clear and elegant interfaces for complex systems</li>
-          <li>Refine the details of interaction design to achieve a high level of polish</li>
-          <li>Acting as a steward for our design system</li>
-          <li>Design interfaces that are functional, beautiful, and delightful</li>
-          <li>Raise the visual design bar in a way that it creates business value</li>
-          <li>Pair with an engineer to find design solutions through functional prototypes</li>
-          <li>Improve the way your team ships product</li>
-          <li>Proficient in defining and evaluating metrics which can be used to analyze the effectiveness of their solutions</li>
+          <li>Understands the underlying motivations for our customers</li>
+          <li>Challenges and influences their team's understanding of the problem</li>
+          <li>Leads quantitative and qualitative research</li>
+          <li>Solves complex system design challenges</li>
+          <li>Diverges and converges quickly and effectively</li>
+          <li>Practices first principles thinking for larger projects or when innovation is a requirement</li>
+          <li>Designs clear and elegant interfaces for complex systems</li>
+          <li>Refines the details of interaction design to achieve a high level of polish</li>
+          <li>Acts as a steward for our design system</li>
+          <li>Designs interfaces that are functional, beautiful, and delightful</li>
+          <li>Raises the visual design bar in a way that it creates business value</li>
+          <li>Pairs with an engineer to find design solutions through functional prototypes</li>
+          <li>Improves the way their team ships product</li>
+          <li>Proficients in defining and evaluating metrics which can be used to analyze the effectiveness of their solutions</li>
           <li>Models moving projects forward with data over opinions.</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Role model our principles and values within your team</li>
+          <li>Role model for our principles and values within their team</li>
           <li>Is a person who other design team members proactively reach out to for feedback and mentorship</li>
-          <li>Identify opportunities to refine our principles and values</li>
-          <li>Consistently seek out opportunities to improve your team or group</li>
-          <li>Know and manage your triggers for fixed mindset</li>
-          <li>Actively seek out and apply lessons and inspiration from the success of others</li>
-          <li>Proactively motivate partners by sharing insightful and relevant feedback</li>
-          <li>Co-own the health and inclusivity of your product team</li>
-          <li>Share your ideas with the industry by writing or talking publicly</li>
-          <li>Support Sourcegraph events</li>
-          <li>Use storytelling to communicate your work in an engaging way</li>
-          <li>Anticipate feedback to address it proactively</li>
-          <li>Communicate effectively with group and org leaders to influence their thinking and decisions</li>
-          <li>Actively help your triad and team align</li>
-          <li>Be decisive to make progress, not just take action</li>
-          <li>Drive resolving dependencies with others</li>
-          <li>Maximize opportunities: when needed, go beyond the project and the role</li>
-          <li>Raise problems when you see them</li>
-          <li>Own your team’s work, consistently seeking to provide more value</li>
-          <li>Work beyond design, within and across teams, peers, and partners to ensure your team delivers high-quality, impactful results</li>
-          <li>Identify and anticipate risks, proactively develop solutions</li>
+          <li>Identifies opportunities to refine our principles and values</li>
+          <li>Consistently seeks out opportunities to improve their team or group</li>
+          <li>Knows and manages their triggers for fixed mindset</li>
+          <li>Actively seeks out and applies lessons and inspiration from the success of others</li>
+          <li>Proactively motivates partners by sharing insightful and relevant feedback</li>
+          <li>Co-owns the health and inclusivity of their product team</li>
+          <li>Shares their ideas with the industry by writing or talking publicly</li>
+          <li>Supports Sourcegraph events</li>
+          <li>Uses storytelling to communicate their work in an engaging way</li>
+          <li>Anticipates feedback to address it proactively</li>
+          <li>Communicates effectively with group and org leaders to influence their thinking and decisions</li>
+          <li>Actively helps their triad and team align</li>
+          <li>Is decisive to make progress, not just take action</li>
+          <li>Drives resolving dependencies with others</li>
+          <li>Maximizes opportunities: when needed, goes beyond the project and the role</li>
+          <li>Raises problems when they see them</li>
+          <li>Owns their team’s work, consistently seeking to provide more value</li>
+          <li>Works beyond design, within and across teams, peers, and partners to ensure their team delivers high-quality, impactful results</li>
+          <li>Identifies and anticipates risks, proactively develops solutions</li>
           <li>Promotes accountability for design efforts by helping other designers define and use metrics to analyze results of their projects</li>
           <li>Shares a long-term vision that influences the team’s roadmap.</li>
         </ul>
@@ -399,12 +399,12 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="category-summaries-row">
       <td class="category-summary">
         <div class="wrapper">
-          Drive strategy across group (engineering)
+          Drives strategy across group (engineering)
         </div>
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Leading standards and key business initiatives across group
+          Leads standards and key business initiatives across group
         </div>
       </td>
       <td class="category-summary">
@@ -416,44 +416,44 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="behaviors-row">
       <td class="behaviors">
         <ul>
-          <li>Deeply understand your group’s products and competition</li>
-          <li>Identify gaps and opportunities in customer understanding for your group</li>
-          <li>Contribute to the group strategy</li>
-          <li>Collaborate with group leads to turn the group strategy into a product vision</li>
-          <li>Steer the group’s design execution toward reaching business outcomes</li>
-          <li>Actively influence how your group brings products to market</li>
+          <li>Deeply understands their group’s products and competition</li>
+          <li>Identifies gaps and opportunities in customer understanding for their group</li>
+          <li>Contributes to the group strategy</li>
+          <li>Collaborates with group leads to turn the group strategy into a product vision</li>
+          <li>Steers the group’s design execution toward reaching business outcomes</li>
+          <li>Actively influences how their group brings products to market</li>
           <li>Promotes accountability for design efforts via advocating and mentoring designers in the use of product metrics. Data over opinions.</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Identify new problems and opportunities for your group to solve</li>
-          <li>Question and fill knowledge gaps for our strategic projects</li>
-          <li>Design connected, modular systems that help us move faster in the future</li>
-          <li>Solve complex system design debt</li>
-          <li>Drive divergence and converge for strategic work at the group level</li>
-          <li>Drive improvements to our design system and tooling</li>
-          <li>Drive improvements to our product's overall visual design</li>
-          <li>Create or advocate for tools and resources to help the entire design team become better at prototyping</li>
-          <li>Improve the way your team ships product</li>
-          <li>Prioritize and help drive discussions on analytics solutions and systems with the goal of improving the utilization of data based decision making in the design process</li>
+          <li>Identifies new problems and opportunities for their group to solve</li>
+          <li>Questions and fills knowledge gaps for our strategic projects</li>
+          <li>Designs connected, modular systems that help us move faster in the future</li>
+          <li>Solves complex system design debt</li>
+          <li>Drives divergence and convergence for strategic work at the group level</li>
+          <li>Drives improvements to our design system and tooling</li>
+          <li>Drives improvements to our product's overall visual design</li>
+          <li>Creates or advocates for tools and resources to help the entire design team become better at prototyping</li>
+          <li>Improves the way their team ships product</li>
+          <li>Prioritizes and helps drive discussions on analytics solutions and systems with the goal of improving the utilization of data based decision making in the design process</li>
           <li>Models how to move complex work forward with data over opinions.</li>
         </ul>
       </td>
       <td class="behaviors">
         <ul>
-          <li>Role model our principles and values for other designers</li>
+          <li>Role model for our principles and values for other designers</li>
           <li>Contribute to refining our values, principles, and how we interpret them</li>
-          <li>Role model growth mindset for others, contributing to their - development</li>
-          <li>Co-own the health and inclusivity of the design team in your group</li>
-          <li>Mentor designers in your group and support their growth</li>
+          <li>Role model for growth mindset for others, contributing to their development</li>
+          <li>Co-owns the health and inclusivity of the design team in their group</li>
+          <li>Mentors designers in their group and supports their growth</li>
           <li>Highly effective communication skills. Writes and presents concisely and clearly.</li>
-          <li>Help teams in your group to get the right things done, fast</li>
-          <li>Resolve deadlock situations</li>
-          <li>Coordinate design work across multiple teams</li>
-          <li>Prioritize the most impactful initiatives to take on</li>
-          <li>Drive excellence in the group’s design execution</li>
-          <li>When necessary, lead design work across multiple teams and projects</li>
+          <li>Helps teams in their group to get the right things done, fast</li>
+          <li>Resolves deadlock situations</li>
+          <li>Coordinates design work across multiple teams</li>
+          <li>Prioritizes the most impactful initiatives to take on</li>
+          <li>Drives excellence in the group’s design execution</li>
+          <li>When necessary, leads design work across multiple teams and projects</li>
           <li>Shares a long-term vision that influences the group’s roadmap</li>
         </ul>
       </td>

--- a/content/departments/engineering/design/career-development.md
+++ b/content/departments/engineering/design/career-development.md
@@ -125,17 +125,17 @@ It’s important to understand that what is listed in the level descriptions are
     <tr class="category-summaries-row">
       <td class="category-summary">
         <div class="wrapper">
-          Understand the importance of strategy and delivering on it
+          Understands the importance of strategy and delivering on it
         </div>
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Autonomously deliver on assigned work
+          Autonomously delivers on assigned work
         </div>
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Functioning as a valued team member
+          Functions as a valued team member
         </div>
       </td>
     </tr>
@@ -204,7 +204,7 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
       <td class="category-summary">
         <div class="wrapper">
-          Independently driving key work with team
+          Independently drives key work with team
         </div>
       </td>
       <td class="category-summary">

--- a/content/departments/engineering/design/career-development.md
+++ b/content/departments/engineering/design/career-development.md
@@ -9,108 +9,26 @@ There are currently six levels for designers at Sourcegraph. A level is composed
 <ul>
   <li>Strategy</li>
   <li>Execution</li>
-  <li>Teamwork and behaviors</li>
+  <li>Teamwork</li>
 </ul>
 It’s important to understand that what is listed in the level descriptions are examples, and not checkboxes for promotion. The expectation is that you demonstrate a level of impact consistent with each of the category descriptions for your level.
+
+## Levels
 
 <style>
   .container {
     --width: 1300px;
   }
-  .levels-table {
-    --proficiency-color: var(--sg-vivid-violet);
-    --execution-color: var(--sg-sky-blue);
-    --teamwork-color: var(--sg-vermillion);
-
-    table-layout: fixed;
-  }
-  .proficiency {
-    --category-color: var(--proficiency-color);
-  }
-  .execution {
-    --category-color: var(--execution-color);
-  }
-  .teamwork {
-    --category-color: var(--teamwork-color);
-  }
-  .levels-table :is(td, th) {
-    vertical-align: top;
-    background: white;
-  }
-  .levels-table [id] {
-    /* Account for sticky table header */
-    scroll-margin-top: calc(var(--header-height) + 2.25rem);
-  }
-  thead th:first-child {
-    width: 8ch;
-  }
-  thead th.category-title {
-    text-align: center;
-    border-color: white;
-    background: var(--category-color);
-  }
-  thead th:is(.proficiency, .teamwork) {
-    color: white;
-  }
-  /*
-  Repeat the category color as a border color after each category summary.
-  Safari doesn't respect different border colors below a cell spanning multiple columns,
-  so we need to draw borders on wrapper elements instead.
-  */
-  .levels-table .category-summaries-row {
-    border-top: none;
-  }
-  .levels-table .category-summary {
-    border-top: none;
-    padding: 0;
-  }
-  .category-summary > .wrapper {
-    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
-    width: 100%;
-    height: 100%;
-    padding: 6px 13px;
-    display: block;
-    border-top: 1px solid var(--category-color);
-  }
-  .level {
-    white-space: nowrap;
-  }
-  .levels-table td[colspan] {
-    text-align: center;
-  }
-  .levels-table td ul {
-     text-align: left;
-  }
-  .level-summary, .category-summaries-row {
-    font-style: italic;
-  }
-  .level-summary {
-    border-bottom: none !important;
-  }
-  .levels-table td.tbd {
-    vertical-align: middle;
-    text-align: left;
-    padding: 2.5rem;
-  }
-  /*
-  Safari doesn't make the IC6 row equal size automatically, so give it explicit height.
-  Note that min-height also doesn't work.
-  */
-  th#ic6 {
-    height: 11rem;
-  }
 </style>
-
-## Levels
 
 <table class="levels-table">
 
   <thead>
     <tr>
-      <th scope="col" class="sticky">Level</th>
-      <th scope="col" class="category-title proficiency sticky">Strategy</th>
-      <th scope="col" class="category-title execution sticky">Execution</th>
-      <th scope="col" class="category-title teamwork sticky">Teamwork and behaviors</th>
+      <th scope="col">Level</th>
+      <th scope="col" class="category-title">Strategy</th>
+      <th scope="col" class="category-title">Execution</th>
+      <th scope="col" class="category-title">Teamwork</th>
     </tr>
   </thead>
 
@@ -130,24 +48,24 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
     </tr>
     <tr class="category-summaries-row">
-      <td class="category-summary proficiency">
+      <td class="category-summary">
         <div class="wrapper">
           Learning what strategy is
         </div>
       </td>
-      <td class="category-summary execution">
+      <td class="category-summary">
         <div class="wrapper">
           Should be able to execute on essential design skills
         </div>
       </td>
-      <td class="category-summary teamwork">
+      <td class="category-summary">
         <div class="wrapper">
           Learning how to be on a team
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Understand your product</li>
           <li>Know our competitors, their solutions, and gaps</li>
@@ -158,7 +76,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Know the metrics and outcomes we aim for in your product area</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Learn from team how to understand customer and business problems</li>
           <li>Ask for and use existing research to inform your solutions</li>
@@ -172,7 +90,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Work closely with engineers to understand and work around constraints</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Know and learn to apply our Design principles</li>
           <li>Understand and apply our company values</li>
@@ -205,24 +123,24 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
     </tr>
     <tr class="category-summaries-row">
-      <td class="category-summary proficiency">
+      <td class="category-summary">
         <div class="wrapper">
           Understand the importance of strategy and delivering on it
         </div>
       </td>
-      <td class="category-summary execution">
+      <td class="category-summary">
         <div class="wrapper">
           Autonomously deliver on assigned work
         </div>
       </td>
-      <td class="category-summary teamwork">
+      <td class="category-summary">
         <div class="wrapper">
           Functioning as a valued team member
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Understand your product</li>
           <li>Know our competitors, their solutions, and gaps</li>
@@ -233,7 +151,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Know the metrics and outcomes we aim for in your product area</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Consistently leverage knowledge of your product area and competition to make decisions</li>
           <li>Actively seek out new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
@@ -246,7 +164,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Understands the value of makring decisions with data over opinions.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Know and learn to apply our Design principles</li>
           <li>Understand and apply our company values</li>
@@ -279,24 +197,24 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
     </tr>
     <tr class="category-summaries-row">
-      <td class="category-summary proficiency">
+      <td class="category-summary">
         <div class="wrapper">
           Starting to contribute to strategy work within team
         </div>
       </td>
-      <td class="category-summary execution">
+      <td class="category-summary">
         <div class="wrapper">
           Independently driving key work with team
         </div>
       </td>
-      <td class="category-summary teamwork">
+      <td class="category-summary">
         <div class="wrapper">
           Part of the connective tissue within the team
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Consistently leverage knowledge of your product area and competition to make decisions</li>
           <li>Actively seek new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
@@ -309,7 +227,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Begins to utilizes metrics to analyze the results of their projects and discover where they can be improved</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Understand the underlying motivations for our customers</li>
           <li>Challenge and influence your team's understanding of the problem</li>
@@ -338,7 +256,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Consistently move projects forward with data over opinions.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Consistently use the Design principles to make decisions</li>
           <li>Proficiently run projects with the R&D toolkit</li>
@@ -382,24 +300,24 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
     </tr>
     <tr class="category-summaries-row">
-      <td class="category-summary proficiency">
+      <td class="category-summary">
         <div class="wrapper">
           Drives strategy with triad
         </div>
       </td>
-      <td class="category-summary execution">
+      <td class="category-summary">
         <div class="wrapper">
           Drive execution for business within team
         </div>
       </td>
-      <td class="category-summary teamwork">
+      <td class="category-summary">
         <div class="wrapper">
           Leading team culture within triad
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Show deep understanding of your team’s products and competitors in your solution design</li>
           <li>Actively seek new and deeper insights about customers to deeply understand their needs, make decisions, and increase confidence</li>
@@ -411,7 +329,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Effectively uses product analytics to identify how products can be altered to deliver better outcomes for the business</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Understand the underlying motivations for our customers</li>
           <li>Challenge and influence your team's understanding of the problem</li>
@@ -430,7 +348,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Models moving projects forward with data over opinions.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Role model our principles and values within your team</li>
           <li>Is a person who other design team members proactively reach out to for feedback and mentorship</li>
@@ -479,24 +397,24 @@ It’s important to understand that what is listed in the level descriptions are
       </td>
     </tr>
     <tr class="category-summaries-row">
-      <td class="category-summary proficiency">
+      <td class="category-summary">
         <div class="wrapper">
           Drive strategy across group (engineering)
         </div>
       </td>
-      <td class="category-summary execution">
+      <td class="category-summary">
         <div class="wrapper">
           Leading standards and key business initiatives across group
         </div>
       </td>
-      <td class="category-summary teamwork">
+      <td class="category-summary">
         <div class="wrapper">
           Helps to establish and model team behaviors across the group
         </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Deeply understand your group’s products and competition</li>
           <li>Identify gaps and opportunities in customer understanding for your group</li>
@@ -507,7 +425,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Promotes accountability for design efforts via advocating and mentoring designers in the use of product metrics. Data over opinions.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Identify new problems and opportunities for your group to solve</li>
           <li>Question and fill knowledge gaps for our strategic projects</li>
@@ -522,7 +440,7 @@ It’s important to understand that what is listed in the level descriptions are
           <li>Models how to move complex work forward with data over opinions.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Role model our principles and values for other designers</li>
           <li>Contribute to refining our values, principles, and how we interpret them</li>

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -55,8 +55,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th scope="col" class="category-title">Proficiency</th>
       <th scope="col" class="category-title">Execution</th>
       <th scope="col" class="category-title">Teamwork</th>
-      <th scope="col" class="category-title">Pre-requisites</th>
-      <th scope="col" class="category-title">Years Experience</th>
       <th scope="col" class="category-title">Additional Notes/Key Points/Examples</th>
     </tr>
   </thead>
@@ -67,8 +65,12 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
     </tr>
     <tr>
-      <td class="level-summary" colspan="6">
-          An engineer focused on learning, growth, and establishing themselves as a contributing teammate. Entry level.
+      <td class="level-summary" colspan="4">
+          <p>An engineer focused on learning, growth, and establishing themselves as a contributing teammate. Entry level.</p>
+          <ul>
+            <li><strong>Prerequisites:</strong> Minimum relevant bachelor degree, or equivalent related experience.</li>
+            <li><strong>Years of experience:</strong> Typically 0-2</li>
+          </ul>
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -103,12 +105,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
         </ul>
       </td>
       <td class="behaviors">
-        Minimum relevant bachelor degree, or equivalent related experience.
-      </td>
-      <td class="behaviors">
-        Typically 0-2 years relevant experience.
-      </td>
-      <td class="behaviors">
         <ul>
           <li>Entry level for professional careers. Still learning the role.</li>
           <li>Core skills limited; requires detailed direction.</li>
@@ -122,8 +118,12 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
     </tr>
     <tr>
-      <td class="level-summary" colspan="6">
-          A solid and autonomous contributor, executor, and collaborator. Completes assignments which have clear, near-term objectives. Operates independently to perform routine tasks.
+      <td class="level-summary" colspan="4">
+          <p>A solid and autonomous contributor, executor, and collaborator. Completes assignments which have clear, near-term objectives. Operates independently to perform routine tasks.</p>
+          <ul>
+            <li><strong>Prerequisites:</strong> Knows the organization and understands the group’s basic terminology and techniques.</li>
+            <li><strong>Years of experience:</strong> Typically 2-5</li>
+          </ul>
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -182,12 +182,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
         </ul>
       </td>
       <td class="behaviors">
-        Knows the organization and understands the group’s basic terminology and techniques.
-      </td>
-      <td class="behaviors">
-        Typically 2-5 years relevant experience.
-      </td>
-      <td class="behaviors">
         <ul>
           <li>Task oriented, but gaining/demonstrating independence.Core skills functional.</li>
           <li>Requires some direction.</li>
@@ -201,8 +195,12 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
     </tr>
     <tr>
-      <td class="level-summary" colspan="6">
-        An experienced, strong individual contributor (Senior equivalent). Represents an area of specialization within the organization. Independently resolves complex problems. Contributes to cross-functional projects. Trains others.
+      <td class="level-summary" colspan="4">
+        <p>An experienced, strong individual contributor (Senior equivalent). Represents an area of specialization within the organization. Independently resolves complex problems. Contributes to cross-functional projects. Trains others.</p>
+        <ul>
+          <li><strong>Prerequisites:</strong> Key differentiator from IC2 is the ability to prioritize and work under broad direction. Can resolve new and complex problems within an area of specialization.</li>
+          <li><strong>Years of experience:</strong> Typically 5-8</li>
+        </ul>
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -270,12 +268,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
         </ul>
       </td>
       <td class="behaviors">
-        Key differentiator from IC2 is the ability to prioritize and work under broad direction. Can resolve new and complex problems within an area of specialization.
-      </td>
-      <td class="behaviors">
-        Typically 5-8 years relevant experience.
-      </td>
-      <td class="behaviors">
         <ul>
           <li>Problem solver. Operates autonomously.</li>
           <li>Strong core skills, requires minimal direction.</li>
@@ -288,8 +280,12 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
     </tr>
     <tr>
-      <td class="level-summary" colspan="6">
-        A particularly experienced, impactful contributor. Brings domain expertise to complex projects. Role requires contribution outside the direct area of responsibility. Leads interdepartmental projects.
+      <td class="level-summary" colspan="4">
+        <p>A particularly experienced, impactful contributor. Brings domain expertise to complex projects. Role requires contribution outside the direct area of responsibility. Leads interdepartmental projects.</p>
+        <ul>
+          <li><strong>Prerequisites:</strong> Has domain-specific knowledge and expertise. Key differentiator from IC3 is the established track record of resolving complex problems and the demonstrated ability to lead cross-functional projects.</li>
+          <li><strong>Years of experience:</strong> Typically 8+</li>
+        </ul>
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -333,12 +329,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
         </ul>
       </td>
       <td class="behaviors">
-      Has domain-specific knowledge and expertise. Key differentiator from IC3 is the established track record of resolving complex problems and the demonstrated ability to lead cross-functional projects.
-      </td>
-      <td class="behaviors">
-      Typically 8+ years relevant experience.
-      </td>
-      <td class="behaviors">
         <ul>
           <li>“Go-to” expert. Usually project leader.</li>
           <li>Contributes outside direct area of responsibility.</li>
@@ -352,8 +342,12 @@ To learn more, see ["Considerations for promotion" in our talent review process]
       <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
     </tr>
     <tr>
-      <td class="level-summary" colspan="6">
-          A Staff Engineer, responsible for identifying impactful problems aligned with business objectives that need to be solved and then driving the solution to those problems. Provides innovative breakthroughs to toughest challenges. Influences management on strategic direction. Will have an impact on multiple organizations, countries/regions and disciplines as well as outside companies. Not all career paths include level 5.
+      <td class="level-summary" colspan="4">
+          <p>A Staff Engineer, responsible for identifying impactful problems aligned with business objectives that need to be solved and then driving the solution to those problems. Provides innovative breakthroughs to toughest challenges. Influences management on strategic direction. Will have an impact on multiple organizations, countries/regions and disciplines as well as outside companies. Not all career paths include level 5.</p>
+          <ul>
+            <li><strong>Prerequisites:</strong> Has unique knowledge and the ability to apply that knowledge to a broader context.</li>
+            <li><strong>Years of experience:</strong> Not essential</li>
+          </ul>
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -389,12 +383,6 @@ To learn more, see ["Considerations for promotion" in our talent review process]
         </ul>
       </td>
       <td class="behaviors">
-        Has unique knowledge and the ability to apply that knowledge to a broader context.
-      </td>
-      <td class="behaviors">
-        Years of experience not essential.
-      </td>
-      <td class="behaviors">
         <ul>
           <li>Deep expertise/unique knowledge.Broad impact, broad context.</li>
           <li>Provides breakthroughs & requires no direction.</li>
@@ -406,7 +394,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <!-- IC6 -->
     <tr>
       <th id="ic6" scope="row" class="level"><a class="anchor" href="#ic6"></a><abbr title="Individual Contributor">IC</abbr>6</th>
-      <td colspan="6" class="tbd">
+      <td colspan="4" class="tbd">
         <p>
           Senior Staff Engineer. We haven't yet finalized the description of this level at Sourcegraph.
         </p>

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -39,113 +39,25 @@ To learn more, see ["Considerations for promotion" in our talent review process]
 
 ![IC Framework Axis](https://storage.googleapis.com/sourcegraph-assets/Eng%20IC%20Career%20Framework%20Axis.png)
 
+## Levels
+
 <style>
   .container {
     --width: 1300px;
   }
-  .levels-table {
-    --proficiency-color: var(--sg-vivid-violet);
-    --execution-color: var(--sg-sky-blue);
-    --teamwork-color: var(--sg-vermillion);
-
-    table-layout: fixed;
-  }
-  .proficiency {
-    --category-color: var(--proficiency-color);
-  }
-  .execution {
-    --category-color: var(--execution-color);
-  }
-  .teamwork {
-    --category-color: var(--teamwork-color);
-  }
-  .prerequisites {
-    --category-color: var(--proficiency-color);
-  }
-  .years-experience {
-    --category-color: var(--execution-color);
-  }
-  .additional-notes {
-    --category-color: var(--teamwork-color);
-  }
-  .levels-table :is(td, th) {
-    vertical-align: top;
-    background: white;
-  }
-  .levels-table [id] {
-    /* Account for sticky table header */
-    scroll-margin-top: calc(var(--header-height) + 2.25rem);
-  }
-  thead th:first-child {
-    width: 8ch;
-  }
-  thead th.category-title {
-    text-align: center;
-    border-color: white;
-    background: var(--category-color);
-  }
-  thead th:is(.proficiency, .teamwork, .prerequisites, .additional-notes) {
-    color: white;
-  }
-  /*
-  Repeat the category color as a border color after each category summary.
-  Safari doesn't respect different border colors below a cell spanning multiple columns,
-  so we need to draw borders on wrapper elements instead.
-  */
-  .levels-table .category-summaries-row {
-    border-top: none;
-  }
-  .levels-table .category-summary {
-    border-top: none;
-    padding: 0;
-  }
-  .category-summary > .wrapper {
-    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
-    width: 100%;
-    height: 100%;
-    padding: 6px 13px;
-    display: block;
-    border-top: 1px solid var(--category-color);
-  }
-  .level {
-    white-space: nowrap;
-  }
-  .levels-table td[colspan] {
-    text-align: center;
-  }
-  .level-summary, .category-summaries-row {
-    font-style: italic;
-  }
-  .level-summary {
-    border-bottom: none !important;
-  }
-  .levels-table td.tbd {
-    vertical-align: middle;
-    text-align: left;
-    padding: 2.5rem;
-  }
-  /*
-  Safari doesn't make the IC6 row equal size automatically, so give it explicit height.
-  Note that min-height also doesn't work.
-  */
-  th#ic6 {
-    height: 11rem;
-  }
 </style>
-
-## Levels
 
 <table class="levels-table">
 
   <thead>
     <tr>
-      <th scope="col" class="sticky">Level</th>
-      <th scope="col" class="category-title proficiency sticky">Proficiency</th>
-      <th scope="col" class="category-title execution sticky">Execution</th>
-      <th scope="col" class="category-title teamwork sticky">Teamwork</th>
-      <th scope="col" class="category-title prerequisites sticky">Pre-requisites</th>
-      <th scope="col" class="category-title years-experience sticky">Years Experience</th>
-      <th scope="col" class="category-title additional-notes sticky">Additional Notes/Key Points/Examples</th>
+      <th scope="col">Level</th>
+      <th scope="col" class="category-title">Proficiency</th>
+      <th scope="col" class="category-title">Execution</th>
+      <th scope="col" class="category-title">Teamwork</th>
+      <th scope="col" class="category-title">Pre-requisites</th>
+      <th scope="col" class="category-title">Years Experience</th>
+      <th scope="col" class="category-title">Additional Notes/Key Points/Examples</th>
     </tr>
   </thead>
 
@@ -154,16 +66,14 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <tr>
       <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
     </tr>
-    <tr class="category-summaries-row">
-      <td class="category-summary" colspan="6">
-        <div class="wrapper">
+    <tr>
+      <td class="level-summary" colspan="6">
           An engineer focused on learning, growth, and establishing themselves as a contributing teammate.
           Entry level.
-        </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Contributes technical solutions to well-scoped tasks, with guidance.</li>
           <li>Demonstrates the essentials needed to do work in their domain.</li>
@@ -174,7 +84,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Understands how Sourcegraoh works @ the highest level.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Manages their own time and wellbeing, meeting commitments while finding balance and creating rest.</li>
           <li>Asks for guidance in unfamiliar areas or for underspecified tasks. Speaks up if not comfortable with the scopes or timelines.</li>
@@ -183,7 +93,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Eager to learn and solve problems.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Actively asks teammates questions to seek feedback and clarify, including cross-functionally (e.g. Design and Product).</li>
           <li>Participates and demonstrates curiosity in team meetings.</li>
@@ -193,13 +103,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Reacts well to feedback and is able to quickly learn from it.</li>
         </ul>
       </td>
-      <td class="behaviors prerequisites">
+      <td class="behaviors">
         Minimum relevant bachelor degree, or equivalent related experience.
       </td>
-      <td class="behaviors years-experience">
+      <td class="behaviors">
         Typically 0-2 years relevant experience.
       </td>
-      <td class="behaviors additional-notes">
+      <td class="behaviors">
         <ul>
           <li>Entry level for professional careers. Still learning the role.</li>
           <li>Core skills limited; requires detailed direction.</li>
@@ -212,15 +122,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <tr>
       <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
     </tr>
-    <tr class="category-summaries-row">
-      <td class="category-summary" colspan="6">
-        <div class="wrapper">
+    <tr>
+      <td class="level-summary" colspan="6">
           A solid and autonomous contributor, executor, and collaborator.<br />Completes assignments which have clear, near-term objectives. Operates independently to perform routine tasks.
-        </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>
             Proficient in core technical skills of their primary focus area, while
@@ -234,7 +142,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Able to manage their time appropriately to encourage efficiency.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Breaks down tasks, plans, estimates and cuts scope as appropriate to deliver reliably.</li>
           <li>Prioritizes their own work in alignment with team goals.</li>
@@ -245,7 +153,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Self-sufficient and able to deliver without much guidance including being able to seek and lead smaller projects.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>
             Communicates clearly (in meetings and asynchronously), escalating blockers
@@ -274,13 +182,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Upholds team culture and levels the technical proficiency on the team up.</li>
         </ul>
       </td>
-      <td class="behaviors prerequisites">
+      <td class="behaviors">
         Knows the organization and understands the group’s basic terminology and techniques.
       </td>
-      <td class="behaviors years-experience">
+      <td class="behaviors">
         Typically 2-5 years relevant experience.
       </td>
-      <td class="behaviors additional-notes">
+      <td class="behaviors">
         <ul>
           <li>Task oriented, but gaining/demonstrating independence.Core skills functional.</li>
           <li>Requires some direction.</li>
@@ -293,15 +201,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <tr>
       <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
     </tr>
-    <tr class="category-summaries-row">
-      <td class="category-summary" colspan="6">
-        <div class="wrapper">
+    <tr>
+      <td class="level-summary" colspan="6">
         An experienced, strong individual contributor (Senior equivalent).<br />Represents an area of specialization within the organization. Independently resolves complex problems. Contributes to cross-functional projects. Trains others.
-        </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>
             Expert in their domain: deep understanding of their team’s code, debugs
@@ -330,7 +236,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Exposed and comfortable in leading larger projects.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Independently scopes and implements solutions to complex, loosely-defined problems.</li>
           <li>
@@ -353,7 +259,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Communicates progress and status updates to stakeholders.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Communicates technical issues and decisions clearly, brings clarity to discussions and helps drive them forward.</li>
           <li>Routinely drives improvements in team/company processes (retros, testing, on-call, planning, etc.)</li>
@@ -364,13 +270,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Actively unblocks teammates.</li>
         </ul>
       </td>
-      <td class="behaviors prerequisites">
+      <td class="behaviors">
         Key differentiator from IC2 is the ability to prioritize and work under broad direction. Can resolve new and complex problems within an area of specialization.
       </td>
-      <td class="behaviors years-experience">
+      <td class="behaviors">
         Typically 5-8 years relevant experience.
       </td>
-      <td class="behaviors additional-notes">
+      <td class="behaviors">
         <ul>
           <li>Problem solver. Operates autonomously.</li>
           <li>Strong core skills, requires minimal direction.</li>
@@ -382,15 +288,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <tr>
       <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
     </tr>
-    <tr class="category-summaries-row">
-      <td class="category-summary" colspan="6">
-        <div class="wrapper">
+    <tr>
+      <td class="level-summary" colspan="6">
         A particularly experienced, impactful contributor.<br />Brings domain expertise to complex projects. Role requires contribution outside the direct area of responsibility. Leads interdepartmental projects.
-        </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>High-quality technical decision making, leading team-sized tasks that affect one or more complex systems or mission-critical areas.</li>
           <li>Consistently incorporates non-technical factors into technical decisions and weights them appropriately.</li>
@@ -408,7 +312,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Able to make trade-offs knowing the impact that it will have.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Supports the EM and PM in ensuring that the team is always working on the right problems with the right scope given higher level goals, and that the team is reliably delivering on time.</li>
           <li>Accountable for the team's work quality and professionalism to ensure the team delivers high quality and work diligently to limit the problems for our customers or other teams.</li>
@@ -420,7 +324,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Identifies problems that need to be solved and executes on them.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Effectively able to convince and challenge teammates and cross-functional stakeholders using valid expertise and respectful communication.</li>
           <li>Actively seeks dissenting opinions, disconfirming evidence, etc.</li>
@@ -429,13 +333,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Ability to delegate and clearly communicate capacity needed to work on those areas.</li>
         </ul>
       </td>
-      <td class="behaviors prerequisites">
+      <td class="behaviors">
       Has domain-specific knowledge and expertise. Key differentiator from IC3 is the established track record of resolving complex problems and the demonstrated ability to lead cross-functional projects.
       </td>
-      <td class="behaviors years-experience">
+      <td class="behaviors">
       Typically 8+ years relevant experience.
       </td>
-      <td class="behaviors additional-notes">
+      <td class="behaviors">
         <ul>
           <li>“Go-to” expert. Usually project leader.</li>
           <li>Contributes outside direct area of responsibility.</li>
@@ -448,15 +352,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     <tr>
       <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
     </tr>
-    <tr class="category-summaries-row">
-      <td class="category-summary" colspan="6">
-        <div class="wrapper">
+    <tr>
+      <td class="level-summary" colspan="6">
           A Staff Engineer, responsible for identifying impactful problems aligned with business objectives that need to be solved and then driving the solution to those problems.<br />Provides innovative breakthroughs to toughest challenges. Influences management on strategic direction. Will have an impact on multiple organizations, countries/regions and disciplines as well as outside companies. Not all career paths include level 5.
-        </div>
       </td>
     </tr>
     <tr class="behaviors-row">
-      <td class="behaviors proficiency">
+      <td class="behaviors">
         <ul>
           <li>Sets the technical vision for their team, and influences the broader technical vision.</li>
           <li>Initiates and drives projects with broad/deep impact that enable higher quality work.</li>
@@ -466,7 +368,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Responsible for working on the right thing.</li>
         </ul>
       </td>
-      <td class="behaviors execution">
+      <td class="behaviors">
         <ul>
           <li>Proactively identifies areas for improvement across engineering. Suggests process and methodology improvements.</li>
           <li>Works closely with Engineering/Product leadership to validate alignment of team roadmaps within their org.</li>
@@ -477,7 +379,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Accountable for the team's work quality and professionalism to ensure the team delivers high quality and work diligently to limit the problems for our customers or other teams.</li>
         </ul>
       </td>
-      <td class="behaviors teamwork">
+      <td class="behaviors">
         <ul>
           <li>Provides technical expertise internally and externally, informing what can be achieved.</li>
           <li>Regularly shares knowledge to influence and up-level large and/or senior audiences.</li>
@@ -487,13 +389,13 @@ To learn more, see ["Considerations for promotion" in our talent review process]
           <li>Proactively provides feedback and flags concerns that are going on within the org.</li>
         </ul>
       </td>
-      <td class="behaviors prerequities">
+      <td class="behaviors">
         Has unique knowledge and the ability to apply that knowledge to a broader context.
       </td>
-      <td class="behaviors years-experience">
+      <td class="behaviors">
         Years of experience not essential.
       </td>
-      <td class="behaviors additional-notes">
+      <td class="behaviors">
         <ul>
           <li>Deep expertise/unique knowledge.Broad impact, broad context.</li>
           <li>Provides breakthroughs & requires no direction.</li>

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -68,8 +68,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td class="level-summary" colspan="6">
-          An engineer focused on learning, growth, and establishing themselves as a contributing teammate.
-          Entry level.
+          An engineer focused on learning, growth, and establishing themselves as a contributing teammate. Entry level.
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -124,7 +123,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td class="level-summary" colspan="6">
-          A solid and autonomous contributor, executor, and collaborator.<br />Completes assignments which have clear, near-term objectives. Operates independently to perform routine tasks.
+          A solid and autonomous contributor, executor, and collaborator. Completes assignments which have clear, near-term objectives. Operates independently to perform routine tasks.
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -203,7 +202,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td class="level-summary" colspan="6">
-        An experienced, strong individual contributor (Senior equivalent).<br />Represents an area of specialization within the organization. Independently resolves complex problems. Contributes to cross-functional projects. Trains others.
+        An experienced, strong individual contributor (Senior equivalent). Represents an area of specialization within the organization. Independently resolves complex problems. Contributes to cross-functional projects. Trains others.
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -290,7 +289,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td class="level-summary" colspan="6">
-        A particularly experienced, impactful contributor.<br />Brings domain expertise to complex projects. Role requires contribution outside the direct area of responsibility. Leads interdepartmental projects.
+        A particularly experienced, impactful contributor. Brings domain expertise to complex projects. Role requires contribution outside the direct area of responsibility. Leads interdepartmental projects.
       </td>
     </tr>
     <tr class="behaviors-row">
@@ -354,7 +353,7 @@ To learn more, see ["Considerations for promotion" in our talent review process]
     </tr>
     <tr>
       <td class="level-summary" colspan="6">
-          A Staff Engineer, responsible for identifying impactful problems aligned with business objectives that need to be solved and then driving the solution to those problems.<br />Provides innovative breakthroughs to toughest challenges. Influences management on strategic direction. Will have an impact on multiple organizations, countries/regions and disciplines as well as outside companies. Not all career paths include level 5.
+          A Staff Engineer, responsible for identifying impactful problems aligned with business objectives that need to be solved and then driving the solution to those problems. Provides innovative breakthroughs to toughest challenges. Influences management on strategic direction. Will have an impact on multiple organizations, countries/regions and disciplines as well as outside companies. Not all career paths include level 5.
       </td>
     </tr>
     <tr class="behaviors-row">

--- a/content/departments/engineering/product/career-development/framework.md
+++ b/content/departments/engineering/product/career-development/framework.md
@@ -1,366 +1,195 @@
 # Sourcegraph product career development framework
 
+## Levels
+
 <style>
   .container {
     --width: 1300px;
   }
-  .levels-table {
-    --ic1-color: var(--sg-sky-blue);
-    --ic2-color: var(--sg-vivid-violet);
-    --ic3-color: var(--sg-mint);
-    --ic4-color: var(--sg-vermillion);
-    --ic5-color: var(--sg-lemon);
-
-    table-layout: fixed;
-  }
-  .ic1 {
-    --level-color: var(--ic1-color);
-  }
-  .ic2 {
-    --level-color: var(--ic2-color);
-  }
-  .ic3 {
-    --level-color: var(--ic3-color);
-  }
-  .ic4 {
-    --level-color: var(--ic4-color);
-  }
-  .ic5 {
-    --level-color: var(--ic5-color);
-  }
-  .levels-table :is(td, th) {
-    vertical-align: top;
-    background: white;
-  }
-  .levels-table [id] {
-    /* Account for sticky table header */
-    scroll-margin-top: calc(var(--header-height) + 2.25rem);
-  }
-  thead th.level-title {
-    text-align: center;
-    border-color: white;
-    background: var(--level-color);
-  }
-   th.category{
-    background: var(--sg-light-gray);
-    text-align: center;
-  }
-  thead th:is(.ic2, .ic4) {
-    color: white;
-  }
-  /*
-  Repeat the level color as a border color for each category deatil.
-  Safari doesn't respect different border colors below a cell spanning multiple columns,
-  so we need to draw borders on wrapper elements instead.
-  */
-  .levels-table .category-detail {
-    border-top: none;
-    padding: 0;
-  }
-  .category-detail > .wrapper {
-    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
-    width: 100%;
-    height: 100%;
-    padding: 6px 13px;
-    display: block;
-    border-top: 1px solid var(--level-color);
-  }
-  .levels-table td[colspan] {
-    text-align: center;
-  }
-  .category-summary {
-    font-style: italic;
-    border-bottom: none !important;
-  }
 </style>
-
-## Levels
 
 <table class="levels-table">
 
   <thead>
     <tr>
-      <!-- <th scope="col" class="sticky"></th> -->
-      <th scope="col" class="level-title ic1 sticky">IC1: Associate PM</th>
-      <th scope="col" class="level-title ic2 sticky">IC2: PM</th>
-      <th scope="col" class="level-title ic3 sticky">IC3: PM</th>
-      <th scope="col" class="level-title ic4 sticky">IC4: Senior PM</th>
-      <th scope="col" class="level-title ic5 sticky">IC5: Staff PM</th>
+      <th scope="col">Level</th>
+      <th scope="col" class="category-title">Business/GTM Strategy</th>
+      <th scope="col" class="category-title">Industry/Market Knowledge</th>
+      <th scope="col" class="category-title">Product Strategy</th>
+      <th scope="col" class="category-title">Developer/Technical Intuition</th>
+      <th scope="col" class="category-title">Maximizing Impact</th>
+      <th scope="col" class="category-title">Data-Driven</th>
+      <th scope="col" class="category-title">Collaboration</th>
+      <th scope="col" class="category-title">Mentorship and Coaching</th>
     </tr>
   </thead>
 
   <tbody>
-    <!-- General Overview -->
+    <!-- IC1 -->
     <tr>
-      <th class="category" colspan="5">General Overview</th>
+      <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
     </tr>
     <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-          An entry level PM who can execute on a highly scoped problem with strong support from engineering counterparts.
-        </div>
-      </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-          A junior PM capable of owning a small piece of a highly ambiguous project that impacts a specific feature within Sourcegraph.
-        </div>
-      </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          A mid-career PM who is confident driving an established feature or product from beginning to end.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          A PM capable of executing an ambiguous, cross-functional project to completion that shapes the future of Sourcegraph's business.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          A very experienced PM, capable of efficiently driving multiple cross-functional projects in a highly autonomous way while understanding the impact of their work to Sourcegraph and the broad market as a whole.
-        </div>
+      <td class="level-summary" colspan="8">
+        An entry level PM who can execute on a highly scoped problem with strong support from engineering counterparts; an Associate PM.
       </td>
     </tr>
-    <!-- Strategy/Proficiency -->
-    <th class="category" colspan="5">Strategy/Proficiency</th>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        Understands how Sourcegraph makes money and how our business KPIs measure the long-term success of the business.
+      </td>
+      <td class="behaviors">
+        Understands how the company's GTM strategy impacts the product experience.
+      </td>
+      <td class="behaviors">
+        Understands the role their product plays in the platform's vision and strategy.
+      </td>
+      <td class="behaviors">
+        Understands the technical constraints related to their product and uses that knowledge to correctly plan and scope their roadmap.
+      </td>
+      <td class="behaviors">
+        Defines goals, leads their team in prioritizing our work, and works with their team to execute tactically.
+      </td>
+      <td class="behaviors">
+        Understands the problem we are trying to solve based on existing research and can articulate this to others.
+      </td>
+      <td class="behaviors">
+        Conducts team meetings in a way that fosters effective team collaboration.
+      </td>
+      <td class="behaviors"></td>
+    </tr>
+    <!-- IC2 -->
     <tr>
-      <td colspan="5" class="category-summary">Business/GTM Strategy</td>
+      <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
     </tr>
     <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-          I understand how Sourcegraph makes money and how our business KPIs measure the long-term success of the business.
-        </div>
-      </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-        </div>
-      </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          I understand how the company's GTM strategy impacts the product experience.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          I partner with the GTM team to support GTM growth within existing features.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          I leverage new product opportunities to expand Sourcegraph into new GTM channels/markets and kickstart new levers of growth.
-        </div>
+      <td class="level-summary" colspan="8">
+        A junior PM capable of owning a small piece of a highly ambiguous project that impacts a specific feature within Sourcegraph.
       </td>
     </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors"></td>
+      <td class="behaviors">
+        Understands the category our product operates in and our key direct competitors. Understands the high-level problems our customers have and how Sourcegraph solves them.
+      </td>
+      <td class="behaviors">
+        Can derive their product's strategy based on the overall strategy and communicate in the open why we will or won't deliver on certain items.
+      </td>
+      <td class="behaviors"></td>
+      <td class="behaviors">
+        Incorporates user research, market/industry knowledge, and business goals in their prioritization of discovery and delivery efforts.
+      </td>
+      <td class="behaviors">
+        Understands the problem we are trying to solve and what information we'd need to validate it. Knows how to measure the success of an initiative.
+      </td>
+      <td class="behaviors">
+        Frequently shares work-in-progress and present updates on their product to everyone in the company.
+      </td>
+      <td class="behaviors"></td>
+    </tr>
+    <!-- IC3 -->
     <tr>
-      <td colspan="5" class="category-summary">Industry/Market Knowledge</td>
+      <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
     </tr>
     <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-        I understand the category that our product operates in and the key customer segments we target.
-        </div>
-      </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-        I understand the category our product operates in and our key direct competitors. I understand the high-level problems our customers have and how Sourcegraph solves them.
-        </div>
-      </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-        I understand the direct key competitors in our category and how we compare against them. I understand specific challenges our customers face and how our product(s) address these.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-        I understand direct and indirect competitors in our category, how we can compare and where we could invest to win. I have built relationships with key customers, understand their specific needs and work collaboratively with them to build solutions.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-        I understand and identify where there are opportunities in adjacent product categories, or creating new product categories that would benefit our business.
-        </div>
+      <td class="level-summary" colspan="8">
+        A mid-career PM who is confident driving an established feature or product from beginning to end.
       </td>
     </tr>
-    <tr>
-      <td colspan="5" class="category-summary">Product Strategy</td>
-    </tr>
-    <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-        I understand the role my product plays in the platform's vision and strategy.
-        </div>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        Understands how the company's GTM strategy impacts the product experience.
       </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-        I can derive my product's strategy based on the overall strategy and communicate in the open why we will or won't deliver on certain items.
-        </div>
+      <td class="behaviors">
+        Understands the direct key competitors in our category and how we compare against them. Understands specific challenges our customers face and how our product(s) address these.
       </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-        I drive the creation of my product's strategy based on the early and continuous feedback of and collaboration with stakeholders.
-        </div>
+      <td class="behaviors">
+        Drives the creation of their product's strategy based on the early and continuous feedback of and collaboration with stakeholders.
       </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-        I drive the long term vision of my product(s) and influence the overarching product vision. I create a strategy that identifies the key challenges we may face and how we overcome them to maximise the impact we have. I continue to iterate and adapt the strategy based on new input and communicate this transparently.
-        </div>
+      <td class="behaviors">
+        Considers how influential devs and dev communities will perceive their product and take that into account when planning their roadmap. Understands the technical aspects of their product and uses that knowledge to create a better product.
       </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-        I efficiently seek net-new product opportunities that expand Sourcegraph into new markets by exploring strategic opportunities to buy or partner with external companies.
-        </div>
+      <td class="behaviors">
+        With a scoped problem, is able to drive the creation and launch of an experience by working cross-team (i.e. product marketing) to create shared outcomes.
+      </td>
+      <td class="behaviors">
+        Understands the pros/cons of different research techniques and knows what to use to solve a particular question.
+      </td>
+      <td class="behaviors">
+        Is familiar with other teams' work and how it relates to their team's work. Works collaboratively with other teams when responsibilities overlap.
+      </td>
+      <td class="behaviors">
+        Recognizes their skill/knowledge gaps and seeks out mentors who can help them grow.
       </td>
     </tr>
+    <!-- IC4 -->
     <tr>
-      <td colspan="5" class="category-summary">Developer/Technical Intuition</td>
+      <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
     </tr>
     <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-        I understand the technical constraints related to my product, and I use that knowledge to correctly plan and scope my roadmap.
-        </div>
-      </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-        </div>
-      </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-        I consider how influential devs and dev communities will perceive my product and take that into account when planning my roadmap. I understand the technical aspects of my product and use that knowledge to create a better product.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-        I understand how influential devs and dev communities will perceive my product, and I effectively communicate with them directly in a way that gains us new knowledge and/or respect. I deeply understand the technical aspects of my product and use that knowledge to create a better product that meets particularly complex technical requirements.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-        I am known and respected by influential devs and dev communities in my product area, and I use that to increase the odds of success for my product. I use my technical intuition to create a better product in ways that rely on brand new approaches and/or my nuanced understanding of the evolving technical landscape of product area.
-        </div>
+      <td class="level-summary" colspan="8">
+        A PM capable of executing an ambiguous, cross-functional project to completion that shapes the future of Sourcegraph’s business; a Senior PM.
       </td>
     </tr>
-    <!-- Execution -->
-    <th class="category" colspan="5">Execution</th>
-    <tr>
-      <td colspan="5" class="category-summary">Maximizing Impact</td>
-    </tr>
-    <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-          I define goals, lead my team in prioritizing our work, and work with my team to execute tactically.
-        </div>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        Partners with the GTM team to support GTM growth within existing features.
       </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-          I incorporate user research, market/industry knowledge, and business goals in my prioritization of discovery and delivery efforts.
-        </div>
+      <td class="behaviors">
+        Understands direct and indirect competitors in our category, how we can compare and where we could invest to win. Has built relationships with key customers, understands their specific needs and works collaboratively with them to build solutions.
       </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          With a scoped problem, I am able to drive the creation and launch of an experience by working cross-team (i.e. product marketing) to create shared outcomes.
-        </div>
+      <td class="behaviors">
+        Drives the long term vision of their product(s) and influence the overarching product vision. Creates a strategy that identifies the key challenges we may face and how we overcome them to maximise the impact we have. Continues to iterate and adapt the strategy based on new input and communicates this transparently.
       </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          Given a rough direction based on critical business needs, I will create the right outcome, based on an understanding of the market and customer.
-        </div>
+      <td class="behaviors">
+        Understands how influential devs and dev communities will perceive their product, and effectively communicates with them directly in a way that gains us new knowledge and/or respect. Deeply understands the technical aspects of their product and uses that knowledge to create a better product that meets particularly complex technical requirements.
       </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          I am able to efficiently execute cross-Sourcegraph efforts in highly ambiguous and often risky projects for Sourcegraph.
-        </div>
+      <td class="behaviors">
+        Given a rough direction based on critical business needs, can create the right outcome, based on an understanding of the market and customer.
+      </td>
+      <td class="behaviors">
+        Is able to clearly define research questions and leverage multiple research methods to gather sufficient data to answer their question.
+      </td>
+      <td class="behaviors">
+        Leads cross-functional collaboration to deliver outcomes that improve user experience. Teams recognize how they create and communicate their strategy and apply it with their teams.
+      </td>
+      <td class="behaviors">
+        Actively serves as a mentor to a team member working on a project related to their own.
       </td>
     </tr>
+    <!-- IC5 -->
     <tr>
-      <td colspan="5" class="category-summary">Data-Driven</td>
+      <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
     </tr>
     <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-          I understand the problem we are trying to solve based on existing research and can articulate this to others.
-        </div>
-      </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-          I understand the problem we are trying to solve and what information we'd need to validate it. I know how to measure the success of an initiative.
-        </div>
-      </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          I understand the pros/cons of different research techniques and know what to use to solve a particular question.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          I am able to clearly define research questions and leverage multiple research methods to gather sufficient data to answer my question.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          I am able to clearly define research questions, leverage multiple research methods and define net-new methods when required.
-        </div>
+      <td class="level-summary" colspan="8">
+        A very experienced PM, capable of efficiently driving multiple cross-functional projects in a highly autonomous way while understanding the impact of their work to Sourcegraph and the broad market as a whole; a Staff PM.
       </td>
     </tr>
-    <!-- Teamwork -->
-    <th class="category" colspan="5">Teamwork</th>
-    <tr>
-      <td colspan="5" class="category-summary">Collaboration</td>
-    </tr>
-    <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-          I conduct team meetings in a way that fosters effective team collaboration.
-        </div>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        Leverages new product opportunities to expand Sourcegraph into new GTM channels/markets and kickstart new levers of growth.
       </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-          I frequently share work in progress and present updates on my product to everyone in the company.
-        </div>
+      <td class="behaviors">
+        Understands and identifies where there are opportunities in adjacent product categories, or creates new product categories that would benefit our business.
       </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          I'm familiar with other teams' work and how it relates to my team's work. I work collaboratively with other teams when responsibilities overlap.
-        </div>
+      <td class="behaviors">
+        Efficiently seeks net-new product opportunities that expand Sourcegraph into new markets by exploring strategic opportunities to buy or partner with external companies.
       </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          I lead cross-functional collaboration to deliver outcomes that improve user experience. Teams recognize how I create and communicate my strategy and apply it with their teams.
-        </div>
+      <td class="behaviors">
+        Is known and respected by influential devs and dev communities in their product area, and us that to increase the odds of success for their product. Uses their technical intuition to create a better product in ways that rely on brand new approaches and/or their nuanced understanding of the evolving technical landscape of product area.
       </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          The business depends on me to successfully manage cross-functional initiatives.
-        </div>
+      <td class="behaviors">
+        Is able to efficiently execute cross-Sourcegraph efforts in highly ambiguous and often risky projects for Sourcegraph.
       </td>
-    </tr>
-    <tr>
-      <td colspan="5" class="category-summary">Mentorship and Coaching</td>
-    </tr>
-    <tr>
-      <td class="category-detail ic1">
-        <div class="wrapper">
-        </div>
+      <td class="behaviors">
+        Is able to clearly define research questions, leverage multiple research methods and define net-new methods when required.
       </td>
-      <td class="category-detail ic2">
-        <div class="wrapper">
-        </div>
+      <td class="behaviors">
+        The business depends on them to successfully manage cross-functional initiatives.
       </td>
-      <td class="category-detail ic3">
-        <div class="wrapper">
-          I recognize my skill/knowledge gaps and seek out mentors who can help me grow.
-        </div>
-      </td>
-      <td class="category-detail ic4">
-        <div class="wrapper">
-          I actively serve as a mentor to a team member working on a project related to my own.
-        </div>
-      </td>
-      <td class="category-detail ic5">
-        <div class="wrapper">
-          I actively serve as mentors to junior team members and other less experienced PMs.
-        </div>
+      <td class="behaviors">
+        Actively serves as mentors to junior team members and other less experienced PMs.
       </td>
     </tr>
   </tbody>

--- a/content/departments/technical-success/ce/career-growth/index.md
+++ b/content/departments/technical-success/ce/career-growth/index.md
@@ -63,299 +63,156 @@ We want to support the career progession of CEs on the Customer Engineering team
 
 Learn more about CEs transitioning to CE management [here](cemgr-candidates-internal.md).
 
+## Levels
+
 <style>
   .container {
     --width: 1300px;
   }
-  .levels-table {
-    --leadership-color: var(--sg-vivid-violet);
-    --business-color: var(--sg-sky-blue);
-    --technology-color: var(--sg-vermillion);
-    --values-color: var(--sg-blurple);
-    --levels-color: var(--sg-mint);
-
-    table-layout: fixed;
-  }
-  .leadership {
-    --category-color: var(--leadership-color);
-  }
-  .business {
-    --category-color: var(--business-color);
-  }
-  .technology {
-    --category-color: var(--technology-color);
-  }
-  .values{
-    --category-color: var(--values-color);
-  }
-  .levels{
-    --category-color: var(--levels-color);
-  }
-  .levels-table :is(td, th) {
-    vertical-align: top;
-    background: white;
-  }
-  .levels-table [id] {
-    /* Account for sticky table header */
-    scroll-margin-top: calc(var(--header-height) + 2.25rem);
-  }
-  thead th.levels{
-    text-align: center;
-    border-color: var(--category-color);
-    background: var(--category-color);
-  }
-  tbody td.category-title {
-    text-align: center;
-    border-color: var(--category-color);
-    background: var(--category-color);
-  }
-  td:is(.leadership, .technology, .values) {
-    color: white;
-  }
-  /*
-  Repeat the category color as a border color after each category summary.
-  Safari doesn't respect different border colors below a cell spanning multiple columns,
-  so we need to draw borders on wrapper elements instead.
-  */
-  .levels-table .category-summaries-row {
-    border-top: none;
-  }
-  .levels-table .category-summary {
-    border-top: none;
-    padding: 0;
-  }
-  .category-summary > .wrapper {
-    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
-    width: 100%;
-    height: 100%;
-    padding: 6px 13px;
-    display: block;
-    border-top: 1px solid var(--category-color);
-    border-bottom: 1px solid var(--category-color);
-    color: var(--category-color)
-  }
-  .level {
-    white-space: nowrap;
-  }
-  .levels-table td[colspan] {
-    text-align: center;
-  }
-  .levels-table td ul {
-     text-align: left;
-  }
-  .level-summary, .category-summaries-row {
-    font-style: italic;
-  }
-  .level-summary {
-    border-bottom: none !important;
-  }
-  .levels-table td.tbd {
-    vertical-align: middle;
-    text-align: left;
-    padding: 2.5rem;
-  }
 </style>
-
-## Levels
 
 <table class="levels-table">
 
   <thead>
     <tr>
-      <th scope="col" class="levels sticky">IC 1</th>
-      <th scope="col" class="levels sticky">IC 2</th>
-      <th scope="col" class="levels sticky">IC 3</th>
-      <th scope="col" class="levels sticky">IC 4</th>
-      <th scope="col" class="levels sticky">IC 5</th>
-      <th scope="col" class="levels sticky">IC 6</th>
+      <th scope="col">Level</th>
+      <th scope="col" class="category-title">Customer Interactions</th>
+      <th scope="col" class="category-title">Achieve the Technical Win</th>
+      <th scope="col" class="category-title">Technical Customer Success</th>
+      <th scope="col" class="category-title">Contextual Understanding</th>
+      <th scope="col" class="category-title">Operational Excellence</th>
+      <th scope="col" class="category-title">Sourcegraph Product</th>
+      <th scope="col" class="category-title">Domain Subject Matter Expertise</th>
+      <th scope="col" class="category-title">Customer Drive</th>
+      <th scope="col" class="category-title">High Agency</th>
+      <th scope="col" class="category-title">High Quality</th>
+      <th scope="col" class="category-title">Open & Transparent</th>
+      <th scope="col" class="category-title">Continuously Grow</th>
+      <th scope="col" class="category-title">Work as a Team / Be Welcoming & Inclusive</th>
     </tr>
   </thead>
 
   <tbody>
+    <!-- IC1 -->
     <tr>
-      <td class="level-summary">A Customer Engineer focused on learning, growth, and establishing themselves as a contributing teammate</td>
-      <td class="level-summary">A Customer Engineer that can autonomously contribute, execute, and collaborate while developing their skills</td>
-      <td class="level-summary">An individual contributor that demonstrates required and desired capabilities (Senior CE)</td>
-      <td class="level-summary">A particularly experienced individual contributor that has mastered capabilities especially in complex circumstances (Senior CE)</td>
-      <td class="level-summary">An individual who excels in their capabilities and emphasizes leadership and growth (Principal CE)</td>
-      <td class="level-summary">A subject matter expert with a visible external brand / presence in the developer ecosystem (Sr Principal CE / Field CTO)</td>
+      <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
     </tr>
-    <tr><td colspan="6" class="category-title leadership">Leadership</td></tr>
     <tr>
-      <td colspan="6" class="category-summary leadership">
-        <div class="wrapper">Customer Interactions</div>
+      <td class="level-summary" colspan="13">
+          A Customer Engineer focused on learning, growth, and establishing themselves as a contributing teammate.
       </td>
-    <tr>
-    <tr>
-      <td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
         <ul>
           <li>Can identify high-level customer business and technical needs, mapping their needs to defined use cases.</li>
           <li>Ability to select the correct communication medium and profile for each communication type and purpose. When communicating with customers, does not over-promise or avoid questions or topics. Provides clear timelines and follows through on commitments.</li>
           <li>Identify the need for help navigating customers political situations.</li>
         </ul>
       </td>
-      <td>
-        <ul>
-          <li>Can ask open-ended questions that validate use cases and uncover new opportunities.</li>
-          <li>Maintains clear communication to internal and external stakeholders. In customer interactions, seeks additional context to confirm understanding where appropriate. Shows an ability to influence customer (scope, use cases) towards best practices.</li>
-          <li>Demonstrated ability to navigate customers political situations in partnership and with guidance from Leadership.</li>
-        </ul>
+      <td class="behaviors">
+        With assistance, builds plans for achieving a technical win and can capture technical design.
       </td>
-      <td>
-        <ul>
-          <li>Can ask strategic questions that both articulate customer pain and quantify the impact of it.</li>
-          <li>Handles customer objections, diffuses situations, and serves as a steady and calm representative of Sourcegraph to the customer especially in complex and political situations. Communicate and negotiate to drive successful client interactions. Escalates properly and in a timely manner.</li>
-          <li>Demonstrated ability to navigate political situations with customers to achieve desired outcomes with no guidance needed.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Masters asking strategic questions that uncover new use cases, validate existing use cases, uncovers latent customer pain and educates the customer on their needs.</li>
-          <li>Can appropriately push back with clients and negotiate mutually agreed outcomes in contentious situations with the customer. Communicates and negotiates to drive successful and repeatable client interactions.</li>
-          <li>Reliably and consistently delivers in the midst of political situations with customers to achieve desired outcomes.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Uses broad and deep technical knowledge along with proven ability to ask strategic questions that uncover new use cases, validate existing use cases and uncovers latent customer pain, but can tie impact of Sourcegraph to customer's business outcomes.</li>
-          <li>Capable of selecting the appropriate engagement style (light touch, consultative, deep technical handholding, ..) and changing it based on context.</li>
-          <li>Situational awareness and capability to involve the right resources based on cultural/personality aspects that match client expectations / fit context.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Can reference examples of where we have uncovered new opportunities to make Sourcegraph stickier and more widely used.</li>
-          <li>Strong interpersonal skills and influence interfacing directly with Director, VP, C-level audiences and also at DevOps, architect and dev team levels, too</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary leadership">
-        <div class="wrapper">Achieve the Technical Win</div>
-      </td>
-    <tr>
-    <tr>
-      <td>With assistance, builds plans for achieving technical win and can capture technical design.</td>
-      <td>With limited direction or assistance, can build a clear technical win and define the technical design for customer solution. Able to identify non-standard or high-risk requirements.</td>
-      <td>Entirely self-directed, can build a clear technical win plan and technical design for customers. Able to raise requests to internal teams on behalf of customer needs.</td>
-      <td>Designs solutions and phased roll out plans / technical design plans against customer needs. Negotiates and influences customer needs and design according to best practices, owning the technical design for customer solutions.</td>
-      <td>Turns gaps into opportunities by formulating a plan for success and driving activity against that plan on behalf of customers.</td>
-      <td>Recognized as an industry influencer and thought leader around code search.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary leadership">
-        <div class="wrapper">Technical Customer Success</div>
-      </td>
-    <tr>
-    <tr>
-      <td>
+      <td class="behaviors">
         <ul>
           <li>Plays an assisting role in producing deliverables that benefit customer needs (eg onboarding plans, collateral, QBR decks, etc). Follows playbooks and templates to guide the customer.</li>
           <li>Learns how to enable customers against their use cases and business value.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
         <ul>
-          <li>With assistance defines customers' business outcomes. Performs activities (demos, trials, webinars) that center around customer stated needs.</li>
-          <li>Participates in internal projects that help fill gaps, mature processes, and deliver more value to our business and our customers.</li>
+          <li>Learns different functions and roles internally and externally and appropriately manages relationships and seeks advice and support as appropriate.</li>
         </ul>
       </td>
-      <td>
-        <ul>
-          <li>Responsible for defining and subsequently orienting activities against customers' business outcomes. Leads the readout via QBRs. Influences and adapts plans to changing conditions while driving execution to deliver value. Appropriately adapts workflows to the customers' needs; displays the appropriate sense of urgency on behalf of the customers' needs.</li>
-          <li>Demonstrated ability to connect Sourcegraph capabilities to client's use cases.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Proactively manages customer activities and constantly aligns clients expectations to schedule and deliverables. Creates playbooks, processes that improve the consistency and level of customer success. Mentors CE's on how to effectively apply playbooks and templates. Possess both technical acumen, but also ability to mentor on soft skills in leading by example.</li>
-          <li>Demonstrated ability to understand the client's value measurement and overarching objectives, and articulate and highlight Sourcegraph business value accordingly.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Builds playbooks, processes, and templates for customers.</li>
-          <li>Influences and actively contributes to team decisions and actively champions change, setting a positive example for others to emulate.</li>
-          <li>Scales outcomes by improving current, and helping define new, standards for driving customer outcomes for the team through the development and communication of best practices, improved processes, etc.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Plays reference role on the team and leads initiatives.</li>
-          <li>Secures team buy-in and organizational readiness on new initiatives.</li>
-        </ul>
-      </td>
-    </tr>
-    <tr><td colspan="6" class="category-title business">Business</td></tr>
-    <tr>
-      <td colspan="6" class="category-summary business">
-        <div class="wrapper">Contextual Understanding</div>
-      </td>
-    <tr>
-    <tr>
-      <td>Learn different functions and roles internally and externally and appropriately manages relationships and seeks advice and support as appropriate.</td>
-      <td>Uses different functions and roles internally and externally to drive success with accounts and internal projects. Can identify a Champion by understanding ways to test if someone is a Champion. Identifies new and potential advocates - builds relationships with them.</td>
-      <td>Ability to properly and timely identify stakeholders and roles and to address them appropriately. Ensures necessary roles are proactively involved on accounts and projects. Nurtures Champion relationship by building plans to strengthen rapport, enable their ability to effectively sell Sourcegraph internally, and align Sourcegraph's success against their personal win.</td>
-      <td>Leverages existing Champions to gain wider access into an account. Uses champions to mitigate detractors, gain access to Economic Buyers (EBs), and find new teams and use-cases to drive expansion.</td>
-      <td>Mentors junior ICs on how to best engage various functions and roles. Able to go into an account and find new advocates; able to identify potential champions for AE to lead the effort to establish a relationship.</td>
-      <td>Ability to build executive champions and get their buy-in on Sourcegraph providing a significant impact on their development organizations, and their company as a whole.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary business">
-        <div class="wrapper">Operational Excellence</div>
-      </td>
-    <tr>
-    <tr>
-      <td>
+      <td class="behaviors">
         <ul>
           <li>Learns Sourcegraph processes, templates, and tools. As instructed, with guidance and support, able to complete required activities.</li>
           <li>Ability to manage own time, providing feedback and asking for guidance as appropriate.</li>
           <li>Learns Sourcegraph value prop is able to pitch to customers.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
+        <ul>
+          <li>Learns core out-of-the-box features: what they are, how they work, how to demo and explain them to customers.</li>
+          <li>Ability to assist customers with questions that they have on Sourcegraph.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Learns about our core buying personas, core use cases and value drivers.</li>
+          <li>Can name our primary competitors.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Curious about how our customers work and how we can deliver value to them.
+      </td>
+      <td class="behaviors"></td>
+      <td class="behaviors">
+        <ul>
+          <li>Receives guidance and support to create high-quality outcomes.</li>
+          <li>Takes ownership of tasks - internal and / or external.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Communicates openly where support / assistance is desired.</li>
+          <li>Proactively communicates timelines and status on tasks.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Open and receptive to feedback and new / different ways of accomplishing a task.</li>
+          <li>Looks for opportunities to improve own processes and workflows.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Treats everyone with respect and empathy, and consistently works well with others to get work done well.</li>
+          <li>Learning to appreciate and different perspectives, and ask for those perspectives when developing solutions.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC2 -->
+    <tr>
+      <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="13">
+          A Customer Engineer that can autonomously contribute, execute, and collaborate while developing their skills.
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Can ask open-ended questions that validate use cases and uncover new opportunities.</li>
+          <li>Maintains clear communication to internal and external stakeholders. In customer interactions, seeks additional context to confirm understanding where appropriate. Shows an ability to influence customer (scope, use cases) towards best practices.</li>
+          <li>Demonstrated ability to navigate customers political situations in partnership and with guidance from Leadership.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        With limited direction or assistance, can build a clear technical win and define the technical design for customer solution. Able to identify non-standard or high-risk requirements.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>With assistance defines customers' business outcomes. Performs activities (demos, trials, webinars) that center around customer stated needs.</li>
+          <li>Participates in internal projects that help fill gaps, mature processes, and deliver more value to our business and our customers.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Uses different functions and roles internally and externally to drive success with accounts and internal projects.</li>
+          <li>Can identify a Champion by understanding ways to test if someone is a Champion.</li>
+          <li>Identifies new and potential advocates - builds relationships with them.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
         <ul>
           <li>Adopts Sourcegraph processes, templates, and tools; completes deliverables and activities according to process.</li>
           <li>Ability to manage own time and prioritize across multiple accounts, providing feedback and asking for guidance as appropriate.</li>
           <li>Understands and applies Sourcegraph value prop and is able to tailor customer pitch and match value prop to stakeholders' unique needs.</li>
         </ul>
       </td>
-      <td>
-        <ul>
-          <li>While adhering to process, able to identify and provide timely feedback and updates on identified blockers, delays, and risks identified or raised.</li>
-          <li>When creating trial / deployment plans, able to identify interruptions and identify potential paths to keep activities on schedule.</li>
-          <li>Applies Sourcegraph value prop throughout the sale and entire customer journey.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Proactively raises blockers, delays, and risks and also establishes proposed solutions or workarounds. Looks for abilities to modify scope / use cases to ensure forward progress against defined process.</li>
-          <li>Creates complex trial and deployment plans and executes against schedule.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Documents setups and customizations to enable other teams. Identifies and mitigate or escalates risks prior to becoming issues.</li>
-          <li>Acts as role model for more junior/new team members for managing time. Makes proposals to improve operating model and tools.</li>
-          <li>Applies Sourcegraph's Value Framework to such an extent that deals have closed for larger amounts, higher close rates are seen (with unsuccessful ops qualified out earlier), and greater ongoing success and expansion of accounts as a result of application.</li>
-        </ul>
-      </td>
-      <td></td>
-    </tr>
-    <tr><td colspan="6" class="category-title technology">Technology</td></tr>
-    <tr>
-      <td colspan="6" class="category-summary technology">
-        <div class="wrapper">Sourcegraph Product</div>
-      </td>
-    <tr>
-    <tr>
-      <td>
-        <ul>
-          <li>Learn core out-of-the-box features: what they are, how they work, how to demo and explain them to customers.</li>
-          <li>Ability to assist customers with questions that they have on Sourcegraph.</li>
-        </ul>
-      </td>
-      <td>
+      <td class="behaviors">
         <ul>
           <li>Understands how core out-of-the-box features provide value and is able to explain them to customers against their needs.</li>
           <li>Ability to assist customers with questions that they have on Sourcegraph.</li>
@@ -363,7 +220,86 @@ Learn more about CEs transitioning to CE management [here](cemgr-candidates-inte
           <li>Voice of the customer: Provides timely and accurate feedback to Product to drive improvements to Sourcegraph.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
+        <ul>
+          <li>Demonstrated understanding of our core buying personas, core use cases and value drivers.</li>
+          <li>Basic up-to-date understanding of competitors' high-level capabilities on Sourcegraph's competitive landscape.</li>
+          <li>Knows the developer ecosystem enough to be able to speak to tools companies use and how they use them.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Understands how our customers work and how we can deliver value to them, enjoys commercial and strategic discussions and shares insights with others.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Applies agency over their work by looking for solutions to challenges, applying good thinking and seeking clarity and direction when needed.</li>
+          <li>Applies agency over their wellbeing by managing their own time while finding balance and creating rest.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Gets clarity to understand what’s required to deliver high-quality outcomes: what good looks like and what the timelines are.</li>
+          <li>Owns their own delivery, managing expectations and owning setbacks effectively.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Communicates the right information at the right time by effectively using synchronous and asynchronous channels, so everyone is involved and informed.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Owns their own development: asks for feedback and direction on developmental priorities, and resources to learn from.</li>
+          <li>Is composed under pressure and flexible to change, able to unlearn/relearn with ease, and asks the necessary questions to clarify ambiguity.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Seeks out different perspectives, and consistently calls for those perspectives when developing solutions.</li>
+          <li>Volunteers to support teams or groups outside of their own team.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC3 -->
+    <tr>
+      <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="13">
+        An individual contributor that demonstrates required and desired capabilities; a Senior CE.</td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Can ask strategic questions that both articulate customer pain and quantify the impact of it.</li>
+          <li>Handles customer objections, diffuses situations, and serves as a steady and calm representative of Sourcegraph to the customer especially in complex and political situations. Communicate and negotiate to drive successful client interactions. Escalates properly and in a timely manner.</li>
+          <li>Demonstrated ability to navigate political situations with customers to achieve desired outcomes with no guidance needed.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Entirely self-directed, can build a clear technical win plan and technical design for customers. Able to raise requests to internal teams on behalf of customer needs.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Responsible for defining and subsequently orienting activities against customers' business outcomes. Leads the readout via QBRs. Influences and adapts plans to changing conditions while driving execution to deliver value. Appropriately adapts workflows to the customers' needs; displays the appropriate sense of urgency on behalf of the customers' needs.</li>
+          <li>Demonstrated ability to connect Sourcegraph capabilities to client's use cases.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Ability to properly and timely identify stakeholders and roles and to address them appropriately.</li>
+          <li>Ensures necessary roles are proactively involved on accounts and projects.</li>
+          <li>Nurtures Champion relationship by building plans to strengthen rapport, enable their ability to effectively sell Sourcegraph internally, and align Sourcegraph's success against their personal win.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>While adhering to process, able to identify and provide timely feedback and updates on identified blockers, delays, and risks identified or raised.</li>
+          <li>When creating trial / deployment plans, able to identify interruptions and identify potential paths to keep activities on schedule.</li>
+          <li>Applies Sourcegraph value prop throughout the sale and entire customer journey.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
         <ul>
           <li>Understands how core out-of-the-box features are used by other customers in a similar team / vertical / space.</li>
           <li>Can guide the customer on how to configure parts of the product based on known best practices.</li>
@@ -372,7 +308,84 @@ Learn more about CEs transitioning to CE management [here](cemgr-candidates-inte
           <li>Understands the various technical concepts that go into deciding to build or buy something like Sourcegraph.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
+        <ul>
+          <li>Can correlate core uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
+          <li>Firm understanding of competitors' high-level capabilities on Sourcegraph's competitive landscape and weaves this knowledge into objection handling and solution positioning.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Thinks beyond day-to-day tasks and contributes insights of strategic and commercial value, that help us deliver value to customers.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Proactively analyses challenges and consults to get relevant input, before generating a variety of solutions, and selecting the right one with confidence.</li>
+          <li>Applies agency over their wellbeing by managing their own time while finding balance and rest.</li>
+          <li>Guides and mentors junior less experienced teammates accordingly.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>May mentor junior employees and each other.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Communicates effectively and is learning to present internally and externally.</li>
+          <li>Viewed as approachable and builds trust easily with internal and external teams.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Owns their own development and is receptive to challenges and feedback.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Works and interacts effectively with people from diverse backgrounds, preferences and perspectives, and understands how to weave these to create better solutions.</li>
+          <li>Rarely encounters someone they can't work with, and proactively initiates contact with others to solve conflict.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC4 -->
+    <tr>
+      <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="13">
+        A particularly experienced individual contributor that has mastered capabilities especially in complex circumstances; a Senior CE.
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Masters asking strategic questions that uncover new use cases, validate existing use cases, uncovers latent customer pain and educates the customer on their needs.</li>
+          <li>Can appropriately push back with clients and negotiate mutually agreed outcomes in contentious situations with the customer. Communicates and negotiates to drive successful and repeatable client interactions.</li>
+          <li>Reliably and consistently delivers in the midst of political situations with customers to achieve desired outcomes.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Designs solutions and phased roll out plans / technical design plans against customer needs. Negotiates and influences customer needs and design according to best practices, owning the technical design for customer solutions.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Proactively manages customer activities and constantly aligns clients expectations to schedule and deliverables. Creates playbooks, processes that improve the consistency and level of customer success. Mentors CE's on how to effectively apply playbooks and templates. Possess both technical acumen, but also ability to mentor on soft skills in leading by example.</li>
+          <li>Demonstrated ability to understand the client's value measurement and overarching objectives, and articulate and highlight Sourcegraph business value accordingly.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Leverages existing Champions to gain wider access into an account.</li>
+          <li>Uses champions to mitigate detractors, gain access to Economic Buyers (EBs), and find new teams and use-cases to drive expansion.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Proactively raises blockers, delays, and risks and also establishes proposed solutions or workarounds. Looks for abilities to modify scope / use cases to ensure forward progress against defined process.</li>
+          <li>Creates complex trial and deployment plans and executes against schedule.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
         <ul>
           <li>Understands advanced features to deliver customer value through extensibility and customization</li>
           <li>Leads the customer on best practices for configuring and using the product, steering clear of less ideal designs in complex customer environments.</li>
@@ -381,146 +394,206 @@ Learn more about CEs transitioning to CE management [here](cemgr-candidates-inte
           <li>Can articulate technical concepts that go into deciding to build or buy something like Sourcegraph and influences accordingly.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
+        <ul>
+          <li>Correlates complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
+          <li>Advanced up-to-date knowledge of competitors' high-level capabilities on Sourcegraph's competitive landscape and their key value propositions, strengths and weaknesses.</li>
+          <li>Draws from own experience, and knowledge of the developer ecosystem speaks to tools companies use, how they use them, limitations of them, and how Sourcegraph fits in.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Challenges whether goals are customer-oriented.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Pre-empts challenges to manage risk, and steps in early to ensure they are resolved quickly and avoid escalation.</li>
+          <li>Consults to get relevant input, before generating a variety of solutions, and selecting the right one with confidence.</li>
+          <li>Applies agency over their wellbeing by managing their own time while finding balance and rest.</li>
+          <li>Guides and mentors junior less experienced teammates accordingly.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Leads by example in producing quality work and is a trusted and reliable source on the team for guidance on what good work looks like.</li>
+          <li>Leans in to help managers keep work on track.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Thinks on their feet and can articulate and communicate a point of view while building trust and rapport.</li>
+          <li>Learning to persuade and challenge clients and internal stakeholders, using valid expertise and respectful communication.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is a role model for personal development and two-way feedback.</li>
+          <li>Challenges the status quo and highlights potential opportunities in change.</li>
+          <li>Is a beacon of composure through change and ambiguity, taking things in their stride but challenging where appropriate.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Guides others on effective collaboration, conflict resolution and improved communication.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC5 -->
+    <tr>
+      <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="13">
+        An individual who excels in their capabilities and emphasizes leadership and growth; a Principal CE.</td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Uses broad and deep technical knowledge along with proven ability to ask strategic questions that uncover new use cases, validate existing use cases and uncovers latent customer pain, but can tie impact of Sourcegraph to customer's business outcomes.</li>
+          <li>Capable of selecting the appropriate engagement style (light touch, consultative, deep technical handholding, ..) and changing it based on context.</li>
+          <li>Situational awareness and capability to involve the right resources based on cultural/personality aspects that match client expectations / fit context.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Turns gaps into opportunities by formulating a plan for success and driving activity against that plan on behalf of customers.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Builds playbooks, processes, and templates for customers.</li>
+          <li>Influences and actively contributes to team decisions and actively champions change, setting a positive example for others to emulate.</li>
+          <li>Scales outcomes by improving current, and helping define new, standards for driving customer outcomes for the team through the development and communication of best practices, improved processes, etc.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Mentors junior ICs on how to best engage various functions and roles.</li>
+          <li>Able to go into an account and find new advocates; able to identify potential champions for AE to lead the effort to establish a relationship.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Documents setups and customizations to enable other teams. Identifies and mitigate or escalates risks prior to becoming issues.</li>
+          <li>Acts as role model for more junior/new team members for managing time. Makes proposals to improve operating model and tools.</li>
+          <li>Applies Sourcegraph's Value Framework to such an extent that deals have closed for larger amounts, higher close rates are seen (with unsuccessful ops qualified out earlier), and greater ongoing success and expansion of accounts as a result of application.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
         <ul>
           <li>Understands advanced features to deliver customer value through extensibility and customization</li>
           <li>Ability to guide a technical audience towards good engineering disciplines and demonstrated experience in what it takes to incorporate Sourcegraph into a customer architecture.</li>
           <li>Voice of the customer: Demonstrated ability to manage project and product changes by re-aligning internal and external teams to customer needs and business value.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
         <ul>
-          <li>Understands advanced features to deliver customer value through extensibility and customization</li>
-          <li>As a thought leader, creates architectural best practices on development ecosystems that leverage Sourcegraph. These best practices are recognized by customers and used to drive competitive advantage for organizations.</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary technology">
-        <div class="wrapper">Domain Subject Matter Expertise</div>
-      </td>
-    <tr>
-    <tr>
-      <td>
-        <ul>
-          <li>Learn about our core buying personas, core use cases and value drivers.</li>
-          <li>Can name our primary competitors.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Demonstrated understanding of our core buying personas, core use cases and value drivers.</li>
-          <li>Basic up-to-date understanding of competitors' high-level capabilities on Sourcegraph's competitive landscape.</li>
-          <li>Knows the developer ecosystem enough to be able to speak to tools companies use and how they use them.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Can correlate core uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
-          <li>Firm understanding of competitors' high-level capabilities on Sourcegraph's competitive landscape and weaves this knowledge into objection handling and solution positioning.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Correlate complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
-          <li>Advanced up-to-date knowledge of competitors' high-level capabilities on Sourcegraph's competitive landscape and their key value propositions, strengths and weaknesses.</li>
-          <li>Drawing from own experience, and knowledge of the developer ecosystem speaks to tools companies use, how they use them, limitations of them, and how Sourcegraph fits in.</li>
-        </ul>
-      </td>
-      <td>
-        <ul>
-          <li>Correlate complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
+          <li>Correlates complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
           <li>Advanced up-to-date knowledge of competitors' high-level capabilities on Sourcegraph's competitive landscape and their key value propositions, strengths and weaknesses.</li>
           <li>Enables and excites advocates (both customer and external/industry) on Sourcegraph technologies and solutions.</li>
           <li>Able to articulate industry trends including use cases and challenges, and how they relate to Sourcegraph.</li>
         </ul>
       </td>
-      <td>
+      <td class="behaviors">
+        Acts as a trusted advisor, drawing on functional expertise to inform customer-driven strategy and commercial thinking.
+      </td>
+      <td class="behaviors">
         <ul>
-          <li>Correlate complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
+          <li>Applies agency over their own workload but also the expertise and scalability of the team.</li>
+          <li>Plans ahead to anticipate and act on the needs of own team, internal and external stakeholders.</li>
+          <li>Applies technical expertise to proactively analyze challenges and is consulted to find the right decisions for complex problems.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Leads quality by providing technical expertise internally and externally, informing what can be achieved and providing structured educational leadership for the team.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Effectively able to persuade and challenge clients and internal stakeholders, using valid expertise and respectful communication.</li>
+          <li>Regularly shares knowledge and is effective at presenting to large and/or senior audiences.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Advocates personal development and two-way feedback for the entire team.</li>
+          <li>Challenges the status quo and highlights potential opportunities in change.</li>
+          <li>Is a beacon of composure through change and ambiguity, taking things in their stride but challenging where appropriate.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Welcomes and works effectively with people from diverse backgrounds, preferences and perspectives, and understands how to weave these to create better solutions.</li>
+          <li>Advocates for others, recognizes and creates space for less vocal members.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC6 -->
+    <tr>
+      <th id="ic6" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic6"></a><abbr title="Individual Contributor">IC</abbr>6</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="13">
+        A subject matter expert with a visible external brand / presence in the developer ecosystem; a Senior Principal CE / Field CTO.</td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Can reference examples of where we have uncovered new opportunities to make Sourcegraph stickier and more widely used.</li>
+          <li>Strong interpersonal skills and influence interfacing directly with Director, VP, C-level audiences and also at DevOps, architect and dev team levels, too</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        Recognized as an industry influencer and thought leader around code search.
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Plays reference role on the team and leads initiatives.</li>
+          <li>Secures team buy-in and organizational readiness on new initiatives.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Ability to build executive champions and get their buy-in on Sourcegraph providing a significant impact on their development organizations, and their company as a whole.</il>
+        </ul>
+      </td>
+      <td class="behaviors"></td>
+      <td class="behaviors">
+        <ul>
+          <li>Understands advanced features to deliver customer value through extensibility and customization</li>
+          <li>As a thought leader, creates architectural best practices on development ecosystems that leverage Sourcegraph. These best practices are recognized by customers and used to drive competitive advantage for organizations.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Correlates complex uses cases and value drivers per persona (IC Eng, IC Dev Ops, IC Security Analyst, EM, VP, etc).</li>
           <li>Advanced up-to-date knowledge of competitors' high-level capabilities on Sourcegraph's competitive landscape and their**** key value propositions, strengths and weaknesses.</li>
           <li>Can advise customers on how to build a developer ecosystem with Sourcegraph.</li>
         </ul>
       </td>
-    </tr>
-    <tr><td colspan="6" class="category-title values">Company Values</td></tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">Customer Drive</div>
+      <td class="behaviors">
+        Showcases influence over customers through trust.
       </td>
-    <tr>
-    <tr>
-      <td>Curious about how our customers work and how we can deliver value to them.</td>
-      <td>Understands how our customers work and how we can deliver value to them, enjoys commercial and strategic discussions and shares insights with others.</td>
-      <td>Thinks beyond day-to-day tasks and contributes insights of strategic and commercial value, that help us deliver value to customers.</td>
-      <td>Challenges whether goals are customer-oriented.</td>
-      <td>Acts as a trusted advisor, drawing on functional expertise to inform customer-driven strategy and commercial thinking.</td>
-      <td>Showcases influence over customers through trust.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">High Agency</div>
+      <td class="behaviors">
+        <ul>
+          <li>Applies agency over their own workload but balances against the most pressing needs of the business and our customers.</li>
+        </ul>
       </td>
-    <tr>
-    <tr>
-      <td></td>
-      <td>Applies agency over their work by looking for solutions to challenges, applying good thinking and seeking clarity and direction when needed. Applies agency over their wellbeing by managing their own time while finding balance and creating rest.</td>
-      <td>Proactively analyses challenges and consults to get relevant input, before generating a variety of solutions, and selecting the right one with confidence. Applies agency over their wellbeing by managing their own time while finding balance and rest. Guides and mentors junior less experienced teammates accordingly.</td>
-      <td>Pre-empts challenges to manage risk, and steps in early to ensure they are resolved quickly and avoid escalation. Consults to get relevant input, before generating a variety of solutions, and selecting the right one with confidence. Applies agency over their wellbeing by managing their own time while finding balance and rest. Guides and mentors junior less experienced teammates accordingly.</td>
-      <td>Applies agency over their own workload but also the expertise and scalability of the team. Plans ahead to anticipate and act on the needs of own team, internal and external stakeholders. Applies technical expertise to proactively analyze challenges and is consulted to find the right decisions for complex problems.</td>
-      <td>Applies agency over their own workload but balances against the most pressing needs of the business and our customers.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">High Quality</div>
+      <td class="behaviors">
+        <ul>
+          <li>Sets the standard for what high quality looks like by providing technical expertise internally and externally, informing what can be achieved and providing structured educational leadership for the team.</li>
+        </ul>
       </td>
-    <tr>
-    <tr>
-      <td>Receives guidance and support to create high-quality outcomes. Takes ownership of tasks - internal and / or external.</td>
-      <td>Gets clarity to understand what’s required to deliver high-quality outcomes: what good looks like and what the timelines are. Owns their own delivery, managing expectations and owning setbacks effectively.</td>
-      <td>May mentor junior employees and each other.</td>
-      <td>Leads by example in producing quality work and is a trusted and reliable source on the team for guidance on what good work looks like. Leans in to help managers keep work on track.</td>
-      <td>Leads quality by providing technical expertise internally and externally, informing what can be achieved and providing structured educational leadership for the team.</td>
-      <td>Sets the standard for what high quality looks like by providing technical expertise internally and externally, informing what can be achieved and providing structured educational leadership for the team.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">Open & Transparent</div>
+      <td class="behaviors">
+        <ul>
+          <li>Regularly shares knowledge, coordinates cross-sharing internal and across teams.</li>
+        </ul>
       </td>
-    <tr>
-    <tr>
-      <td>Communicates openly where support / assistance is desired. Proactively communicates timelines and status on tasks.</td>
-      <td>Communicates the right information at the right time by effectively using synchronous and asynchronous channels, so everyone is involved and informed.</td>
-      <td>Communicates effectively and is learning to present internally and externally. Viewed as approachable and builds trust easily with internal and external teams.</td>
-      <td>Thinks on their feet and can articulate and communicate a point of view while building trust and rapport. Learning to persuade and challenge clients and internal stakeholders, using valid expertise and respectful communication.</td>
-      <td>Effectively able to persuade and challenge clients and internal stakeholders, using valid expertise and respectful communication. Regularly shares knowledge and is effective at presenting to large and/or senior audiences.</td>
-      <td>Regularly shares knowledge, coordinates cross-sharing internal and across teams.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">Continuously Grow</div>
+      <td class="behaviors">
+        <ul>
+          <li>Advocates means for creating growth opportunities across the team.</li>
+          <li>As an individual, seeks out feedback from others and showcases leadership.</li>
+        </ul>
       </td>
-    <tr>
-    <tr>
-      <td>Open and receptive to feedback and new / different ways of accomplishing a task. Looks for opportunities to improve own processes and workflows.</td>
-      <td>Owns their own development: asks for feedback and direction on developmental priorities, and resources to learn from. Is composed under pressure and flexible to change, able to unlearn/relearn with ease, and asks the necessary questions to clarify ambiguity.</td>
-      <td>Owns their own development and is receptive to challenges and feedback.</td>
-      <td>Is a role model for personal development and two-way feedback. Challenges the status quo and highlights potential opportunities in change. Is a beacon of composure through change and ambiguity, taking things in their stride but challenging where appropriate.</td>
-      <td>Advocates personal development and two-way feedback for the entire team. Challenges the status quo and highlights potential opportunities in change. Is a beacon of composure through change and ambiguity, taking things in their stride but challenging where appropriate.</td>
-      <td>Advocates means for creating growth opportunities across the team. As an individual, seeks out feedback from others and showcases leadership.</td>
-    </tr>
-    <tr>
-      <td colspan="6" class="category-summary values">
-        <div class="wrapper">Work as a Team / Be Welcoming & Inclusive</div>
-      </td>
-    <tr>
-    <tr>
-      <td>Treats everyone with respect and empathy, and consistently works well with others to get work done well. Learning to appreciate and different perspectives, and ask for those perspectives when developing solutions.</td>
-      <td>Seeks out different perspectives, and consistently calls for those perspectives when developing solutions. Volunteers to support teams or groups outside of their own team.</td>
-      <td>Works and interacts effectively with people from diverse backgrounds, preferences and perspectives, and understands how to weave these to create better solutions. Rarely encounters someone they can't work with, and proactively initiates contact with others to solve conflict.</td>
-      <td>Guides others on effective collaboration, conflict resolution and improved communication.</td>
-      <td>Welcomes and works effectively with people from diverse backgrounds, preferences and perspectives, and understands how to weave these to create better solutions. Advocates for others, recognizes and creates space for less vocal members.</td>
-      <td></td>
+      <td class="behaviors"></td>
     </tr>
   </tbody>
 </table>

--- a/content/departments/technical-success/support/career-growth/cs-career-levels.md
+++ b/content/departments/technical-success/support/career-growth/cs-career-levels.md
@@ -26,374 +26,303 @@ Promotion discussions occur when your manager can make the case that you’ve ha
 
 Promotions from one level to another are considered in impact reviews conducted by CS leadership in collaboration with you individually. An in-band compensation increase (while staying at the same level) can happen at any time, in recognition of exceeding expectations in your current level without having yet met the expectations of the next level.
 
+## Levels
+
 <style>
   .container {
     --width: 1300px;
   }
-  .levels-table {
-    --proficiency-color: var(--sg-vivid-violet);
-    --delivery-color: var(--sg-sky-blue);
-    --teamwork-color: var(--sg-vermillion);
-
-    table-layout: fixed;
-  }
-  .proficiency {
-    --category-color: var(--proficiency-color);
-  }
-  .delivery {
-    --category-color: var(--delivery-color);
-  }
-  .teamwork {
-    --category-color: var(--teamwork-color);
-  }
-  .levels-table :is(td, th) {
-    vertical-align: top;
-    background: white;
-  }
-  .levels-table [id] {
-    /* Account for sticky table header */
-    scroll-margin-top: calc(var(--header-height) + 2.25rem);
-  }
-  thead th:first-child {
-    width: 8ch;
-  }
-  thead th.category-title {
-    text-align: center;
-    border-color: white;
-    background: var(--category-color);
-  }
-  thead th:is(.proficiency, .teamwork) {
-    color: white;
-  }
-  /*
-  Repeat the category color as a border color after each category summary.
-  Safari doesn't respect different border colors below a cell spanning multiple columns,
-  so we need to draw borders on wrapper elements instead.
-  */
-  .levels-table .category-summaries-row {
-    border-top: none;
-  }
-  .levels-table .category-summary {
-    border-top: none;
-    padding: 0;
-  }
-  .category-summary > .wrapper {
-    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
-    width: 100%;
-    height: 100%;
-    padding: 6px 13px;
-    display: block;
-    border-top: 1px solid var(--category-color);
-  }
-  .level {
-    white-space: nowrap;
-  }
-  .levels-table td[colspan] {
-    text-align: center;
-  }
-  .level-summary, .category-summaries-row {
-    font-style: italic;
-  }
-  .level-summary {
-    border-bottom: none !important;
-  }
-  .levels-table td.tbd {
-    vertical-align: middle;
-    text-align: left;
-    padding: 2.5rem;
-  }
-  /*
-  Safari doesn't make the two IC6/IC7 rows equal size automatically, so give them explicit heights
-  Note that min-height also doesn't work.
-  */
-  th#ic6, th#ic7 {
-    height: 11rem;
-  }
 </style>
 
-## Levels
+<table class="levels-table">
 
-<table>
-  <tr>
-   <td>
-   </td>
-   <td><strong>IC 1: An individual new to the field with no prior industry experience; focused on learning, growth, and establishing themselves as a contributing member of the team (Entry Level)</strong>
-   </td>
-   <td><strong>IC 2: An individual beginning to autonomously contribute, execute, and collaborate on routine customer issues while developing their skills (Associate)</strong>
-   </td>
-   <td><strong>IC 3: A mid-level individual contributor beginning to independently solve for more complex customer issues (Specialist)</strong>
-   </td>
-   <td><strong>IC 4: A senior-level individual contributor that has demonstrated capabilities to consistently resolve more complex customer issues independently (Senior)</strong>
-   </td>
-   <td><strong>IC 5: A particularly experienced individual who excels in their capabilities with a focus on leadership and growth; possesses unique knowledge and ability to navigate the most complex customer issues and inquiries; takes on an active role in mentoring IC1s-IC4s (Lead)</strong>
-   </td>
-   <td><strong>IC 6: A subject matter expert with a visible external brand/presence; equivalent in impact to a Manager, and acts as a mentor to preceding IC level team members (Principal)</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>Proficiency
-   </td>
-   <td><strong>Non-Technical</strong>:
-<p>
-• You troubleshoot and resolve common customer issues with guidance.
-<p>
-• You demonstrate the essentials needed to do work in our domain (as outlined in our<a href="../../support/index.md#our-guiding-principles"> guiding principle</a><span style="text-decoration:underline;">s</span>).
-<p>
-• You willingly receive feedback from teammates to deliver positive outcomes for customers and the team.
-<p>
-• You increase your knowledge of Sourcegraph, our customers, team, general processes and workflows through reading, observing, and doing.
-<p>
-<strong>Technical</strong>:
-<p>
-• You have a basic understanding of Linux.
-<p>
-• You have a basic understanding of Git.
-<p>
-• You have a basic understanding of databases.
-<p>
-• You have limited working proficiency with codehosts.
-<p>
-• You are familiar with containerized runtimes like Docker and Kubernetes.
-<p>
-• You have a basic understanding of Sourcegraph main product areas.
-   </td>
-   <td><strong>Non-Technical:</strong>
-<p>
-• You solve customer issues, sometimes with guidance, and are able to collaborate with your teammates to help them troubleshoot problems.
-<p>
-• You consistently embody our <a href="../index.md#our-guiding-principles">guiding principles</a> in the cases that you take responsibility for.
-<p>
-• Externally, you are able to effectively and proactively communicate with customers, facilitating collaboratively as appropriate.
-<p>
-• You integrate feedback from teammates to deliver high-quality solutions.
-<p>
-• You increase your communication, product, technical (dev or ops), collaboration, and facilitation knowledge/skills through reading, observing, and doing.
-<p>
-<strong>Technical:</strong>
-<p>
-• You are proficient in the primary elements of deployment types (Docker and Kubernetes).
-<p>
-• You have professional working proficiency of Git.
-<p>
-• You have professional working proficiency of all codehosts - GitHub (Cloud or Self-hosted), GitLab (Cloud or Self-hosted), Bitbucket Server, Bitbucket Data Center, or Perforce.
-<p>
-• You have a strong understanding of Sourcegraph main product areas (Search, Batch Changes, Insights, Monitoring, etc)
-<p>
-• You have a strong understanding of databases.
-<p>
-• You have a strong understanding of containerized runtimes like Docker and Kubernetes.
-<p>
-• You have a strong understanding of cloud technologies.
-   </td>
-   <td><strong>Non-Technical:</strong>
-<p>
-• You are able to effectively facilitate troubleshooting calls with customers independently.
-<p>
-• At any point in time, anyone can review your cases alongside our guiding principles and definitions of success and you meet these at least 95% of the time.
-<p>
-• Externally, you lead all plans for issue resolution, maintaining clear and transparent communications with customers throughout; you identify next steps and followthrough to completion.
-<p>
-• You are skilled at diffusing customer frustrations/escalations.
-<p>
-• You write validated customer-facing documentation updates related to the dev ops aspects of our product.
-<p>
-• You can explain the reasoning and trade-offs behind your decisions, including technical decisions.
-<p>
-• You provide helpful, timely case documentation and/or code reviews.
-<p>
-• You invest in your own growth; willingly exploring new tools, skills, areas of the codebase, etc.
-<p>
-<strong>Technical:</strong>
-<p>
-• You are an expert in all deployment types.
-<p>
-• You have advanced knowledge of Sourcegraph main product areas and are a subject matter expert in at least one product area (Search, Batch Changes, Insights, Monitoring, etc)
-<p>
-• You have advanced knowledge of cloud technologies.
-<p>
-• You have full professional proficiency of Git.
-<p>
-• You have a working understanding of 1 or more of Sourcegraph's codebase languages (Go, Javascript, Python, Typescript) while developing proficiency in the rest.
-   </td>
-   <td><strong>Non-Technical</strong>:
-<p>
-• You are an expert in your domain: you have a deep understanding of our product and codebase/dev ops practices, and are a skilled communicator, collaborator and facilitator.
-<p>
-• You have in depth knowledge of the existing codebase and stay abreast of new refactors, omissions, etc.
-<p>
-• You find technical solutions to open-ended, ambiguously defined problems (in our product or centered on the support team/workflow).
-<p>
-• When finding solutions, you identify the core problems that need to be solved, as well as goals, risks, trade-offs, customer impact, technical debt, non-technical factors, etc.
-<p>
-• You give insightful feedback on higher-level aspects (architecture, scalability, customer-focus, etc.) in case/code reviews and RFCs, holding teammates to the same high standard you set for yourself.
-<p>
-• You maintain awareness of approaches outside of Sourcegraph that we’re not using, and use this to help define best practices for the team/domain.
-<p>
-<strong>Technical</strong>:
-<p>
-• You are a subject matter expert in all deployment types, and act as a mentor to IC1s and IC2s.
-<p>
-• You are an expert in cloud technologies.
-<p>
-• You are well-versed in all Sourcegraph features and contextual concepts.
-<p>
-• You are an expert in Git.
-<p>
-• You have full proficiency in all codehosts and have working knowledge of, at least, one other codehost apart from GitHub, GitLab, BitBucket or Perforce.
-<p>
-• You are proficient in writing code in Go, Javascript, Python or any of our core programming languages.
-<p>
-• You write maintainable, well-tested code (for our product or for team tooling) that aligns with the style and practices of the team/codebase.
-   </td>
-   <td><strong>Non-Technical</strong>:
-<p>
-• You make high-quality technical, and non-technical, decisions leading team-sized tasks that affect one or more complex systems or mission-critical areas.
-<p>
-• You consistently incorporate non-technical factors into technical decisions and weigh them appropriately.
-<p>
-• You have proficiency beyond your domain areas, understanding more about business operations and/or engineering scope/efforts.
-<p>
-• You invest in technology, tools, and processes that benefit your entire team.
-<p>
-• You lift your teammates through feedback, mentorship, and sharing reusable patterns.
-<p>
-<strong>Technical</strong>:
-<p>
-• You are a subject matter expert in all Sourcegraph features and contextual concepts and regularly help unblock and enable your teammates.
-<p>
-• You have full proficiency in all codehosts and have working knowledge of multiple other codehosts apart from GitHub, GitLab, BitBucket or Perforce.
-<p>
-• You are an expert in writing code in Go, Javascript, Python or any of our core programming languages.
-   </td>
-   <td><strong>Non-Technical</strong>:
-<p>
-• You help set the vision for the team and influence the broader vision beyond the team.
-<p>
-• You lead cross functional projects that impact aspects of the business both within, and outside, your primary domain.
-<p>
-• You provide oversight, coaching, and guidance through case/code reviews and other activities, both on or off the team.
-<p>
-<strong>Technical</strong>:
-<p>
-• You contribute at least 10 PRs per quarter in support of Product and Engineering defined needs.
-   </td>
-  </tr>
-  <tr>
-   <td>Delivery
-   </td>
-   <td>• Under the guidance of your manager, you create a plan to consistently deliver on your commitments, while creating space to allow for learning, growth and rest.
-<p>
-• You exercise profound compassion, with colleagues and customers.
-<p>
-• You recognize when you are blocked and ask for support.
-   </td>
-   <td>• You manage your day-to-day workflow appropriately to reliably deliver on your commitments, adhering to all defined team processes and workflows.
-<p>
-• You ask for guidance in unfamiliar areas or for underspecified tasks and speak up if you are not at ease with what you understand you need to do.
-<p>
-• You have a general understanding of how users interact with our product/infrastructure.
-<p>
-• You are able to establish rapport with customers and colleagues to achieve meaningful and productive conversation.
-<p>
-• Your tickets are maintained and kept up-to-date to allow for accurate team-level reporting.
-   </td>
-   <td>• You prioritize your work in alignment with team/company goals and objectives.
-<p>
-• You scope and implement solutions to pre-defined problems, with guidance.
-<p>
-• You detect problems (in the product or our processes) that could erode the customer experience and actively engage to resolve them.
-<p>
-• You firmly grasp how users interact with our product/infrastructure.
-<p>
-• You are skilled in establishing rapport with customers and colleagues, and consistently deliver results on time.
-   </td>
-   <td>• You independently scope and implement solutions to complex, loosely-defined problems.
-<p>
-• You estimate methodically, based on iterative learning and set realistic expectations/timelines that drive effort and support healthy work habits.
-<p>
-• When faced with roadblocks, you identify appropriate courses of action, engaging others or unblocking yourself as appropriate.
-<p>
-• You are accountable end-to-end on everything for which you take responsibility.
-<p>
-• You proactively identify areas for improvement and balance new work with the necessary day-to-day tasks needed to keep the team operating well to provide a positive customer experience.
-   </td>
-   <td>• You independently scope and implement solutions to extremely complex and/or vague customer issues, and identify the problems to be solved.
-<p>
-• You remain composed in: ambiguous situations, challenging situations, situations involving multiple stakeholders, etc.
-<p>
-• You intentionally and proactively align your work around a deep understanding of how people use the products/customer experience.
-<p>
-• You proactively identify areas for improvement beyond the scope of our team and contribute meaningfully to solutions while continuing to deliver on our team’s goals.
-   </td>
-   <td>• You proactively identify areas for improvement at the org/company level.
-<p>
-• You suggest process and methodology improvements.
-<p>
-• You work closely with engineering and CE leadership to validate alignment between teams.
-<p>
-• You are highly skilled at scoping, designing, and delivering solutions for large, complex challenges.
-   </td>
-  </tr>
-  <tr>
-   <td>Teamwork
-   </td>
-   <td>• You actively ask teammates, including cross-functional (e.g. engineering), questions to seek feedback and clarity.
-<p>
-• You participate and demonstrate curiosity in team meetings.
-<p>
-• You follow documented team processes and seek clarification when in doubt.
-<p>
-• You communicate with candor and transparency.
-   </td>
-   <td>• You actively participate and are able to initiate conversation in team and cross-functional meetings.
-<p>
-• You suggest improvements to team processes and help keep the handbook up-to-date.
-<p>
-• You communicate thoughtfully and intentionally, both synchronously and asynchronously.
-<p>
-• You are flexible to change.
-<p>
-• You resist group think and help the team maintain productive, healthy dialogues.
-   </td>
-   <td>• You communicate clearly, both synchronously and asynchronously, escalating blockers quickly, clarifying requirements and sharing assumptions and context.
-<p>
-• You set the example on defining/modifying team processes; participating in identifying problems, suggesting improvements, and helping with solutions.
-<p>
-• You proactively add and edit handbook documentation to help others.
-<p>
-• You offer timely, helpful feedback to others and trust them to decide to what extent to incorporate it.
-<p>
-• You help onboarding and orienting new team members.
-<p>
-• You participate in the hiring process where possible, conducting interviews (with training) and writing helpful feedback.
-   </td>
-   <td>• You communicate technical and non-technical issues and decisions clearly, bringing clarity to discussions, and help to drive the process forward.
-<p>
-• You routinely drive improvements in team/company processes (retros, planning, etc).
-<p>
-• You consider the effects of your work and words on other teams and represent the Support team well in discussions with cross-functional teammates, customers, and stakeholders.
-<p>
-• You share your experience and expertise to help others grow, through mentoring and coaching where possible.
-<p>
-• You proactively propose additions and changes to the team’s forward plans.
-   </td>
-   <td>• You are thoughtfully (and with empathy) able to convince and challenge teammates and cross-functional stakeholders using valid expertise and respectful communication.
-<p>
-• You actively seek dissenting opinions, disconfirming evidence, etc.
-<p>
-• You share a long-term vision that influences the team’s go forward plans.
-<p>
-• You operate in a way that demonstrates self-awareness (you often identify feedback before anyone has to give it to you) and active intentionality (you have a plan before you communicate/act).
-   </td>
-   <td>• You provide domain/technical expertise internally and externally, informing what can be achieved.
-<p>
-• You actively coach others on effective communication, collaboration and conflict resolution skills.
-<p>
-• You regularly share knowledge and mentor teammates
-<p>
-• You possess a visible external presence and willingly present to large and/or senior audiences to represent the Support team.
-<p>
-• You persuade and challenge customers and internal stakeholders, using valid expertise and respectful communication.
-   </td>
-  </tr>
+  <thead>
+    <tr>
+      <th scope="col">Level</th>
+      <th scope="col" class="category-title">Non-Technical Proficiency</th>
+      <th scope="col" class="category-title">Technical Proficiency</th>
+      <th scope="col" class="category-title">Delivery</th>
+      <th scope="col" class="category-title">Teamwork</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <!-- IC1 -->
+    <tr>
+      <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        An individual new to the field with no prior industry experience; focused on learning, growth, and establishing themselves as a contributing member of the team. Entry Level.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Troubleshoots and resolves common customer issues with guidance.</li>
+          <li>Demonstrates the essential needed to do work in our domain (as outlined in our<a href="../../support/index.md#our-guiding-principles"> guiding principles</a>).</li>
+          <li>Willingly receives feedback from teammates to delivers positive outcomes for customers and the team.</li>
+          <li>Increases their knowledge of Sourcegraph, our customers, team, general processes and workflows through reading, observing, and doing.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Has a basic understanding of Linux.</li>
+          <li>Has a basic understanding of Git.</li>
+          <li>Has a basic understanding of databases.</li>
+          <li>Has limited working proficiency with code hosts.</li>
+          <li>Is familiar with containerized runtimes like Docker and Kubernetes.</li>
+          <li>Has a basic understanding of Sourcegraph main product areas.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Under the guidance of their manager, can create a plan to consistently deliver on their commitments, while creating space to allow for learning, growth and rest.</li>
+          <li>Exercises profound compassion, with colleagues and customers.</li>
+          <li>Recognizes when they are blocked and asks for support.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Actively asks teammates, including cross-functional (e.g. engineering), questions to seek feedback and clarity.</li>
+          <li>Participates and demonstrates curiosity in team meetings.</li>
+          <li>Follows documented team processes and seeks clarification when in doubt.</li>
+          <li>Communicates with candor and transparency.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC2 -->
+    <tr>
+      <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        An individual beginning to autonomously contribute, execute, and collaborate on routine customer issues while developing their skills. Associate.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Solves customer issues, sometimes with guidance, and is able to collaborate with their teammates to help them troubleshoot problems.</li>
+          <li>Consistently embodies our <a href="../index.md#our-guiding-principles">guiding principles</a> in the cases that they take responsibility for.</li>
+          <li>Externally, is able to effectively and proactively communicate with customers, facilitating collaboratively as appropriate.</li>
+          <li>Integrates feedback from teammates to deliver high-quality solutions.</li>
+          <li>Increases their communication, product, technical (dev or ops), collaboration, and facilitation knowledge/skills through reading, observing, and doing.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is proficient in the primary elements of deployment types (Docker and Kubernetes).</li>
+          <li>Has professional working proficiency of Git.</li>
+          <li>Has professional working proficiency of all code hosts - GitHub (Cloud or Self-hosted), GitLab (Cloud or Self-hosted), Bitbucket Server, Bitbucket Data Center, or Perforce.</li>
+          <li>Has a strong understanding of Sourcegraph main product areas (Search, Batch Changes, Insights, Monitoring, etc)
+          <li>Has a strong understanding of databases.</li>
+          <li>Has a strong understanding of containerized runtimes like Docker and Kubernetes.</li>
+          <li>Has a strong understanding of cloud technologies.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Manages their day-to-day workflow appropriately to reliably deliver on their commitments, adhering to all defined team processes and workflows.</li>
+          <li>Asks for guidance in unfamiliar areas or for underspecified tasks and speaks up if is not at ease with what they understand they need to do.</li>
+          <li>Has a general understanding of how users interact with our product/infrastructure.</li>
+          <li>Is able to establish rapport with customers and colleagues to achieve meaningful and productive conversation.</li>
+          <li>Their tickets are maintained and kept up-to-date to allow for accurate team-level reporting.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Actively participates and is able to initiate conversation in team and cross-functional meetings.</li>
+          <li>Suggests improvements to team processes and helps keep the handbook up-to-date.</li>
+          <li>Communicates thoughtfully and intentionally, both synchronously and asynchronously.</li>
+          <li>Is flexible to change.</li>
+          <li>Resists group think and helps the team maintain productive, healthy dialogues.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC3 -->
+    <tr>
+      <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        A mid-level individual contributor beginning to independently solve for more complex customer issues. Specialist.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Is able to effectively facilitate troubleshooting calls with customers independently.</li>
+          <li>At any point in time, anyone can review their cases alongside our guiding principles and definitions of success, and they meet these at least 95% of the time.</li>
+          <li>Externally, they lead all plans for issue resolution, maintaining clear and transparent communications with customers throughout; they identify next steps and followthrough to completion.</li>
+          <li>Is skilled at diffusing customer frustrations/escalations.</li>
+          <li>Writes validated customer-facing documentation updates related to the dev ops aspects of our product.</li>
+          <li>Can explain the reasoning and trade-offs behind their decisions, including technical decisions.</li>
+          <li>Provides helpful, timely case documentation and/or code reviews.</li>
+          <li>Invests in their own growth; willingly exploring new tools, skills, areas of the codebase, etc.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is an expert in all deployment types.</li>
+          <li>Has advanced knowledge of Sourcegraph main product areas and is a subject matter expert in at least one product area (Search, Batch Changes, Insights, Monitoring, etc)
+          <li>Has advanced knowledge of cloud technologies.</li>
+          <li>Has full professional proficiency of Git.</li>
+          <li>Has a working understanding of 1 or more of Sourcegraph's codebase languages (Go, Javascript, Python, Typescript) while developing proficiency in the rest.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Prioritizes their work in alignment with team/company goals and objectives.</li>
+          <li>Scopes and implements solutions to pre-defined problems, with guidance.</li>
+          <li>Detects problems (in the product or our processes) that could erode the customer experience and actively engages to resolve them.</li>
+          <li>Firmly grasps how users interact with our product/infrastructure.</li>
+          <li>Is skilled in establishing rapport with customers and colleagues, and consistently delivers results on time.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Communicates clearly, both synchronously and asynchronously, escalating blockers quickly, clarifying requirements and sharing assumptions and context.</li>
+          <li>Sets the example on defining/modifying team processes; participating in identifying problems, suggesting improvements, and helping with solutions.</li>
+          <li>Proactively adds and edits handbook documentation to help others.</li>
+          <li>Offers timely, helpful feedback to others and trusts them to decide to what extent to incorporate it.</li>
+          <li>Helps onboarding and orienting new team members.</li>
+          <li>Participates in the hiring process where possible, conducting interviews (with training) and writing helpful feedback.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC4 -->
+    <tr>
+      <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        A senior-level individual contributor that has demonstrated capabilities to consistently resolve more complex customer issues independently. Senior.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Is an expert in their domain: they have a deep understanding of our product and codebase/dev ops practices, and are a skilled communicator, collaborator and facilitator.</li>
+          <li>Has in-depth knowledge of the existing codebase and stays abreast of new refactors, omissions, etc.</li>
+          <li>Finds technical solutions to open-ended, ambiguously-defined problems (in our product or centered on the support team/workflow).</li>
+          <li>When finding solutions, identifies the core problems that need to be solved, as well as goals, risks, trade-offs, customer impact, technical debt, non-technical factors, etc.</li>
+          <li>Gives insightful feedback on higher-level aspects (architecture, scalability, customer-focus, etc.) in case/code reviews and RFCs, holding teammates to the same high standard they set for themself.</li>
+          <li>Maintains awareness of approaches outside of Sourcegraph that we’re not using, and uses this to help define best practices for the team/domain.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is a subject matter expert in all deployment types, and acts as a mentor to IC1s and IC2s.</li>
+          <li>Is an expert in cloud technologies.</li>
+          <li>Is well-versed in all Sourcegraph features and contextual concepts.</li>
+          <li>Is an expert in Git.</li>
+          <li>Has full proficiency in all code hosts and working knowledge of at least one other code host apart from GitHub, GitLab, BitBucket or Perforce.</li>
+          <li>Is proficient in writing code in Go, Javascript, Python or any of our core programming languages.</li>
+          <li>Writes maintainable, well-tested code (for our product or for team tooling) that aligns with the style and practices of the team/codebase.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Independently scopes and implements solutions to complex, loosely-defined problems.</li>
+          <li>Estimates methodically, based on iterative learning, and sets realistic expectations/timelines that drive effort and support healthy work habits.</li>
+          <li>When faced with roadblocks, identifies appropriate courses of action, engaging others or unblocking themself as appropriate.</li>
+          <li>Is accountable end-to-end on everything for which they take responsibility.</li>
+          <li>Proactively identifies areas for improvement and balances new work with the necessary day-to-day tasks needed to keep the team operating well to provide a positive customer experience.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Communicates technical and non-technical issues and decisions clearly, bringing clarity to discussions, and helps to drive the process forward.</li>
+          <li>Routinely drives improvements in team/company processes (retros, planning, etc).</li>
+          <li>Considers the effects of their work and words on other teams, and represents the Support team well in discussions with cross-functional teammates, customers, and stakeholders.</li>
+          <li>Shares their experience and expertise to help others grow, through mentoring and coaching where possible.</li>
+          <li>Proactively proposes additions and changes to the team’s forward plans.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC5 -->
+    <tr>
+      <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        A particularly experienced individual who excels in their capabilities with a focus on leadership and growth; possesses unique knowledge and ability to navigate the most complex customer issues and inquiries; takes on an active role in mentoring IC1s-IC4s. Lead.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Makes high-quality technical and non-technical decisions leading team-sized tasks that affect one or more complex systems or mission-critical areas.</li>
+          <li>Consistently incorporates non-technical factors into technical decisions and weighs them appropriately.</li>
+          <li>Has proficiency beyond their domain areas, understanding more about business operations and/or engineering scope/efforts.</li>
+          <li>Invests in technology, tools, and processes that benefit their entire team.</li>
+          <li>Lifts their teammates through feedback, mentorship, and sharing reusable patterns.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is a subject matter expert in all Sourcegraph features and contextual concepts, and regularly helps unblock and enable their teammates.</li>
+          <li>Has full proficiency in all code hosts and working knowledge of multiple other code hosts apart from GitHub, GitLab, BitBucket or Perforce.</li>
+          <li>Is an expert in writing code in Go, Javascript, Python or any of our core programming languages.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Independently scopes and implements solutions to extremely complex and/or vague customer issues, and identifies the problems to be solved.</li>
+          <li>Remains composed in: ambiguous situations, challenging situations, situations involving multiple stakeholders, etc.</li>
+          <li>Intentionally and proactively aligns their work around a deep understanding of how people use the products/customer experience.</li>
+          <li>Proactively identifies areas for improvement beyond the scope of our team and contributes meaningfully to solutions while continuing to deliver on our team’s goals.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Is thoughtfully (and with empathy) able to convince and challenge teammates and cross-functional stakeholders using valid expertise and respectful communication.</li>
+          <li>Actively seeks dissenting opinions, disconfirming evidence, etc.</li>
+          <li>Shares a long-term vision that influences the team’s go forward plans.</li>
+          <li>Operates in a way that demonstrates self-awareness (often identifies feedback before anyone has to give it to them) and active intentionality (has a plan before they communicate/act).</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC6 -->
+    <tr>
+      <th id="ic6" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic6"></a><abbr title="Individual Contributor">IC</abbr>6</th>
+    </tr>
+    <tr>
+      <td class="level-summary" colspan="4">
+        A subject matter expert with a visible external brand/presence; equivalent in impact to a Manager, and acts as a mentor to preceding IC level team members. Principal.</li>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors">
+        <ul>
+          <li>Helps set the vision for the team and influences the broader vision beyond the team.</li>
+          <li>Leads cross functional projects that impact aspects of the business both within, and outside, their primary domain.</li>
+          <li>Provides oversight, coaching, and guidance through case/code reviews and other activities, both on or off the team.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Contributes at least 10 PRs per quarter in support of Product and Engineering defined needs.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Proactively identifies areas for improvement at the org/company level.</li>
+          <li>Suggests process and methodology improvements.</li>
+          <li>Works closely with engineering and CE leadership to validate alignment between teams.</li>
+          <li>Is highly skilled at scoping, designing, and delivering solutions for large, complex challenges.</li>
+        </ul>
+      </td>
+      <td class="behaviors">
+        <ul>
+          <li>Provides domain/technical expertise internally and externally, informing what can be achieved.</li>
+          <li>Actively coaches others on effective communication, collaboration and conflict resolution skills.</li>
+          <li>Regularly shares knowledge and mentors teammates.</>
+          <li>Possesses a visible external presence and willingly presents to large and/or senior audiences to represent the Support team.</li>
+          <li>Persuades and challenges customers and internal stakeholders, using valid expertise and respectful communication.</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
 </table>

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -203,8 +203,7 @@ const remarkSpecialWarningBlocks: Plugin<[], MdastRoot> = () =>
 const rehypeResponsiveTables: Plugin<[], Root> = () => tree => {
     visit(tree, (node, index, parent) => {
         if (isElement(node, 'table')) {
-            // Note: Matches breakpoint used for th.sticky CSS class
-            parent!.children[index!] = h('div.table-responsive-sm', node)
+            parent!.children[index!] = h('div.table-responsive', node)
         }
     })
 }

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -398,16 +398,6 @@ kbd {
         overflow: auto;
     }
 
-    // Can be applied to <th> table header cells
-    // Only apply above small size, because on small we use scrolling table wrappers that conflict with sticky headers.
-    @include media-breakpoint-up(sm) {
-        th.sticky {
-            position: sticky;
-            top: calc(var(--header-height) - 1px);
-            z-index: 2;
-        }
-    }
-
     table {
         th {
             font-weight: 600;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -21,3 +21,4 @@ $text-muted: var(--gray-05);
 
 @import './badges.scss';
 @import './cards.scss';
+@import './levels-table.scss';

--- a/src/styles/levels-table.scss
+++ b/src/styles/levels-table.scss
@@ -1,0 +1,97 @@
+.levels-table {
+    --category-color-1: var(--sg-vivid-violet);
+    --category-color-2: var(--sg-sky-blue);
+    --category-color-3: var(--sg-vermillion);
+    --category-color-4: var(--sg-mint);
+    --category-color-5: var(--sg-lemon);
+
+    table-layout: fixed;
+}
+.levels-table :is(td, th) {
+    vertical-align: top;
+    background: white;
+}
+thead th:first-child {
+    width: 8ch;
+}
+thead th.category-title {
+    width: 36ch;
+    text-align: center;
+    border-color: white;
+    &:nth-of-type(5n + 2) {
+        color: white;
+        background: var(--category-color-1);
+    }
+    &:nth-of-type(5n + 3) {
+        background: var(--category-color-2);
+    }
+    &:nth-of-type(5n + 4) {
+        color: white;
+        background: var(--category-color-3);
+    }
+    &:nth-of-type(5n) {
+        background: var(--category-color-4);
+    }
+    &:nth-of-type(5n + 1) {
+        background: var(--category-color-5);
+    }
+}
+/*
+  Repeat the category color as a border color after each category summary.
+  Safari doesn't respect different border colors below a cell spanning multiple columns,
+  so we need to draw borders on wrapper elements instead.
+  */
+.levels-table .category-summaries-row {
+    border-top: none;
+}
+.levels-table .category-summary {
+    border-top: none;
+    padding: 0;
+}
+.category-summary > .wrapper {
+    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
+    width: 100%;
+    padding: 6px 13px;
+}
+.category-summary {
+    &:nth-of-type(n) > .wrapper {
+        border-top: 1px solid var(--category-color-1);
+    }
+    &:nth-of-type(2n) > .wrapper {
+        border-top: 1px solid var(--category-color-2);
+    }
+    &:nth-of-type(3n) > .wrapper {
+        border-top: 1px solid var(--category-color-3);
+    }
+}
+.level {
+    white-space: nowrap;
+}
+.levels-table td[colspan] {
+    text-align: center;
+}
+.level-summary,
+.category-summaries-row {
+    font-style: italic;
+}
+.level-summary {
+    border-bottom: none !important;
+    ul {
+        text-align: left;
+    }
+    li {
+        margin-top: 0.25em;
+    }
+}
+.levels-table td.tbd {
+    vertical-align: middle;
+    text-align: left;
+    padding: 2.5rem;
+}
+/*
+  Safari doesn't make the IC6 row equal size automatically, so give it explicit height.
+  Note that min-height also doesn't work.
+  */
+th#ic6 {
+    height: 11rem;
+}

--- a/src/styles/levels-table.scss
+++ b/src/styles/levels-table.scss
@@ -67,9 +67,6 @@ thead th.category-title {
 .level {
     white-space: nowrap;
 }
-.levels-table td[colspan] {
-    text-align: center;
-}
 .level-summary,
 .category-summaries-row {
     font-style: italic;

--- a/src/styles/levels-table.scss
+++ b/src/styles/levels-table.scss
@@ -54,14 +54,20 @@ thead th.category-title {
     padding: 6px 13px;
 }
 .category-summary {
-    &:nth-of-type(n) > .wrapper {
+    &:nth-of-type(5n + 1) {
         border-top: 1px solid var(--category-color-1);
     }
-    &:nth-of-type(2n) > .wrapper {
+    &:nth-of-type(5n + 2) {
         border-top: 1px solid var(--category-color-2);
     }
-    &:nth-of-type(3n) > .wrapper {
+    &:nth-of-type(5n + 3) {
         border-top: 1px solid var(--category-color-3);
+    }
+    &:nth-of-type(5n + 4) {
+        border-top: 1px solid var(--category-color-4);
+    }
+    &:nth-of-type(5n) {
+        border-top: 1px solid var(--category-color-5);
     }
 }
 .level {


### PR DESCRIPTION
This is a big PR with a lot of lines modified but **no content is actually fundamentally changed by it**. I noticed when reviewing the eng career framework changes that the table was painfully broken on mobile (or any window smaller than full-size desktop, really), and the other departments tables were either equally bad or worse. In fixing the table responsiveness, I was bothered by how inconsistent the framework tables appeared, so I also attempt in this PR to unify them on a couple other fronts. 🙂

### CSS changes
- Fixes responsiveness of tables in the handbook so that they always become horizontally scrollable once they get sufficiently wide
  - Doing so required removing sticky headers for the tables. The only tables that made use of the sticky header were the career leveling framework tables, and I'd argue that sane cell widths are way more critical to table usability than sticky headers
- Sets appropriate widths to the columns of the tables for the career leveling frameworks
- Extracts the common CSS spread across the 5 instances of career leveling framework tables so that the CSS is no longer duplicated 5 times
- Generalizes the cycling of the header color scheme for leveling framework tables

### Layout consistency changes
- Updates all instances of career framework tables to use the same axis orientation: proficiency areas across the x-axis and levels down the y-axis (this required "rotating" tables in several cases)
- Unifies presentation of table headers
- Unifies presentation of general level descriptions
- Unifies usage of unordered lists in table cells

### Language/voice changes
- Updates all instances of career framework tables to use the 3rd person voice (uses descriptions of the form "Does a thing", rather than "[You] do a thing" or "I do a thing")
- Fixes a number of typos

### Demo

#### Eng framework (full demo):

Desktop:

Before | After
:------:|:------:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/8942601/225254218-37657d0f-9847-41b3-b684-b8bf88782d2d.png"> | <video src="https://user-images.githubusercontent.com/8942601/225252301-b3f00b6b-ca2d-4e93-93ef-a875e54ab688.mov"></video>

Mobile:

Before | After
:------:|:-----:
<video src="https://user-images.githubusercontent.com/8942601/225254591-5c5ebf1b-bc8a-4ec5-a8a7-5be3289a4e8b.mov"></video> | <video src="https://user-images.githubusercontent.com/8942601/225252523-93594336-6256-41d3-a2c6-60579b57dd7b.mov"></video>

For the other departments, I didn't record videos for mobile every time but the behavior is the same as for eng now.

#### Design (screenshot since there's only 3 columns):

Before | After
:------:|:------:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/8942601/225254047-d6ca2164-3846-4911-9536-407f6efff391.png"> | <img width="1016" alt="image" src="https://user-images.githubusercontent.com/8942601/225251979-ce36c824-ae1d-4ecf-a27b-7b3c66e10d00.png">

#### Product:

Before | After
:------:|:-----:
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/8942601/225253860-c2ddbdbe-fabb-4cba-9951-bf0f54a535e5.png"> | <video src="https://user-images.githubusercontent.com/8942601/225252008-6d316c71-ba56-4a94-b73e-82b3a586f079.mov"></video>

#### CE:

Before | After
:------:|:-----:
<img width="1203" alt="image" src="https://user-images.githubusercontent.com/8942601/225253669-1a77d477-3780-4d46-9f5c-cf3115848b99.png"> | <video src="https://user-images.githubusercontent.com/8942601/225252048-9aba8c2d-29ef-48f7-aac1-e1039b456491.mov"></video>

#### CS:

Before | After
:------:|:-----:
<img width="1203" alt="image" src="https://user-images.githubusercontent.com/8942601/225253435-64136a7c-50a4-4d80-b3a2-81f9b7bebae3.png"> | <video src="https://user-images.githubusercontent.com/8942601/225252084-a85f7e18-cf62-4d85-a005-3ef6d42dabc3.mov"></video>
