### PR TITLE
banner: add link to new Cloud landing page

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -16,7 +16,8 @@ export function Banner({ path }: { path: string }): JSX.Element {
             <aside className="warning">
                 <div>
                     <b>
-                        To learn more about the Sourcegraph Cloud product, please refer to our{' '}
+                        To learn more about the{' '}
+                        <a href="https://about.sourcegraph.com/cloud">Sourcegraph Cloud product</a>, please refer to our{' '}
                         <a href="https://docs.sourcegraph.com/cloud">user-facing documentation</a>.
                     </b>{' '}
                     The documentation here is meant for internal Sourcegraph use, and may represent unreleased,


### PR DESCRIPTION
Add link to https://about.sourcegraph.com/cloud, the new Cloud landing page, in the warning banner that is added to Cloud handbook pages.