### PR TITLE
Set width variable based on character size

### DIFF
--- a/content/departments/engineering/design/career-development.md
+++ b/content/departments/engineering/design/career-development.md
@@ -17,7 +17,7 @@ It’s important to understand that what is listed in the level descriptions are
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -113,7 +113,7 @@ As an IC you'll progress on several axis:
 
 <style>
   .container {
-    --width: 1620px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/engineering/product/career-development/framework.md
+++ b/content/departments/engineering/product/career-development/framework.md
@@ -4,7 +4,7 @@
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/technical-success/ce/career-growth/index.md
+++ b/content/departments/technical-success/ce/career-growth/index.md
@@ -67,7 +67,7 @@ Learn more about CEs transitioning to CE management [here](cemgr-candidates-inte
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/content/departments/technical-success/support/career-growth/cs-career-levels.md
+++ b/content/departments/technical-success/support/career-growth/cs-career-levels.md
@@ -30,7 +30,7 @@ Promotions from one level to another are considered in impact reviews conducted 
 
 <style>
   .container {
-    --width: 1300px;
+    --width: var(--container-width);
   }
 </style>
 

--- a/src/styles/levels-table.scss
+++ b/src/styles/levels-table.scss
@@ -1,3 +1,8 @@
+:root {
+    // Enough to show 4 full columns and a peek of a 5th column, if there is one.
+    --container-width: 210ch;
+}
+
 .levels-table {
     --category-color-1: var(--sg-vivid-violet);
     --category-color-2: var(--sg-sky-blue);


### PR DESCRIPTION
Sets a `--container-width` custom property based on character width to apply to the parent container of all the career level framework pages with tables. This width makes it such that 4 full columns can fit on the page at any given time. If a table contains more than 4 columns, the container is wide enough for to peak the 5th column, revealing there's horizontal overflow. For example:

4 Columns | 5+ Columns
-----------|-------------
<img width="1705" alt="image" src="https://user-images.githubusercontent.com/8942601/225980425-0740c6c6-f159-46a6-868e-3b8960141a2f.png"> | <img width="1968" alt="image" src="https://user-images.githubusercontent.com/8942601/225980197-7ad6ec1e-f3e8-4549-a017-8bc0bff3a7fe.png">
