### PR TITLE
Update use cases with direct links

### DIFF
--- a/content/strategy-goals/strategy/use-cases/index.md
+++ b/content/strategy-goals/strategy/use-cases/index.md
@@ -1,3 +1,7 @@
 # Use cases
 
-See [parent page](../index.md#use-cases) for the index of use cases and related resources.
+- [Developer onboarding](dev-onboarding/)
+- [Code reuse](code-reuse/)
+- [Code health](code-health/)
+- [Code security](code-security/)
+- [Incident response](incident-response/)

--- a/content/strategy-goals/strategy/use-cases/index.md
+++ b/content/strategy-goals/strategy/use-cases/index.md
@@ -1,7 +1,7 @@
 # Use cases
 
-- [Developer onboarding](dev-onboarding/)
-- [Code reuse](code-reuse/)
-- [Code health](code-health/)
-- [Code security](code-security/)
-- [Incident response](incident-response/)
+- [Developer onboarding](dev-onboarding/index.html)
+- [Code reuse](code-reuse/index.html)
+- [Code health](code-health/index.html)
+- [Code security](code-security/index.html)
+- [Incident response](incident-response/index.html)


### PR DESCRIPTION
Link to the use cases directly since the strategy page currently doesn't