### PR TITLE
make the levels table appear without horizontal scrollbar

### DIFF
--- a/content/departments/engineering/design/career-development.md
+++ b/content/departments/engineering/design/career-development.md
@@ -17,7 +17,7 @@ It’s important to understand that what is listed in the level descriptions are
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -113,7 +113,7 @@ As an IC you'll progress on several axis:
 
 <style>
   .container {
-    --width: 1620px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -113,7 +113,7 @@ As an IC you'll progress on several axis:
 
 <style>
   .container {
-    --width: 1300px;
+    --width: 1620px;
   }
 </style>
 

--- a/content/departments/engineering/product/career-development/framework.md
+++ b/content/departments/engineering/product/career-development/framework.md
@@ -4,7 +4,7 @@
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/technical-success/ce/career-growth/index.md
+++ b/content/departments/technical-success/ce/career-growth/index.md
@@ -67,7 +67,7 @@ Learn more about CEs transitioning to CE management [here](cemgr-candidates-inte
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/technical-success/support/career-growth/cs-career-levels.md
+++ b/content/departments/technical-success/support/career-growth/cs-career-levels.md
@@ -30,7 +30,7 @@ Promotions from one level to another are considered in impact reviews conducted 
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/src/styles/levels-table.scss
+++ b/src/styles/levels-table.scss
@@ -1,3 +1,8 @@
+:root {
+    // Enough to show 4 full columns and a peek of a 5th column, if there is one.
+    --container-width: 210ch;
+}
+
 .levels-table {
     --category-color-1: var(--sg-vivid-violet);
     --category-color-2: var(--sg-sky-blue);


### PR DESCRIPTION
The right side of the table was hidden for me and I did not notice the scrollbar, since it's only on the bottom of the rather large table

## Before
<img width="1262" alt="Screenshot 2023-03-17 at 15 18 30" src="https://user-images.githubusercontent.com/9974711/225931003-48f788fc-6007-4ac7-a550-fcb082109820.png">


## After

<img width="1617" alt="Screenshot 2023-03-17 at 15 18 16" src="https://user-images.githubusercontent.com/9974711/225931029-c45272be-7909-4cd1-8c5a-b0ae1d2fb109.png">
