### PR TITLE
Add support to autolink golinks

### DIFF
--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -24,6 +24,7 @@ import { visit } from 'unist-util-visit'
 import { VFile } from 'vfile'
 
 import * as generatedMarkdown from './generatedMarkdown'
+import { rehypeGoLinks } from './rehypeGoLinks'
 import { rehypeMarkupDates } from './rehypeMarkupDates'
 import { rehypeSlackChannels } from './rehypeSlackChannels'
 import { rehypeSmartypants } from './rehypeSmartypants'
@@ -81,6 +82,7 @@ export default async function markdownToHtml(
         .use(rehypeSmartypants, { backticks: false, dashes: 'oldschool' })
         .use(rehypeMarkupDates)
         .use(rehypeSlackChannels)
+        .use(rehypeGoLinks)
         // Wrap all tables in Bootstrap's responsive helper to make them scroll instead of overflowing
         .use(rehypeResponsiveTables)
         // Trim .md suffix from links

--- a/src/lib/rehypeGoLinks.ts
+++ b/src/lib/rehypeGoLinks.ts
@@ -1,0 +1,37 @@
+import { ElementContent } from 'hast'
+import { defaultIgnore, findAndReplace } from 'hast-util-find-and-replace'
+import type { Node } from 'hast-util-find-and-replace/lib/index'
+import { h } from 'hastscript'
+import { Plugin } from 'unified'
+
+// goLinksPattern matches go/something links, e.g. go/sg or go/sg-frontend
+// It only matches the beginning of a string or preceded by whitespace
+// to avoid the case where this-is-not-a-go/link is matched
+const goLinksPattern = /(^|\s)go\/([\w-]+)(\W|$)/g
+
+// eslint-disable-next-line unicorn/consistent-function-scoping
+export const rehypeGoLinks: Plugin = () => root =>
+    findAndReplace(
+        root as Node,
+        goLinksPattern,
+        (...args: unknown[]): ElementContent[] => {
+            const [, prefix, name, suffix] = args as string[]
+            return [
+                { type: 'text', value: prefix },
+                h(
+                    'a',
+                    {
+                        class: 'go-link',
+                        href: `http://go/${name}`,
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                    },
+                    `go/${name}`
+                ),
+                { type: 'text', value: suffix },
+            ]
+        },
+        {
+            ignore: [...defaultIgnore, 'code', 'a'],
+        }
+    )

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -47,6 +47,18 @@ kbd {
         }
     }
 
+    .go-link {
+        border-radius: 3px;
+        background: rgba(48, 149, 192, 0.1);
+        color: rgb(18, 100, 163);
+        padding: 0 2px 1px 2px;
+        &:hover {
+            text-decoration: none;
+            background: rgba(29, 155, 209, 0.2);
+            color: rgb(11, 76, 140);
+        }
+    }
+
     .octicon {
         display: inline-block;
         vertical-align: text-top;


### PR DESCRIPTION
add support to autolink go links, e.g., `go/cloud-ops`, `go/glossory`

### Test plan

tested locally and it worked

![CleanShot 2023-03-30 at 11 09 24](https://user-images.githubusercontent.com/8373004/228926179-aa9b63d3-b6b2-44a8-89f2-2ee086c82003.png)

also tested the regex against all `*.md` in the handbook, only go links are matched

![CleanShot 2023-03-30 at 11 10 03](https://user-images.githubusercontent.com/8373004/228926332-57a1408c-258c-48ec-965b-3f0d40b883da.png)

