### PR TITLE
restore team emails

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -4,6 +4,7 @@ quinn_slack:
   name: Quinn Slack
   role: '[CEO](../../ceo/index.md), co-founder, Board of Directors'
   location: Mill Valley, CA, USA 🇺🇸
+  email: sqs@sourcegraph.com
   reports_to: none
   manager_role_slug: ceo
   github: sqs
@@ -31,6 +32,7 @@ beyang_liu:
   reports_to: ceo
   manager_role_slug: cto
   location: San Francisco, CA, USA 🇺🇸
+  email: beyang@sourcegraph.com
   github: beyang
   links: '[@beyang](https://twitter.com/beyang), [LinkedIn](https://www.linkedin.com/in/beyang-liu)'
   description: Beyang Liu is CTO and cofounder of Sourcegraph. Prior to Sourcegraph, Beyang was a software engineer at Palantir Technologies, where he developed new data analysis software on a small, customer-facing team working with Fortune 500 companies. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab and thoroughly enjoyed his compilers course.
@@ -41,6 +43,7 @@ stephen_gutekanst:
   reports_to: cto
   location: Phoenix, AZ, USA 🇺🇸
   github: slimsag
+  email: stephen@sourcegraph.com
   links: '[@slimsag](https://twitter.com/slimsag), [LinkedIn](https://www.linkedin.com/in/slimsag)'
   pronunciation: '[pronounce my name 🔊](https://www.name-coach.com/stephen-gutekanst)'
   description: 'Stephen enjoys spending time with his numerous [kittos](https://github.com/slimsag/slimsag/blob/master/CATS.md) while solving some of the most critical and technically challenging issues he can get his hands on. Prior to Sourcegraph, he worked 3 years full-time on a game engine in Go while in school. Over the past ~6 years he has been working directly with some of our largest customers and relentlessly advocating for users, and today focuses on high-value low-cost wins across the board.'
@@ -52,6 +55,7 @@ eric_fritz:
   reports_to: engineering_manager_code_intelligence
   location: Milwaukee, WI, USA 🇺🇸
   github: efritz
+  email: eric@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)'
   pronunciation: '[pronounce my name 🔊](https://www.name-coach.com/eric-fritz)'
   description: Eric received a PhD in Computer Science from the University of Wisconsin - Milwaukee where he published research on compiler construction and taught courses in compilers and software engineering. Prior to Sourcegraph, Eric built infrastructure for UCaaS products. While not programming, Eric enjoys cooking while muttering Gordon Ramsay deep cuts to himself.
@@ -63,6 +67,7 @@ eric_brody-moore:
   manager_role_slug: business_operations_manager
   location: Nashville, TN, USA 🇺🇸
   github: ebrodymoore
+  email: ericbm@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/ericbm/)'
   description: Eric enjoys golfing, snowboarding and just about anything else outdoors. Prior to Sourcegraph, Eric has worked across strategy & ops, finance and analytics at Drift and Deloitte Consulting. He was going to end his bio here, but had to mention his deep, deep love for his hometown Michigan Wolverines.
 
@@ -72,6 +77,7 @@ keegan_carruthers-smith:
   reports_to: search_lead
   location: Cape Town, South Africa 🇿🇦
   github: keegancsmith
+  email: keegan@sourcegraph.com
   links: '[@keegan_csmith](https://twitter.com/keegan_csmith)'
   description: Keegan likes living in places with lots of sun and fibre internet. Prior to Sourcegraph, Keegan worked on the developer tools team at Facebook and spent too much time studying Mathematics and Computer Science. When not doing his day job, Keegan is usually out and about with his wife and son. He can also be found in a skatepark, on a squash court or on a mountain.
 
@@ -81,6 +87,7 @@ joe_chen:
   role: Software Engineer
   reports_to: engineering_manager_cloud
   github: unknwon
+  email: joe@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jiahua-joe-chen-86218a81/)'
   description: Joe lives in his little dark room. Prior to Sourcegraph, Joe created the Gogs project, a painless self-hosted Git service. Joe graduated with a MS in Software Development from Boston University.
 
@@ -92,6 +99,7 @@ thorsten_ball:
   manager_role_slug: source_lead
   location: Aschaffenburg, Bavaria, Germany 🇩🇪
   github: mrnugget
+  email: thorsten@sourcegraph.com
   links: '[@thorstenball](https://twitter.com/thorstenball), [LinkedIn](https://www.linkedin.com/in/thorsten-ball-3142b652), [thorstenball.com](https://thorstenball.com)'
   description: "Thorsten started his career as a software engineer after dropping out of college where he studied philosophy. Since then he's mainly worked for startups (flinc, ioki) in the mobility space before starting at Sourcegraph. In his spare time, he's also a writer and wrote and self-published [two](https://interpreterbook.com) [books](https://compilerbook.com) about his favorite pet topics: interpreters & compilers. He lives together with his wife and daughter in a small-ish city in Germany. He met his wife, who happened to hail from the same small town in Germany, in Australia while he was working at a shipyard."
 
@@ -103,6 +111,7 @@ dan_adler:
   manager_role_slug: vp_operations
   location: San Francisco, CA, USA 🇺🇸
   github: dadlerj
+  email: dan@sourcegraph.com
   links: '[@DanielNealAdler](https://twitter.com/DanielNealAdler), [LinkedIn](https://www.linkedin.com/in/danielnealadler/)'
   description: 'In his role at Sourcegraph, Dan finally found the perfect mix of IDEs and spreadsheets. After receiving a C.S. degree from Rice U., Dan spent a decade in the business world: consulting, investing, and before Sourcegraph, getting an MBA at Stanford. Dan lives with his fiancé and dog in San Francisco.'
 
@@ -112,6 +121,7 @@ geoffrey_gilmore:
   reports_to: search_lead
   location: San Francisco, CA, USA 🇺🇸
   github: ggilmore
+  email: geoffrey@sourcegraph.com
   description: Geoffrey is an MIT graduate who enjoys kicking people in his spare time.
 
 erik_seliger:
@@ -120,6 +130,7 @@ erik_seliger:
   reports_to: engineering_manager_batch_changes
   location: Bremen, Germany 🇩🇪
   github: eseliger
+  email: erik@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/erik-seliger/)'
   description: Erik has a background in Systems Engineering and decided that software is the most interesting field of engineering, which he never quit since first touching Turbo Pascal at age 11.
 
@@ -130,6 +141,7 @@ kai_passo:
   reports_to: regional_director_sales_east
   location: Atlanta, GA, USA 🇺🇸
   github: kpsource
+  email: kai@sourcegraph.com
   description: Kai enjoys time with his family, sailing, and vacationing in Maine (for lobster, sea glass, and amazing sunsets). In terms of work, he focuses on helping customers solve business problems and providing an exceptional customer experience.
 
 rob_rhyne:
@@ -138,6 +150,7 @@ rob_rhyne:
   manager_role_slug: director_design
   role: Director of Design
   location: Wilmington, NC, USA 🇺🇸
+  email: rob@sourcegraph.com
   links: '[@robrhyne](https://twitter.com/robrhyne), [LinkedIn](https://www.linkedin.com/in/rrhyne)'
   description: Rob is a designer, developer, and accidental salesman with a penchant for solving business problems with usable design and code. When not making products, he is raising two boys with his wife, working on his boat, or fishing offshore for anything that makes good poke.
 
@@ -149,6 +162,7 @@ chris_pine_code_insights:
   manager_role_slug: engineering_manager_code_insights
   location: Portland, OR, USA 🇺🇸
   github: chrispine
+  email: chrispine@sourcegraph.com
 
 owen_convey_code_exploration:
   name: Owen Convey
@@ -158,6 +172,7 @@ owen_convey_code_exploration:
   manager_role_slug: engineering_manager_code_exploration
   location: Barcelona, Spain 🇪🇸
   github: scalabilitysolved
+  email: oconvey@sourcegraph.com
 
 dave_try:
   name: Dave Try
@@ -165,6 +180,7 @@ dave_try:
   reports_to: engineering_manager_batch_changes
   location: Ibague, Colombia 🇨🇴/ Sydney, Australia 🇦🇺
   github: davejrt
+  email: dave@sourcegraph.com
   description: Dave likes riding his bike up hill, drinking coffee and travelling. After graduating University and getting his start as a Unix system administrator, he still has a soft spot for Solaris and enjoys solving problems on large scale infrastructure.
 
 dax_mcdonald:
@@ -174,6 +190,7 @@ dax_mcdonald:
   reports_to: engineering_manager_cloud
   location: Phoenix, AZ, USA 🇺🇸
   github: daxmc99
+  email: dax@sourcegraph.com
   links: '[Twitter](https://twitter.com/cloudmarooned)'
   description: Dax enjoys playing ultimate frisbee 🥏, running 🏃‍♂️ and running K8s on his Raspberry Pi. Before Sourcegraph, he worked on making Kubernetes easier to use with Rio and K3s. He is an avid enthusiast of open-source and open-hardware. He has contributed to several open source projects such as Kubernetes, Linkerd & MetalLB
 
@@ -184,6 +201,7 @@ robert_lin:
   location: Burnaby, Canada 🇨🇦
   pronouns: he/him
   github: bobheadxi
+  email: robert@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/robert-lin)'
   description: Robert loves climbing plastic rocks and playing around with ideas and technologies through hacking on projects and writing. He recently graduated from the University of British Columbia with an BSc in Mathematics, where he used to run a club dedicated to helping students work together to build software projects.
 
@@ -193,6 +211,7 @@ marek_zaluski:
   reports_to: engineering_manager_batch_changes
   location: Ottawa, Canada 🇨🇦
   github: marekweb
+  email: marek@sourcegraph.com
   links: '[Twitter](https://twitter.com/marekweb)'
   description: "Marek is a JavaScript and TypeScript developer with an interest in developer tools and tech education. He occasionally teaches programming courses and contributes to coding bootcamps, and he previously ran a software consulting agency. He lives in Canada's capital with his wife and his jack russell terrier 🐕."
 
@@ -203,6 +222,7 @@ stefan_hengl:
   reports_to: search_lead
   location: Berlin, Germany 🇩🇪
   github: stefanhengl
+  email: stefan@sourcegraph.com
   description: Stefan lives in Berlin with his wife and two children. Prior to Sourcegraph, Stefan was a software engineer at Zalando and SAP, where he worked on data pipelines and low-latency, high-throughput microservices. He graduated in Physics but eventually realized that software engineering is his true passion. In his free time, Stefan enjoys cooking, plays chess with his daughter, and dreams about building a house in the wilderness of Norway.
 
 juliana_peña:
@@ -212,6 +232,7 @@ juliana_peña:
   reports_to: search_lead
   location: Redmond, WA, USA 🇺🇸
   github: limitedmage
+  email: juliana@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/julianapena/), [Twitter](https://twitter.com/limitedmage)'
   pronunciation: '[pronounce my name 🔊](https://www.name-coach.com/julip)'
   description: "Juliana is originally from Cali, Colombia 🇨🇴 and went to college in Mexico City 🇲🇽 before moving to the Seattle area. She loves building powerful and beautiful web applications that improve people's lives. Before Sourcegraph, Juliana worked at Microsoft building successful startup projects, and is now very excited to be working in a real startup company. Outside of work, Juliana loves cyling, collecting Lego, playing video games, and traveling."
@@ -224,6 +245,7 @@ chris_pine:
   manager_role_slug: engineering_manager_batch_changes
   location: Portland, OR, USA 🇺🇸
   github: chrispine
+  email: chrispine@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/chris-pine-4b188272/), [Twitter](https://twitter.com/OtherChrisPine)'
   pronunciation: '/[kɹɪs paɪn](http://ipa-reader.xyz/?text=k%C9%B9%C9%AAs%20pa%C9%AAn&voice=Joanna)/'
   description: "Chris started his career making games, working on Civilization III and Alpha Centauri. Chris also spent several years working at Opera Software in Norway, mainly on Opera's Ecmascript engine. Somewhere in there, Chris accidentally wrote a book, [Learn to Program](https://pragprog.com/titles/ltp3/learn-to-program-third-edition/). At New Relic, Chris moved into management, and (much to his surprise) loved it! Chris lives with his spouse (Katy), their three kids (C, Ruby, and Apl), three rats, a little dog, and an ancient grey cat. Hobbies include the boardgame Go, failing to play the guitar, and spiritual inquiry (mostly Tao, Zen, and Alan Watts). Chris really (like really) loves parentheses."
@@ -236,6 +258,7 @@ noah_santschi-cooney:
   location: Wexford, Ireland 🇮🇪
   pronunciation: '/[noʊə santʃi kuːnɪ](http://ipa-reader.xyz/?text=no%CA%8A%C9%99%20sant%CA%83i%20ku%CB%90n%C9%AA&voice=Amy)/'
   github: strum355
+  email: noah@sourcegraph.com
   links: '[LinkedIn](https://linkedin.com/in/strum355), [Twitter](https://twitter.com/strum355)'
   description: Noah is a half Swiss 🇨🇭 half Irish 🇮🇪 UCC CS graduate who spends his time evangelising the Actor model, containers (not of the shipping variety), his favourite programming languages and complaining about subpar editor experiences. Sometime in the past, the last point drove him over the edge and into the world of language servers. Previously he was Performance Engineering Intern at Teamwork, Frontend/DevOps at CloudCIX and Head Systems Administrator at UCC Netsoc, the college tech/gaming society.
 
@@ -244,6 +267,7 @@ bill_kolman:
   role: Account Executive
   reports_to: regional_director_sales_east
   location: New York, New York
+  email: Bill@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/william-kolman/)'
   description: "Bill lives in Long Island City, Queens with his wife, daughter, and dog. He has been in tech related sales since 2008. Most recently he has been working in early stage startups, building businesses from the ground up in the eastern US. Bill is an avid bicyclist, so when he's not evangelizing Sourcegraph or studying the newest trends in technology, he is probably exploring the 5 boroughs on his bike."
 
@@ -253,6 +277,7 @@ owen_brennan:
   role: Account Executive
   reports_to: rsd_west
   location: Boise, Idaho, USA
+  email: owen@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/owenbrennan/)'
   description: "Owen has worked in early-stage technology sales for almost his entire career. He's passionate about helping customers resolve their unique business challenges, and fostering a long-term impact for them. Outside of work, Owen can be found with his family exploring his home State of Idaho: hiking, fly fishing, rafting and snowboarding."
 
@@ -263,6 +288,7 @@ jonah_dueck:
   reports_to: rd_ce_us_apj
   location: Seattle, WA, USA 🇺🇸
   github: justdueck
+  email: jonah@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jonah-dueck/)'
   description: "Jonah has been working within the IT space since high school. He started out by founding and running a small IT company in northern Nevada while still in high school and after graduating, moved on to working for another small company in Northern California. Most recently, he worked in internal IT operations and technical program management at Google for about 2 years. Outside of work, he enjoys rock climbing, playing music (guitar and drums), riding his motorcycle and working on his old VW bus (there's always something breaking on it)."
 
@@ -274,6 +300,7 @@ owen_convey:
   manager_role_slug: engineering_manager_code_intelligence
   location: Barcelona, Spain 🇪🇸
   github: scalabilitysolved
+  email: oconvey@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/owenconvey/)'
   description: "Owen was born and raised in England and has been residing in Barcelona since 2012. He spends a lot of time watching Rugby, playing with his young daughter and tinkering with his laptop. Prior to Sourcegraph, he was a manager at Help Scout and loves empowering and motivating autonomous engineering teams. His Achilles' heel is most definitely pizza."
 
@@ -285,6 +312,7 @@ scott_campbell:
   manager_role_slug: regional_director_sales_east
   location: Asheville, North Carolina, United States 🇺🇸
   github: spc74
+  email: scott@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/scottpcampbell/)'
   pronunciation: s k AH t k ae m b u hl
   description: "Scott lives in Asheville, NC with his wife and youngest daughter. He has two other older children that are in college and graduated from college, respectively. He's had a long career in engineering and sales capacities with various software companies, large and small. He possesses a natural curiousity to deeply understand his customer's challenges and help them apply technology to materially impact their business. Outside of work, Scott enjoys nearly any activity involving water or mountains, including snowboarding, hiking, biking and wake surfing. He also enjoys rooting for his alma mater Texas A&M Aggies football team, landscaping and traveling to explore new parts of the world."
@@ -297,6 +325,7 @@ tommy_o_donnell:
   manager_role_slug: manager_financial_planning
   location: Tralee, County Kerry, Ireland 🇮🇪
   github: TommyODonnell
+  email: tommy@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/tommyodonnell87/)'
   description: Tommy hails from County Kerry on the South West Coast of Ireland. He graduated with a degree in Business studies from the University of Limerick before completing a Masters in Accounting at Dublin City University. Prior to Sourcegraph Tommy spent over 5 years working on a diverse range of clients at the EY Limerick and Boston offices, before spending a further 5 years in a financial reporting role at Pivotal Software. When he is not stuck in spreadsheets, you will probably find him having a quiet pint of Guinness, following the fortunes of the New England Patriots and the Kerry Gaelic Football team, or reading up on the latest rounds of funding’s in the startup world.
 
@@ -307,6 +336,7 @@ mike_mclaughlin:
   reports_to: rd_ce_us_apj
   location: Chicago, IL, USA 🇺🇸
   github: mike-r-mclaughlin
+  email: mike@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/mikermclaughlin/)'
   description: "Mike spent the first half of his career as a developer. He transitioned to pre-sales after realizing how much he loves working with customers to solve technically challenging problems. Mike lives in Chicago's Lincoln Park neighborhood with his wife Erika and their 2 cats (Winston and Mattie) and dog (Stella). His pets can usually be found napping by his desk during working hours. When not working, Mike enjoys traveling, live music, and relaxing on the couch."
 
@@ -317,6 +347,7 @@ rok_novosel:
   reports_to: eng_lead
   location: Trebnje, Slovenia 🇸🇮
   github: novoselrok
+  email: rok@sourcegraph.com
   links: '[@novoselrok](https://twitter.com/novoselrok)'
   description: "Rok is a software engineer from Trebnje, Slovenia. He finished his Master's degree in computer science at the University of Ljubljana, focusing on parallel programming languages. Before joining Sourcegraph his work was mostly in the ad-tech industry. In his free time, he likes to tinker with various side projects ranging from compilers to WebAssembly. Outside of programming, he enjoys hiking, playing FIFA and supporting the Arsenal football club."
 
@@ -327,6 +358,7 @@ andré_eleuterio:
   reports_to: engineering_manager_security
   location: Curitiba, Brazil 🇧🇷
   github: andreeleuterio
+  email: andre@sourcegraph.com
   links: '[@eleuterio\_](https://twitter.com/eleuterio_)'
   description: André is a Security Engineer from Curitiba, Brazil. Before joining Sourcegraph he was working at npm and GitHub, holding different security responsibilities. André is a devout follower of Athletico Paranaense, a local soccer team, despite its rare joys and successes. Definitely a geek, be careful when bringing up Breath of the Wild or Magic the Gathering around André as that can lead to some very long conversations.
 
@@ -337,6 +369,7 @@ camden_cheek:
   reports_to: search_lead
   location: Monument, Colorado, USA 🇺🇸
   github: camdencheek
+  email: camden@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/camdencheek/)'
   description: Camden is originally from Michigan, but recently moved to Colorado, where he enjoys spending his time hiking, playing cello, and perfecting his dev environment. Before joining the Sourcegraph team, Camden worked on building a logging agent in Go at observIQ. Before that, Camden got a degree in Biomedical Engineering before deciding that the only thing he really liked about it was the coding.
 
@@ -347,6 +380,7 @@ tom_ross:
   reports_to: engineering_manager_code_exploration
   location: York, North Yorkshire, UK 🇬🇧
   github: umpox
+  email: tom@sourcegraph.com
   description: Tom lives in York, UK with his girlfriend (also a developer) and their two cats (Gus & Leo). He stumbled upon his love for the web when starting an internship, before realising that he had to support Internet Explorer 8. Since then, Tom has enjoyed building powerful web-applications and, prior to Sourcegraph, has been a developer at DAZN and Sky. In his free time, he enjoys supporting his soccer team Liverpool FC, swimming, and following various forms of motorsport.
 
 greg_bastis:
@@ -357,6 +391,7 @@ greg_bastis:
   manager_role_slug: vp_sales
   location: San Francisco, CA, USA
   github: gb1228
+  email: gb@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/gregbastis/)'
   description: Greg (“GB” to limit confusion with Sourcegraph’s first Gregg, Stone) lives San Francisco’s Outer Sunset neighborhood with his wife, Brenda, who he met working at Boulder, Colorado’s landmark The Sink Bar & Restaurant in 2005. He first moved to San Francisco in 2008 for a job with Salesforce, before heading over to Optimizely where he spent 6 years helping enterprise Product & Engineering teams deliver exceptional digital experiences through Full Stack experimentation. When not working, you can find GB on his 90’s era steel bicycles, exploring all that Northern California has to offer (usually wearing lots and lots of pink).
 
@@ -367,6 +402,7 @@ seth_hoover:
   reports_to: director_sales_ops
   location: Menifee, CA, USA 🇺🇸
   github: seth-sourcegraph
+  email: seth@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/sethhoover)'
   description: "Seth lives in Menifee, CA with his wife, three dogs, two cats, and a horse (the horse actually has an 'apartment' at a nearby equestrian facility). He has been working on the Salesforce.com platform for more than 13 years. He started out working as a member of Salesforce Support prior to moving into consulting. In his free time, he enjoys martial arts, paintball, airsoft, offroading and ATVs, movies and reading."
 
@@ -377,6 +413,7 @@ seth_hoover:
   reports_to: engineering_manager_code_intelligence
   location: Drøbak, Norway 🇳🇴
   github: olafurpg
+  email: olafurpg@sourcegraph.com
   links: '[Twitter](https://twitter.com/olafurpg), [LinkedIn](https://linkedin.com/in/olafurpg).'
   description: Olaf is an Icelander who was born in Sweden and lives in Norway with his wife who he met at a sauna in Finland. Prior to Sourcegraph, Olaf worked on Scala developer tooling such as Scalafmt (code formatter), Scalafix (refactoring and linting tool), Metals (language server), BSP (Build Server Protocol) and SemanticDB (data model about code). In his spare time, Olaf likes to make delicious food and run in the woods.
 
@@ -386,6 +423,7 @@ malo_marrec:
   pronouns: he/him
   role: Product Manager, Batch Changes
   location: Paris, France 🇫🇷
+  email: malo@sourcegraph.com
   github: malomarrec
   links: '[Linkedin](https://www.linkedin.com/in/malo-marrec)'
   description: Malo lives in Paris, France after some time in the Bay Area. Prior to Sourcegraph, he bounced around a few early stage startups building infrastucture and developer tools. Malo graduated with an MS from Stanford, and an MS from Ecole Centrale Paris. Outside of work, he kite surfs and reads a ton of books.
@@ -397,6 +435,7 @@ james_clifford:
   reports_to: rsd_west
   location: San Francisco, CA, USA 🇺🇸
   github: jclifford1
+  email: jclifford@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jamesclifford91/)'
   description: "James lives in San Francisco's North Beach neighborhood. Prior to Sourcegraph, James spent 5.5 years at Optimizely where he helped enterprise Engineering, Product, and Data teams to deliver better digital experiences through Full Stack experimentation and feature management. James graduated with a BA in Economics from Middlebury College. Outside of work, James can be found skiing in Tahoe or surfing and kiteboarding in the Pacific Ocean and San Francisco Bay."
 
@@ -406,6 +445,7 @@ tj_devries:
   reports_to: engineering_manager_code_intelligence
   location: Rockford, MI, USA 🇺🇸
   github: tjdevries
+  email: tjdevries@sourcegraph.com
   links: '[twitch.tv/teej_dv](https://twitch.tv/teej_dv)'
   pronuncation: The letter T, and then the letter J
   description: TJ lives in Rockford, Michigan. Besides coding during the day, TJ also likes to code on his Twitch stream (linked above). Generally you can find him working on Neovim or Neovim-related plugins and having a good time hanging out with Twitch chat. Outside of coding, TJ loves to spend time with his wife, son and doggo. Also, playing four-mallet marimba is one of his other favorite activities.
@@ -416,6 +456,7 @@ manuel_ucles:
   reports_to: engineering_manager_batch_changes
   location: Phoenix, AZ, USA 🇺🇸
   github: mucles
+  email: manuel@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/manuel-ucles-444080151/)'
   description: Manny is from Honduras 🇭🇳 but has lived in Phoenix, Arizona most of his life. He enjoys playing basketball, chess and does boxing/MMA in his spare time. Prior to Sourcegraph, Manny worked as an Application Engineer at Freedom Financial. He also has experience as a Software Engineer at Mckesson and a Data Analyst at Uber.
 
@@ -426,6 +467,7 @@ caitlin_moran:
   reports_to: regional_director_sales_east
   location: Brooklyn, NY USA 🇺🇸
   github: Caitlinsourcegraph
+  email: caitlin@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/caitlincarducci/)'
   description: Caitlin is married to her wife Mo and lives in Brooklyn with their dogs Henry and Onion Ring. Prior to Sourcegraph, Caitlin spent 4 years at Optimizely before starting the sales team as the first Account Executive at Radar. Outside of work Caitlin enjoys spending time with her family, riding her bike (or Peloton if there is snow on the ground!) and exploring NYC!
 
@@ -436,6 +478,7 @@ jon_kishpaugh:
   reports_to: rsd_west
   location: San Francisco, CA, USA
   github: JonKish
+  email: jon@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jonathan-kishpaugh-8459217/)'
   description: Jon aka Kish currently lives in San Francisco with his wife Lauren. He’s spent the last 14 years working in small to mid-size start-ups, helping them build their Enterprise GTM. Life outside of work is focused on family, good food, and staying active.
 
@@ -446,6 +489,7 @@ dudley_nostrand:
   manager_role_slug: senior_manager_value_engineering
   location: Hamilton, Massachusetts, USA
   github: dnostrand
+  email: dudley@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/dudleynostrand/)'
   description: Dudley lives in Hamilton, MA ( just north of Boston) with his wife Sasha and two kids Xander and Bennett (both in college in NC). Originally from Florida and Newport, Rhode Island, he moved to Hamilton 22 years ago. He spent 15 years at Fidelity Investments, before moving on to tech companies like BMC and Appdynamics/Cisco. He enjoys spending time boating, fishing, riding his motorcycle, and traveling with his family to tropical destinations to sit on the beach and swim in the ocean.
 
@@ -456,6 +500,7 @@ tammy_zhu:
   reports_to: vp_operations
   manager_role_slug: director_legal
   location: San Francisco, CA, USA 🇺🇸
+  email: tammy@sourcegraph.com
   description: Tammy joins Sourcegraph after years of counseling technology companies on matters including products, litigation, commercial contracts, data privacy, M&A, startup financing, and regulatory filings and investigations. She enjoys creative writing, reading fiction, solo traveling, watching basketball, and baking sourdough during the pandemic.
 
 warren_gifford:
@@ -465,6 +510,7 @@ warren_gifford:
   reports_to: manager_support
   location: Portland, OR, USA 🇺🇸
   github: DaedalusG
+  email: warren@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/warren-gifford-he-him-b1141a1b4/)'
   description: "Warren is a nerd who became interested in coding after reading one too many sci-fi's. Following a nonlinear trajectory, he studied mathematics and philosophy before becoming an automotive technician, and finally attended a coding bootcamp to pursue software development. Perennially curious, Warren can be found reading poetry, playing violin, exercising, or watching star trek with his loyal dog Bajor."
 
@@ -475,6 +521,7 @@ valery_bugakov:
   reports_to: engineering_manager_code_exploration
   location: Bali, Indonesia
   github: valerybugakov
+  email: valery@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/valerybugakov/), [@valerybugakov](https://twitter.com/valerybugakov)'
   pronunciation: '[Pronounce my name 🔊](https://www.pronouncenames.com/search?name=Valery)'
   description: "Valery is a product-centric software engineer. He joins Sourcegraph after years of helping various early-stage startups to build web products and scale frontend engineering teams. Open-source enthusiast and avid traveler he can't wait for the open borders to explore new places. In his free time, he enjoys snowboarding, especially freeriding in the winter, and basketball + surfing in the summer."
@@ -486,6 +533,7 @@ vova_kulikov:
   reports_to: engineering_manager_code_insights
   location: St. Petersburg, Russia 🇷🇺
   github: vovakulikov
+  email: vova@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/vovakulikov/), [@vovakulikov](https://twitter.com/_vovakulikov), [vovakulikov.me](https://vovakulikov.me)'
   pronunciation: '[Pronounce my name 🔊](https://www.pronouncenames.com/search?name=Vova)'
   description: Vova is a software engineer with a designer background. Found himself passionate about UX/UI and write some open-source code. He joins Sourcegraph after years of working on the frontend platform at Wrike. He loves generative art, geometry, and mathematics. Outside of work, he loves to play basketball and watch NBA Boston Celtics games.
@@ -497,6 +545,7 @@ alex_fogg:
   reports_to: rd_ce_us_apj
   location: Philadelphia, PA, USA 🇺🇸
   github: alexfogg
+  email: afogg@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/alexfogg/)'
   description: Alex spent the bulk his career working as a software engineer and team lead in NYC at startups and media companies. His love of people, process, communication, and customers led him to the customer engineering role. Alex loves traveling and staying active via hiking/biking/running. He spends his weeknights watching YouTube cooking videos and loves to try out new recipes.
 
@@ -506,6 +555,7 @@ adeola_akinsiku:
   reports_to: engineering_manager_batch_changes
   location: Atlanta, GA, USA 🇺🇸
   github: adeola-ak
+  email: adeola@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/adeola-a-b0b6b270), [Readme](../../technical-success/support/bios/adeola-readme.md)'
   description: Adeola joins Sourcegraph fresh out of an engineering bootcamp after years of doing work that she never felt challenged or very excited about. Having studied Finance in undergrad, she knows a thing or two about credit and managing money, but really loves to talk about all things code. Adeola finds life to be awfully boring without purpose and meaning, and strives to become a better person both professionally and personally everyday. Real connections mean a lot to Adeola and she loves to engage with people who feel the same way. Outside of work, she loves going out to eat, watching basketball, sniffing candles, reading and relaxing.
 
@@ -516,6 +566,7 @@ beatrix_woo:
   reports_to: engineering_manager_delivery
   location: San Diego, CA, USA 🇺🇸 / Hong Kong 🇭🇰
   github: abeatrix
+  email: beatrix@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/wbeatrix/), [@3eatrix](https://www.twitter.com/3eatrix/), [Readme](../../technical-success/support/bios/bee-readme.md)'
   pronunciation: '[Pronounce my name 🔊](https://www.youtube.com/watch?v=aZWHsV96NqY)'
   description: 'Originally from Hong Kong, Beatrix is now residing in the sunny San Diego with her husband and their Shiba Inu, Goku. She was working as an analyst and has worked for Morgan Stanley and Uber before she picked up her old passion in coding. In her free time, Beatrix likes to spend time with her family, learn about different technologies, build mechanical keyboards, and play [League of Legends](https://na.op.gg/summoner/userName=biues) with friends.'
@@ -526,6 +577,7 @@ stompy_mwendwa:
   reports_to: manager_support
   location: Nairobi, Kenya 🇰🇪
   github: airamare01
+  email: stompy@sourcegraph.com
   links: '[@stompy_amare](https://twitter.com/stompy-amare), [stompymwendwa.com](https://stompymwendwa.com), [LinkedIn](https://www.linkedin.com/in/stompy-mwendwa)'
   pronunciation: '[pronounce my name 🔊](https://www.name-coach.com/stompy-mwendwa)'
   description: "Stompy is from the Pride of Africa and previously worked in customer success roles prior to joining Sourcegraph. He is a CS graduate and fell in with computers playing around with MS-DOS in the mid-90s. Stompy loves helping people achieve their goals and is a staunch believer of the Swahili proverb: Kusaidia ni moyo wala si utajiri' - Helping is of the heart, not of the pocket. When he's not working, he loves hopping onto motorcycles and going on adventures, watching/playing basketball(Go Lakers!), playing video games, listening to hip-hop and going out to eat."
@@ -537,6 +589,7 @@ indradhanush_gupta:
   reports_to: source_lead
   location: Kolkata, India 🇮🇳
   github: indradhanush
+  email: indradhanush@sourcegraph.com
   links: '[Twitter](https://twitter.com/indradhanush92), [indradhanush.github.io](https://indradhanush.github.io)'
   pronunciation: '[Pronounce my name 🔊](https://pronouncenames.com/pronounce/indradhanush)'
   description: Indradhanush is a tinkerer and a lazy one at that. If he ever has to do the same thing twice, chances are he will work on automating it away. He likes to go down rabbit holes thinking about human psychology and obsesses about his audio quality on video calls. Away from work, he suffers from having too many hobbies but is most passionate about playing drums. His other hobbies in order of frequency are playing Dungeons & Dragons once a week with friends, playing on his PS4 once every few weeks, reading a book (science, fiction and fantasy) once every few months and painting once every few years.
@@ -549,6 +602,7 @@ steph_hay:
   manager_role_slug: sales_strategy_operations_manager
   location: Los Angeles, CA, USA 🇺🇸
   github: stephmhay
+  email: steph@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/stephmhay)'
   description: Steph lives in Los Angeles and loves taking advantage of the perfect weather by getting outside as much as possible. After multiple failed attempts at surfing, she has finally accepted that she is much better suited to outdoor activities requiring little to no skill and has since taken up paddleboarding and long walks on the beach. Steph started her career in investment banking and also worked in venture investing before joining Sourcegraph.
 
@@ -559,6 +613,7 @@ kelsey_brown:
   reports_to: director_data_analytics
   location: Arlington, VA, USA 🇺🇸
   github: kelsey-brown
+  email: kelsey@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/kelsey-brown-25220b68/)'
   description: Prior to Sourcegraph, Kelsey worked in consulting on projects related to strategy, business operations, and technology. Outside of work, Kelsey loves doing anything active, including weightlifting, snowboarding, and playing ultimate frisbee. She is currently based in the Washington, DC area, but hails from Chicago, and would therefore be happy to passionately defend the superiority of Chicago-style over New York-style pizza with you any day of the week.
 
@@ -570,6 +625,7 @@ fabiana_castellanos:
   manager_role_slug: creative_ops_manager
   location: Oceanside, CA USA 🇺🇸
   github: fabicastp
+  email: fabiana@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/fabicastp/)'
   description: "Fabiana is from Venezuela 🇻🇪 but moved to California 4 years ago with her husband, dog and parrot. She's a big fan of processes and organization, and you’ll often hear her say _I have a spreadsheet for that._ She’s had the pleasure of doing project management with creatives throughout her professional career. They are the yin to her yang, she says. She’s also very proud of her Venezuelan culture and loves inviting people over to her home to eat arepas."
 
@@ -580,6 +636,7 @@ kendrick_morris:
   reports_to: manager_financial_planning
   location: San Francisco, CA USA 🇺🇸
   github: kmorris50
+  email: kendrick@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/kendrick-morris-cpa-3563b993/)'
   description: Kendrick grew up in Houston, TX and now resides in San Francisco, CA. He graduated with a degree in Economics-Accounting & Government from Claremont McKenna College. Prior to Sourcegraph, Kendrick worked in the Deloitte San Francisco audit practice and currently holds a CPA license in California. He enjoys listening to podcasts, collecting vintage basketball cards, and driving just about anywhere for good barbecue.
 
@@ -600,6 +657,7 @@ kelli_rockwell:
   reports_to: engineering_manager_batch_changes
   location: Seattle, WA, USA 🇺🇸
   github: courier-new
+  email: kelli@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/kellirockwell/), [Twitter](https://twitter.com/courierneue)'
   pronunciation: '/[ˈkɛl.i ˈɹɑk.wɛl](http://ipa-reader.xyz/?text=%CB%88k%C9%9Bl.i%20%CB%88%C9%B9%C9%91k.w%C9%9Bl&voice=Joanna)/'
   description: "Kelli grew up in Arizona before slowly making her way up the west coast US from LA to SF to Seattle, WA. She became a 'professional web developer' before she was even qualified to babysit, getting paid in Neopoints to make Neopets layouts and community fan pages for her online friends as a pre-teen. She is definitely not addicted to [bubble tea](https://en.wikipedia.org/wiki/Bubble_tea) (or “boba”, as it’s called on the west coast) and professes that she could stop at any time. When she's not consuming boba, she plays tennis, attends developer conferences and meet-ups, travels for the food, completes jigsaw puzzles, and tries to convince her hypoallergenic cat, Calla, to cuddle with her while coding."
@@ -609,6 +667,7 @@ khoshal_wial:
   role: Regional Director Sales EMEA
   reports_to: vp_sales
   manager_role_slug: regional_director_sales_emea
+  email: khoshal@sourcegraph.com
 
 ryan_phillips:
   name: Ryan Phillips
@@ -617,6 +676,7 @@ ryan_phillips:
   role: Product Manager
   location: San Francisco, CA, USA 🇺🇸
   github: Ryphil
+  email: ryphil@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/ryphil/)'
   description: Born in the wild west (Texas), Ryan now lives in San Francisco, CA where he loves exploring the amazing nature nearby! Ryan lives to experience and build products which have an incredibly high level of craft - custom JH Audio headphones, to beautiful books such as Designing Design, to delicious food! Outside of Sourcegraph, Ryan is a lecturer at the d.school at Stanford University, teaching at the intersection of technology, design, and inclusion. He is always open to adventure, lets explore together!
 
@@ -626,6 +686,7 @@ coury_clark:
   role: Software Engineer, Backend
   reports_to: engineering_manager_code_insights
   location: Phoenix, AZ, USA
+  email: coury@sourcegraph.com
   github: coury-clark
   description: Born and raised in Arizona, currently living in Phoenix. He learned to fly airplanes when he was 12 years old at a local glider club, and got his pilot’s license in both gliders and single engine airplanes in his teens. He started programming in c++ with a desire to make video games, and spent some time learning that he is a terrible 3D artist in Maya. Since then, Coury has loved exploring the complexities of software engineering, and has decided he is still a terrible artist (in any dimension). In his free time he likes to play music on piano / guitar, explore new foods through cooking, spend time birding and doing photography, and hanging out with his wife and cat.
 
@@ -637,6 +698,7 @@ aimee_menne:
   manager_role_slug: vp_technical_success
   location: Denver, CO USA 🇺🇸
   github: amenne
+  email: aimee@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/aimee-menne-8343487/)'
   description: Aimee has spent her career, and is extremely passionate about, delivering customer-centric solutions. An Indiana native, she spent time in both Washington DC and San Francisco before landing in Denver, Colorado. Outside of work, Aimee is usually doing a variety of outdoor activities (running, cycling, skiing, hiking, camping, fishing) or traveling to new places.
 
@@ -655,6 +717,7 @@ devon_coords:
   manager_role_slug: director_technical_recruiting
   location: White Plains, NY USA 🇺🇸
   github: devoncoords
+  email: devon@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/devonelliscoords)'
   description: 'Devon loves spending time with her husband (Andrew), daughter (Madison), dog (Bailey), and cat (Gato). Prior to Sourcegraph, Devon was the Managing Director of a tech recruiting agency in New York City and has a decade of experience in the industry. When not working, Devon tries to spend most of her time outside, trying to keep her plants alive, doing home renovation projects, cooking, and watching any Real Housewives franchise.'
 
@@ -665,6 +728,7 @@ trevor_houghton:
   reports_to: director_recruiting_peopleops
   location: Austin, TX, USA 🇺🇸
   github: TrevorHoughton
+  email: trevor@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/trevorhoughton/)'
   description: Trevor grew up in Portland, OR before attending Colorado College, where he played NCAA soccer and majored in International Political Economy. He has sinced moved to Austin, TX and gained sales experience at Emergo and talent acquisition experience at Indeed.com. Outside of work, Trevor enjoys coaching, playing piano, skiing, traveling, and losing at chess.
 
@@ -675,6 +739,7 @@ kevin_quigley:
   reports_to: regional_director_sales_east
   location: Atlanta, GA, USA 🇺🇸
   github: kevin-quigley
+  email: kevin.quigley@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/kevinquigley18/)'
   description: Kevin grew up in Atlanta, graduated from the University of Georgia :dog:, and then travelled for a year (USA road trip, Southeast Asia, and Australia). He enjoys backpacking in our national parks, Georgia football, and exercising!
 
@@ -686,6 +751,7 @@ nicky_van_maanen:
   manager_role_slug: tech_ops_manager
   location: Costa Mesa, California, USA 🇺🇸
   github: NickyVM
+  email: nicky@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/nvanmaanen/)'
   description: Currently, Nicky is enjoying the ocean and eucalyptus trees with her family in Southern California but her heart remains in the commotion and sounds of New York City. She has a BA in Anthropology from Scripps College and an MS in Public Policy from Carnegie Mellon University. Prior to Sourcegraph, Nicky has held numerous jobs from Selling Mini Coopers to working in the Computer Forensic Unit at the Manhattan DAs office.
 
@@ -696,6 +762,7 @@ nate_maynard:
   reports_to: manager_technical_advisory
   location: Denver, Colorado, USA 🇺🇸
 
+  email: nate.maynard@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/namaynard/)'
   description: Originally from Massachusetts, Nate currently is enjoying the more open spaces of the United States out west. Having moved from San Francisco to Denver in October of 2021 he likes to live close to the mountians reducing his commute from 4 hours to 2 trading the Sierras for the Rockies. Nate also enjoys spending time with friends playing golf, cycling, and playing video games. His professional passion is explaining techincal products and concepts to both technical and non techincal people.
 
@@ -715,6 +782,7 @@ gabe_torres:
   reports_to: manager_support
   location: Los Angeles, CA, USA 🇺🇸
   github: gabtorre
+  email: gabe@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/gabtorres/)'
   description: Gabe is a developer from Los Angeles with a background in design. He enjoys sports, fitness, gaming, reading, exploring new places with his dog Bruno, and staring at art.
 
@@ -725,6 +793,7 @@ jason_harris:
   reports_to: manager_support
   location: Los Angeles, CA USA
   github: jasonhawkharris
+  email: jason.harris@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jasonhawkharris/)'
   description: "Jason is a musician and software engineer living in Los Angeles. He is married to a nurse practitioner named Ashley. He has two tabby cats, Pierre and Dmitri. They actively plan his demise. However, he suspects they'll never pull the trigger because they secretly love him, though they would never admit it."
 
@@ -735,6 +804,7 @@ michael_bali:
   reports_to: manager_support
   location: Lagos, Nigeria 🇳🇬
   github: topebali
+  email: michael.bali@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/michael-temitope-bali-830640171)'
   description: Michael is very passionate about helping those around him. He enjoys Soccer alot and discussing politics most especially politics in Africa with friends. During his leisure, he enjoys playing console games, reading books (crime thrillers) and travelling. He is also enthusiastic about meeting new folks and open minded to learning!
 
@@ -745,6 +815,7 @@ alex_jean-baptiste:
   reports_to: manager_support
   location: Atlanta, Georgia USA 🇺🇸
   github: alexAtSourcegraph
+  email: alex.jean-baptiste@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/alexjeanb)'
   pronunciation: '[Name pronunciation](https://www.name-coach.com/alex-jean-baptiste)'
   description: Alex is a Haitian-American 🇭🇹🇺🇸 information technologist and writer from Miami, Florida🌴. He is passionate about the arts. He enjoys hiking trails, visiting museums, and performing comedy🤣. He is done writing.
@@ -756,6 +827,7 @@ mariam_adedeji:
   reports_to: manager_support
   location: Lagos, Nigeria 🇳🇬
   github: rhiam
+  email: mariam@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/omobolanle-adedeji-0b845167)'
   description: Mariam is a confident female engineer from Nigeria. Previously worked as a software engineer prior to joining Sourcegraph. She enjoys coding, watching movies, travelling, making new friends, and organising events.
 
@@ -766,6 +838,7 @@ alex_isken:
   reports_to: marketing_lead
   location: Milwaukee, WI, USA 🇺🇸
   github: iskyOS
+  email: alex.isken@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/alexisken/), '
   description: "Alex is a proud Milwaukeean. Prior to Sourcegraph, Alex worked in various technology roles at Nielsen and was also a PMM at Datadog in NYC (but he's very happy to be back in the midwest). Alex loves board games, disc golf, and microbreweries, and he has an undying passion for Marquette basketball."
 
@@ -777,6 +850,7 @@ bill_caplan:
   manager_role_slug: manager_technical_advisory
   location: Raleigh, NC USA 🇺🇸
   github: billCaplan
+  email: bill.caplan@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/caplanbill/)'
   description: Bill lives in Raleigh, NC with his wife Kristen and their son Grayson. After growing up in Pittsburgh and spending time at Ohio State (Go Bucks!), he spent seven years in San Francisco, working to help customers better understand and utilize the software that they buy. He recently moved back to the East Coast, now calling Raleigh home. In his free time he enjoys watching or playing sports (football, racing, hockey) and trying to become a backyard pizza chef.
 
@@ -788,6 +862,7 @@ marija_petrovic:
   reports_to: vp_talent
   location: Naples, FL USA 🇺🇸
   github: marija.petrovic214
+  email: marija.petrovic@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/marija-petrovic-sphr-b49b9b38/)'
   description: "Marija, pronounced 'Maria', is a Serbian-American living in Naples, Florida. She is passionate about helping people find their dream career while promoting the vision and values of the organization + all things People/HR/Analytics related. She is currently finishing her Master's in HR Analytics and Resource Management at American University and has a BS in Finance and Information Systems from the University of Florida."
 
@@ -799,6 +874,7 @@ amie_rotherham:
   manager_role_slug: director_global_communications
   location: Toronto, Canada 🇨🇦
   github: amieroth
+  email: amie.rotherham@sourcegraph.com
   links: '[LinkedIn] (https://www.linkedin.com/in/amierotherham/) [Twitter] (https://twitter.com/amieroth)'
   description: "Amie grew up on Vancouver Island on the far west coast of Canada, and currently lives in Toronto by way of San Francisco by way of Vancouver. She's spent 10 years working in tech PR, helping B2B brands and emerging tech gain mainstream adoption. She spends her time sending snail mail (and practicing calligraphy), testing out new recipes in the kitchen (and getting lessons from her chef husband), and reading (mainly fiction)."
 
@@ -809,6 +885,7 @@ max_wiederholt:
   reports_to: manager_technical_advisory
   location: Mountain View, CA, USA 🇺🇸
   github: maaaaaaaax
+  email: max.wiederholt@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/maxwiederholt/), [Twitter](https://twitter.com/maxwiederholt)'
   description: "Max was born and raised in the San Francisco Bay Area. Prior to Sourcegraph, Max founded [Mischief](https://www.mischief.app/), a social network that helps anyone make a movie or TV series, then license that work to a streaming service. Max has worked on Google's developer relations team and Confluent's sales team. He graduated from UCLA with a BA in Political Science, before learning to code via [Harvard's CS50x online course](https://cs50.harvard.edu/x/2021/) and [San Jose's Coding Dojo](https://www.codingdojo.com/)."
 
@@ -819,6 +896,7 @@ victoria_yunger:
   reports_to: marketing_lead
   location: San Francisco, CA, USA 🇺🇸
   github: thisisvic
+  email: victoria.yunger@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/victoriayunger/)'
   description: "Victoria was born in Ukraine, grew up in Israel, and then moved to the U.S. to pursue her Master's degree at UChicago. As of five years, she calls San Francisco her (foggy) home. Pre-Sourcegraph, Victoria worked as a product marketer at Zendesk and held several marketing roles in Israel."
 
@@ -829,6 +907,7 @@ luke_taylor:
   reports_to: regional_director_sales_emea
   location: Amsterdam, The Netherlands
   github: iamluketaylor
+  email: luke.taylor@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/iamluketaylor/)'
   description: "Working on the EMEA Sales Team. A Brit based out of beautiful Amsterdam. After bouncing around tiny start ups for a few years in London, I did 5 years at Optimizely, working with a bunch of folks here (James Clifford, Greg Bastis, Jon Kishpaugh, Khoshal Wial and co.). Outside of work my day-to-day is mostly just filler, killing time in between meals. When I'm not eating I love to train, play hockey, surf (badly), play my bass guitar and game (PC). I am also always trying to find new ways to grow and develop myself - happiness is the goal! Always down to talk about all things personal and professional growth."
 
@@ -839,6 +918,7 @@ milan_freml:
   reports_to: source_lead
   location: Ružomberok, Žilinský, Slovakia 🇸🇰
   github: kopancek
+  email: milan.freml@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/milan-freml)'
   pronunciation: Name pronounciation - almost the same as the city in Italy
   description: "Milan lives in a [small town](https://goo.gl/maps/vRzGwscRW66tsNdr6) in Slovakia with his wife and 2 small kids. He spent 4 years in Dublin, Ireland, where they have nice beer and whiskey, but he was not enjoying the rain much. Milan previously worked in Auth0 as a senior full stack engineer and before that in AWS in a similar role. He loves reading books 📚 (nowadays mostly science fiction and fantasy), cycling 🚲 (when it's not raining), traveling 🌄. He also cooks 👨‍🍳 and bakes bread and when kids allow, also drinks some 🍺 and plays some 🎮. He's also building his house 🏠"
@@ -850,6 +930,7 @@ ellie_dawson:
   reports_to: head_sales_development
   location: Cincinnati, OH, USA
   github: elliedawson
+  email: ellie.dawson@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/elliefathman/)'
   description: "Ellie lives in Cincinnati, OH with her husband, Chase. After graduating from the University of Cincinnati, Ellie spent time as a technical recruiter working across a variety of skill sets. When she's not working, you can find her checking out the local restaurant scene, cycling and working out, reading, and playing with her pup, Holly!"
 
@@ -860,6 +941,7 @@ ajay_sridhar:
   reports_to: rd_ce_emea
   location: London, UK 🇬🇧
   github: ajaynz
+  email: ajay.sridhar@sourcegraph.com
   links: '[LinkedIn](https://linkedin.com/in/ajaysridhar/)'
   description: Ajay lives in the UK with his wife and daughter, he came over to Sourcegraph from prior sales roles at Puppe. He loves everything sports and cars, in his spare time you will either find him at the gym or doing somethign fun outdoor.
 
@@ -870,6 +952,7 @@ erzhan_torokulov:
   reports_to: source_lead
   location: Bishkek, Kyrgyzstan 🇰🇬
   github: erzhtor
+  email: erzhan.torokulov@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/erzhtor/), [erzhtor.com](https://erzhtor.com/)'
   pronunciation: '[Pronounce my name 🔊](https://www.name-coach.com/erzhan-torokulov?preview=on)'
   description: Erzhan is a Software Engineer with industry experience building high-quality software solutions with a passion for learning. He has experience working on backend, frontend as well as mobile development. Outside work, he enjoys traveling and trying new things/activities.
@@ -880,6 +963,7 @@ brannon_rouse:
   reports_to: head_sales_development
   location: Birmingham, AL, United States 🇺🇸
   github: Brannon-Rouse
+  email: brannon.rouse@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/brannon-rouse-1a106414b/)'
   description: Brannon grew up in Dallas, Texas and currently lives in Birmingham, Alabama with his wife, Emery. Brannon is an avid runner, a big Dallas sports fan, and a Taco Tuesday enthusiast. Before joining Sourcegraph he worked in the digital health startup space where he developed a passion for development, team-building, and bullet journaling.
 
@@ -891,6 +975,7 @@ diego_comas:
   manager_role_slug: engineering_manager_security
   location: Barcelona, Spain 🇪🇸
   github: dcomas
+  email: diego.comas@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/diegocomas)'
   description: Diego lives in Barcelona, with his wife and two kids. He is passionate about technology, sci-fi movies and football(soccer). In the last 10 years he lived in London (UK) and worked for tech startups and scale ups building teams and helping them improve their security posture. Diego never misses a game of his local team FC Barcelona 🏟. In his spare time (if kids allow!) he likes to play football ⚽️, other sports like padel tennis 🎾 and sailing ⛵️ in the Costa Brava.
 
@@ -917,6 +1002,7 @@ andrew_hsu:
   reports_to: rd_ce_us_apj
   location: Los Angeles, California, United States 🇺🇸
   github: superhsu
+  email: andrew.hsu@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/andrewjhsu/)'
   description: Andrew lives in Los Angeles, California, with his partner and their grumpy cat, Ginger. He has a passion for technology and sales. Growing up at a young age, he helped his cousins build and sell computers. Andrew has spent most of his career as a Sales Engineer. Before Sourcegraph, he helped sell observability software at Splunk. Outside of work, he enjoys traveling ✈️, spending time with family & friends, watching movies, playing competitive sports & e-sports.
 
@@ -928,6 +1014,7 @@ jh_chabran:
   pronunciation: 'Name Pronunciation: [/ʒiaʃ/](https://www.name-coach.com/jh-chabran)'
   location: Lyon, France 🇫🇷
   github: jhchabran
+  email: jean-hadrien.chabran@sourcegraph.com
   description: JH loves to learn new things all the time and to build software that helps other developers. He got into coding by learning how some developers managed to translate old video games through reverse engineering. In his free time, JH likes to experiment with new tools, play indie video games, take long walks with his (stubborn) Corgi and cook for his friends and family.
 
 mohammad_umer_alam:
@@ -937,6 +1024,7 @@ mohammad_umer_alam:
   reports_to: engineering_manager_security
   location: Staten Island, NY 🇺🇸
   github: mohammadualam
+  email: mohammad.alam@sourcegraph.com
   links: '[LinkedIn](https://linkedin.com/in/mohammadalam/)'
   description: Mohammad is an avid tinkerer of gadgets and networks. He enjoys taking apart old electronics☎️ and see how they tick. So passion for technology and in relation to it, security, comes naturally to him. He is also very enthusiastic about driving his Jeep Wrangler, although he has yet to go offroading with it. Mohammad also enjoys staying active via outdoor activities and taking part in recreational sports leagues. He is a diehard Yankees⚾️ fan and hopes that they can win another championship soon so he can attend the ticker-tape parade in NYC.
 
@@ -947,6 +1035,7 @@ grace_bohl:
   reports_to: director_recruiting_peopleops
   location: Denver, CO 🇺🇸
   github: gracebohl
+  email: you@sourcegraph.com
   description: Grace is a Chicago, IL native and moved to Denver over 4 years ago. Prior to Sourcegraph, Grace gained experience recruiting in high growth SaaS companies such as Xactly Corp and Slack. When not working, Grace enjoys taking advantage of everything Colorado has to offer such as hiking, camping and snowboarding. In her free time, she enjoys going on walks, cooking, traveling and hanging with family and friends.
 
 cesar_jimenez:
@@ -955,6 +1044,7 @@ cesar_jimenez:
   reports_to: engineering_manager_code_intelligence
   location: Seattle, WA 🇺🇸
   github: numbers88s
+  email: cesar.jimenez@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/cesarrjimenez/)'
   description: Cesar loves running, hiking, playing board games, listening to music, and going for walks with his wife and baby boy Leo. Favorite video games includes SOCOM 2 and Super Smash Bros Melee too! Proudly on Team Fox/Falco. Cesar used to be a dev bootcamp instructor at Code Fellows and loves cooking, and his favorite thing to do is try out new restaurants.
 
@@ -965,6 +1055,7 @@ kemper_hamilton:
   reports_to: director_recruiting_peopleops
   location: Austin, TX, United States 🇺🇸
   github: kemperhamilton
+  email: kemper.hamilton@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/kemperhamilton/)'
   description: Kemper has been an Austinite for ten years. She loves traveling, listening to live music, spending time outdoors, and she is a cheese & charcuterie enthusiast 🧀 She has experience in corporate communications, HR operations, and recruitment.
 
@@ -975,6 +1066,7 @@ nancy_shah:
   reports_to: manager_technical_advisory
   location: Oakton, VA, United States 🇺🇸
   github: nancy4dev
+  email: nancy@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/nancy-s-97b71859/)'
   pronunciation: 'How to say my last name: [Shah](https://www.howtopronounce.com/shah)'
   description: Nancy grew up in upstate New York, but has lived in the DC Metro Area for most of her life. You can find Nancy rock climbing most evenings.  She also enjoys trying out new coffee shops, tyring out vegan recipes, drinking tea, binge watching TV shows, and spending time outdoors.
@@ -986,7 +1078,18 @@ michal_sennett:
   reports_to: ebp_lead
   location: Dallas, TX, USA 🇺🇸
   github: msennett22
+  email: michal.sennett@sourcegraph.com
   description: Michal lives in Dallas with her husband Josh, and two dogs, Jet (labrador mix) and Jax (chiweenie)! She has held diverse roles ranging from Employee Engagement, Project Management, Career Coaching, Customer Success and Sales. Michal has a passion for hosting people and planning unique experiences. She loves traveling and learning about new cultures, especially by eating their cuisine.
+
+keely_aguayo:
+  name: Keely Aguayo
+  pronouns: she/her
+  role: Payroll Manager
+  reports_to: financial_controller
+  location: New Orleans, LA, USA 🇺🇸
+  github: keelyaguayo
+  email: keely.aguayo@sourcegraph.com
+  description: 'Keely lives in New Orleans with her husband, Chris, their four sons: Sullivan, Anderson, Miller, and Wilder, and a 14 year old Bichon Frise named Elle.'
 
 simon_waterer:
   name: Simon Waterer
@@ -995,6 +1098,7 @@ simon_waterer:
   reports_to: rd_ce_emea
   location: London, United Kingdom 🏴󠁧󠁢󠁥󠁮󠁧󠁿
   github: simoncwaterer
+  email: simon.waterer@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/simonwaterer/)'
   description: Simon lives in Buckinghamshire near Oxford, though he grew up in Edinburgh. He likes most sports but especially cricket, rugby and F1. He lives with his wife Julie, cats Tabatha and Sadie and Willow the 1 year old sprocker spaniel. He loves spending time outdoors taking the dog for a walk, walking around with a bag of golf clubs - and one day maybe able to do both. He has worked across a range of technologies including object and NoSQL databses, high performance and grid computing.
 
@@ -1005,6 +1109,7 @@ taylor_sperry:
   role: Product Manager, Frontend Platform
   location: Denver, CO, USA 🇺🇸
   github: taylorsperry
+  email: taylor.sperry@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/taylor-sperry/)'
   description: "Taylor spent many years as a book editor in NYC before quitting her job with absolutely no plan and landing at the Turing School of Software and Design in her hometown of Denver, CO. She joined Sourcegraph after a stint helping build enterprise software as an engineer at Workiva. She's happiest in a kitchen full of people (always a sous chef, never the chef), or outside with her nose in a book, a podcast in her ears, or skis on her feet."
 
@@ -1016,6 +1121,7 @@ rafal_gajdulewicz:
   manager_role_slug: engineering_manager_cloud
   location: Warsaw, Poland 🇵🇱
   github: rafax
+  email: rafal.gajdulewicz@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/gajdulewicz/)'
   description: Rafal lives in Warsaw, Poland with his wife & 2 sons. Before Sourcegraph, Rafal worked as Software Engineer at Google, building UIs for Kubernetes-related products. In his free time, Rafal enjoys riding bicycles and motorcycles, surfing and snowboarding.
 
@@ -1026,6 +1132,7 @@ varun_gandhi:
   reports_to: engineering_manager_code_intelligence
   location: 'Taipei, Taiwan'
   github: varungandhi-src
+  email: varun.gandhi@sourcegraph.com
   links: '[Twitter](https://twitter.com/typesanitizer), [LinkedIn](https://www.linkedin.com/in/varungandhi15/)'
   description: After training as a physicist, Varun decided to take a hard left turn after being enamored by functional programming and compilers. Loving all things related to developer tools, Varun worked on the Swift compiler before joining Sourcegraph. In his spare time, Varun may be found learning a new language, watching a movie at the cinema, bopping to some kpop, or animatedly gesticulating at an Arsenal game.
 
@@ -1035,6 +1142,7 @@ carter_jaenichen:
   reports_to: head_sales_development
   location: Orange County, CA, USA 🇺🇸
   github: carterjaenichen
+  email: carter.jaenichen@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/carterjaenichen/)'
   description: Carter lives in Orange County, CA with his girlfriend Kelsey, and 3 dogs (Dogs are awesome). He loves sports, specifically football, basketball, golf, and snowboarding. He is striving to grow personally, professionally, and financially. Carter is an extrovert and loves meeting new people; probably the reason he is pursuing a career in sales.
 
@@ -1044,10 +1152,12 @@ amber_nocerino:
   reports_to: ebp_lead
   location: Austin, TX, USA
   github: ambernoc
+  email: amber.nocerino@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/ambersmo)'
 
 dan_diemer:
   name: Dan Diemer
+  email: dan.diemer@sourcegraph.com
   github: dhdiemer
   pronouns: he/him
   role: Senior Customer Engineer
@@ -1059,6 +1169,7 @@ dan_diemer:
 
 carson_hopkins:
   name: Carson Hopkins
+  email: carson.hopkins@sourcegraph.com
   github: hopkinscl
   pronouns: she/her
   role: Senior Customer Engineer
@@ -1068,6 +1179,7 @@ carson_hopkins:
 
 olivia_simpson:
   name: Olivia Simpson
+  email: olivia@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/olivia-simpson-9a8a1835/)'
   github: olivia488
   role: Program Manager, Demand Generation Campaigns
@@ -1077,6 +1189,7 @@ olivia_simpson:
 
 amy_johnson:
   name: Amy Johnson
+  email: amy.johnson@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/amy-johnson-2367a4137/)'
   github: amyjohnsonSG
   role: Accountant
@@ -1086,6 +1199,7 @@ amy_johnson:
 
 Daniel_Gwyn:
   name: Daniel Gwyn
+  email: daniel.gwyn@sourcegraph.com
   links: '[LinkdIn](https://www.linkedin.com/in/daniel-gwyn-6b9ab6161/)'
   github: danieltgwyn
   role: Sales Dev Rep
@@ -1099,6 +1213,7 @@ alex_ostrikov:
   reports_to: source_lead
   location: Dubai, UAE 🇦🇪
   github: sashaostrikov
+  email: alex.ostrikov@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/alexander-ostrikov-a4027810b/)'
   description: Alexander (but you can also call him Alex or Sasha) lives in Dubai, UAE where he moved from St. Petersburg, Russia with his fiancée Olga and their cat (with a _brilliant_ name — Kot ("cat" in Russian)). When not coding, he likes spending his time learning all the memes in the world, listening to music, singing (in fact mostly screaming) some metal songs, playing drums (once in a blue moon, to be honest), but his favourite pastime is making endless wallpapers with photos of Kot being weirdly zoomed into and cropped.
 
@@ -1108,6 +1223,7 @@ Nate_Freng:
   role: Tech Ops Engineer
   reports_to: tech_ops_manager
   location: Fargo, ND, USA 🇺🇸
+  email: nate.freng@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/nathanielfreng)'
   description: Nate lives in Fargo, ND with his wife (Chelsey) and their four kids (Avery, Auden, Alder, and Addison). A great variety of jobs have led to where he is now from driving forklift, in-home healthcare, implementing insurance benefits plans to finally landing in IT where he has had an interest since he was young. Originally graduation college with a B.S. in Human Development and Family Science, Nate has been working almost the past 10 years doing IT work for organizations of various sizes ranging from 100 to 1000 users. Outside of work he spends most of his time  doing things with his family or working on home DIY projects. When left up to his own devices he enjoys podcasts, reading, video games, and all things fitness. Also food, cannot forget food!
 
@@ -1118,6 +1234,7 @@ filip_haftek:
   reports_to: engineering_manager_cloud
   location: Kraków, Poland 🇵🇱
   github: filiphaftek
+  email: filip.haftek@sourcegraph.com
   links: '[LinkedIn](https://pl.linkedin.com/in/filip-haftek-a5710114)'
   description: 'Filip is a software engineer DevOps located in Krakow, Poland. He really likes to help people, especially in the areas he has an experience like cloud infrastructure (+ terraform), automation, CI/CD, search engines and the applications performance and monitoring. He loves to spend time with his family, especially skiing, walking through the forests and travelling together. Winter is his favourite part of the year :skier: :snowflake:'
 
@@ -1128,6 +1245,7 @@ cory_dobson:
   reports_to: rsd_west
   location: Portland, OR, USA 🇺🇸
   github: corydobson
+  email: cory.dobson@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/cory-dobson-12530826/)'
   description: 'Cory is an Enterprise Account Executive based in Portland, OR. Prior to Sourcegraph, Cory worked in different Solutions Engineering roles at developer-focused companies like GitHub, Stripe, and Algolia. Outside of work, he likes playing music, taking photos, and exploring new places.'
 
@@ -1138,6 +1256,7 @@ isuru_fonseka:
   reports_to: rd_ce_us_apj
   location: Sydney, Australia 🇦🇺
   github: Isuru-F
+  email: isuru.fonseka@sourcegraph.com
   links: '[LinkedIn](https://linkedin.com/in/isurufonseka)'
   description: 'Isuru lives in Sydney, Australia. In his free time he is hanging out with his wife and two cats, fishing, or playing squash'
 
@@ -1146,6 +1265,7 @@ daniel_dides:
   role: Software Engineer
   reports_to: engineering_manager_cloud
   location: Flint, TX, USA 🇺🇸
+  email: daniel.dides@sourcegraph.com
   github: danieldides
   links: '[LinkedIn](https://www.linkedin.com/in/danieldides/)'
   description: Daniel lives in Flint, TX with his wife, two dogs, a cat, and a couple of horses. During the day, Dan enjoys helping people leverage Kubernetes and modern cloud tooling. When he's not working, he enjoys watching rocket launches, designing and 3D printing parts, and tinkering with new technologies.
@@ -1155,6 +1275,7 @@ nicolas_hernandez:
   role: Enterprise Account Executive - Sales
   reports_to: regional_director_sales_east
   location: Miami, FL, USA 🇺🇸
+  email: nick.hernandez@sourcegraph.com
   github: fryster66
   links: '[LinkedIn](https://www.linkedin.com/in/nicolas-hernandez-70242033/), [Why I Joined Sourcegraph](https://medium.com/@doktanick/why-i-am-joining-sourcegraph-99fba51df985)'
   description: Nick grew up in San Francisco and is currently in Miami. He graduated from Stanford where he studied Comp Lit and then took a fellowship to study law in Germany. He started his career in Enteprise Software at MuleSoft where he held a number of different sales roles. After that, he built the sales team at Vivian, a healthcare labor marketplace owned by IAC. Nick likes to read books, drink tea, and explore on foot. He is taking music recommendations.
@@ -1165,6 +1286,7 @@ rohan_gupta:
   reports_to: head_sales_development
   location: Austin, TX, USA 🇺🇸
   pronouns: he/him
+  email: rohan.gupta@sourcegraph.com
   github: rohanguptatx
   links: '[LinkedIn](https://www.linkedin.com/in/rohanguptatx/), [@rguptatech](https://twitter.com/rguptatech), [Why I Joined](https://medium.com/@rohanguptatx/sourcegraph-the-future-of-big-code-1de9adbeca36)'
   description: Rohan is a Boston-ite turned Austin-ite. He enjoys running, finding the next best food truck or music festival, and helping customers solve unique business challenges.
@@ -1176,6 +1298,7 @@ david_veszelovszki:
   reports_to: source_lead
   location: Budapest, Hungary 🇭🇺
   pronouns: he/him
+  email: david.veszelovszki@sourcegraph.com
   github: vdavid
   links: '[LinkedIn](https://www.linkedin.com/in/veszelovszki/)'
   description: David is a developer with 150+ coding projects behind him, specializing in web development, i18n, and refactoring 🧑‍💻. He’s a very organized person with spreadsheets on a scary amount of aspects of his life. He loves doing research and playing with new technologies. He has nine siblings, an amazing wife, and a baby daughter 👶. He snowboards 🏂, does freediving 🐚, slacklines 🌴____🕺____🌴, used to paraglide 🪂, and is a divemaster 🤿. He's a meditator 🧘 with three 10-day vipassana courses spent in complete silence and once served for ten days as a volunteer. Besides coding, he's enthusiastic about online education 🧑‍🏫 and indoor vertical farming 👨‍🌾.
@@ -1183,11 +1306,13 @@ david_veszelovszki:
 andrew_reed:
   name: Andrew Reed
   role: Senior Manager, Sales Development
+  email: andrew.reed@sourcegraph.com
   reports_to: vp_sales
   manager_role_slug: head_sales_development
 
 ashwin_Thakur:
   name: Ashwin Thakur
+  email: ash.thakur@sourcegraph.com
   pronouns: he/him
   github: ashwint98
   role: Sales Development Representative (EMEA)
@@ -1198,6 +1323,7 @@ ashwin_Thakur:
 
 casi_neff:
   name: Casi Neff
+  email: casi.neff@sourcegraph.com
   github: casineff
   role: Sales Development Representative (East)
   reports_to: head_sales_development
@@ -1212,6 +1338,7 @@ philipp_spiess:
   reports_to: engineering_manager_code_exploration
   location: Vienna, AT 🇦🇹
   pronunciation: '[ˈʃpiːs](http://ipa-reader.xyz/?text=%CB%88%CA%83pi%CB%90s&voice=Marlene)'
+  email: philipp.spiess@sourcegraph.com
   github: philipp-spiess
   links: '[@PhilippSpiess](https://twitter.com/PhilippSpiess), [LinkedIn](https://www.linkedin.com/in/philipp-spiess/)'
   description: Philipp grew up in the countryside of Austria and developed a passion for Web programming very early. After moving to Vienna to study computer science and working on some freelancing gigs, he helped create a PDF editor for the Web. Before joining Sourcegraph, Philipp worked as a Front-End Engineer at Meta/Facebook in London. Outside of work, his hobbies vary wildly, from being a home barista to learning new cooking techniques, working on DIY projects, or playing video games.
@@ -1224,6 +1351,7 @@ desene_sterling:
 
 shawntee_harris:
   name: Shawnteé Harris
+  email: shawntee.harris@sourcegraph.com
   reports_to: vp_technical_success
   github: shawnteeharris
   pronouns: she/her
@@ -1233,6 +1361,7 @@ shawntee_harris:
 
 connor_obrien:
   name: Connor OBrien
+  email: connor.obrien@sourcegraph.com
   role: Chief of Staff to CEO
   pronouns: he/him
   github: connoro13c
@@ -1247,6 +1376,7 @@ michael_lin:
   location: Richmond, BC, Canada 🇨🇦
   role: Software Engineer
   reports_to: engineering_manager_cloud
+  email: michael.lin@sourcegraph.com
   github: michaellzc
   links: '[LinkedIn](https://www.linkedin.com/in/mlzc/), [@_mlzc](https://twitter.com/_mlzc)'
   description: |
@@ -1263,11 +1393,13 @@ petri_last:
   location: Stellenbosch, Western Cape, South Africa 🇿🇦
   github: pjlast
   pronunciation: '[pɪətʁɪ lɑst](http://ipa-reader.xyz/?text=p%C9%AA%C9%99t%CA%81%C9%AA%20l%C9%91st&voice=Joey)'
+  email: petri.last@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/petri-johan-last-1b1214135/)'
   description: "Petri lives in [Stellenbosch, South Africa](https://www.google.com/maps/place/Stellenbosch) with his wife and dog. When he's not busy overthinking everything he does, he enjoys reading (horror, fantasy, sci-fi), gaming (horror, RPG, story-driven), music (hard, fast, and loud), and whatever additional flavour of hobby for the month."
 
 Samantha_Ulrich:
   name: Samantha (sam) Ulrich
+  email: sam.ulrich@sourcegraph.com
   github: samU713
   pronouns: she/her
   role: Senior Accountant
@@ -1278,6 +1410,7 @@ Samantha_Ulrich:
 
 andrew_norrish:
   name: Andrew Norrish
+  email: andrew.norrish@sourcegraph.com
   github: anorrish
   pronouns: he/him
   role: Senior Implementation Project Manager
@@ -1298,6 +1431,7 @@ sam_lottes:
   reports_to: head_sales_development
   location: New York, NY, USA 🇺🇸
   github: SamLottes
+  email: sam.lottes@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/samuel-lottes/)'
   description: Sam grew up in Madison, WI and currently resides New York City. He's an avid reader and loves urbanism, team sports, and escaping in the great outdoors. He also desperately wants to own his own dog, but is decidedly too irresponsible for such a commitment. At work, Sam enjoys having personable, data-driven conversations that help close new business and iterating on workflows to continuously be the best version of himself he can be.
 
@@ -1307,11 +1441,13 @@ andrew_kim:
   reports_to: head_sales_development
   location: Seattle 🇺🇸
   github: ackim507
+  email: andrew.kim@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/andrew-kim-0096b492/)'
   description: Andrew grew up in Seattle, WA. His favorite memories include singing with his acapella group for the Obama at the whitehouse when attending Boston University. He will remain a diehard seahawks fan and continue to grow his passions in music production, DJing, and cooking. He aspires to continue his career growth in sales and is always eager to learn new things from his peers, family, and friends.
 
 taras_yemets:
   name: Taras Yemets
+  email: taras.yemets@sourcegraph.com
   github: taras-yemets
   pronouns: he/him
   role: Software Engineer
@@ -1322,6 +1458,7 @@ taras_yemets:
 
 idan_varsano:
   name: Idan Varsano
+  email: idan.varsano@sourcegraph.com
   github: varsanojidan
   pronouns: he/him
   role: Software Engineer, repo-management
@@ -1332,6 +1469,7 @@ idan_varsano:
 
 maureen_loughrey:
   name: Maureen Loughrey
+  email: maureen.loughrey@sourcegraph.com
   github: maureenlsourcegraph
   pronouns: she/her
   role: Tech Ops Engineer
@@ -1341,6 +1479,7 @@ maureen_loughrey:
 
 lauren_anderson:
   name: Lauren Anderson
+  email: lauren.anderson@sourcegraph.com
   github: andersonlauren
   pronouns: she/her
   role: Director of Data & Analytics
@@ -1352,6 +1491,7 @@ lauren_anderson:
 
 madison clark:
   name: Madison Clark
+  email: madison.clark@sourcegraph.com
   github: madisongclark
   pronouns: she/her
   role: Senior Manager, Internal Communications
@@ -1361,6 +1501,7 @@ madison clark:
 
 michael mcmahan:
   name: Michael McMahan
+  email: michael.mcmahan@sourcegraph.com
   github: mjmcmahan
   pronouns: he/him
   role: Enterprise Account Executive
@@ -1374,6 +1515,7 @@ justin dorfman:
   reports_to: cto
   location: Los Angeles, CA, USA 🇺🇸
   github: jdorfman
+  email: justin.dorfman@sourcegraph.com
   links: '[Twitter](https://twitter.com/jdorfman), [LinkTree](https://linktr.ee/jdorfman)'
   description: Justin is responsible for fostering the adoption of universal code search in the open source community. Previously, he led similar initiatives for Curifense (a CNCF project), Gitcoin, & MaxCDN. He has contributed to Bootstrap, Font Awesome, jQuery, Nginx, GNU Bash, and many more. He also serves on the Open Source Collective board of directors. In 2017, he co-founded SustainOSS, which hosts events and podcasts for Open Source Software Sustainers.
 
@@ -1384,6 +1526,7 @@ bolaji_olajide:
   reports_to: engineering_manager_batch_changes
   location: Lagos, Nigeria 🇳🇬
   github: BolajiOlajide
+  email: bolaji.olajide@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/bolaji-olajide/)'
   description: 'Bolaji grew up in Lagos, Nigeria and studied Computer Science at a university in Nigeria. Outside of work, he enjoys gaming, listening to music and watching football. He is also an avid contributor to OSS.'
 
@@ -1393,9 +1536,11 @@ todd_herskovitz:
   reports_to: rsd_west
   location: San Francisco, CA, USA 🇺🇸
   github: toddherskovitz
+  email: todd@sourcegraph.com
 
 sander_ginn:
   name: Sander Ginn
+  email: sander.ginn@sourcegraph.com
   github: sanderginn
   pronouns: he/him
   role: Software Engineer
@@ -1406,6 +1551,7 @@ sander_ginn:
 
 sally_voisen:
   name: Sally Voisen
+  email: sally.voisen@sourcegraph.com
   github: stvoisen
   pronouns: she/her
   role: Senior Executive Business Partner
@@ -1422,6 +1568,7 @@ daniel_marques:
   role: Product Designer, Batch Changes
   location: Leiria, Portugal 🇵🇹
   github: danielmarquespt
+  email: daniel.marques@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/danielmarquespt/)'
   description: 'Daniel is Product Designer based in Portugal. He is very passionate about everything related with technology, internet, eletronics and geek stuff. Besides that he loves the going outside, walking trails, riding his motorcycle or just chilling with friends watching the sunset.'
 
@@ -1433,6 +1580,7 @@ brock_perko:
   manager_role_slug: rsd_west
   location: Mill Valley, CA USA 🇺🇸
   github: 0xPerko
+  email: brock_perko@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/brock-perko-5094349/)'
   description: 'Brock lives in Mill Valley, CA with his wife and cat. A Bay Area native, he has built a career in Sales working at startups Eventbrite, Slack, and Productiv previously. Outside of work, Brock enjoys hiking in Marin and the California Coast, golf, live music, and nights out in San Francisco at his favorite restaurants. He is also a big fan of cryptocurrencies and Web3 technology, with a personal goal of opening a local deli someday.'
 
@@ -1442,6 +1590,7 @@ chris_warwick:
   reports_to: engineering_manager_code_insights
   location: Philadelphia, PA United States 🇺🇸
   github: chwarwick
+  email: christopher.warwick@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/warwickc)'
   description: 'Chris is a software engineer based near Philadelphia, PA where he lives with his wife and three children. He has spent a number of years building mobile and web applications. When not working he enjoys spending time outside and running.'
 
@@ -1451,6 +1600,7 @@ becca_steinbrecher:
   role: Software Engineer
   location: Mesa County, CO, USA 🇺🇸
   github: st0nebraker
+  email: becca.steinbrecher@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/becca-steinbrecher/)'
   description: 'Becca grew up in San Diego and has been in Colorado since 2017. In her free time she enjoys rock climbing, practicing yoga, playing piano, eating, riding bikes, snowboarding, and trying new things.'
 
@@ -1462,11 +1612,13 @@ laura_hacker:
   location: Grand Rapids, MI, USA 🇺🇸
   github: lrhacker
   pronunciation: '/[ˈlɔːɹə hækəɹ](http://ipa-reader.xyz/?text=%CB%88l%C9%94%CB%90%C9%B9%C9%99%20h%C3%A6k%C9%99%C9%B9&voice=)/'
+  email: laura.hacker@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/lrhacker)'
   description: 'Laura lives in Grand Rapids, Michigan with her husband and their cat. In addition to her computer science degree, she also spent several years studying zoology and still has plenty of random animal facts to share. Outside of work, she likes to try out different art mediums and crafts, experiment with baking new recipes, and spend time with her family and friends.'
 
 tracey_johnson:
   name: Tracey Johnson
+  email: tracey.johnson@sourcegraph.com
   github: traceyljohnson
   pronouns: they/them
   role: Brand Designer
@@ -1482,11 +1634,13 @@ Nicky_Comber:
   reports_to: financial_controller
   location: Buenos Aires, Argentina 🇦🇷
   github: nickycomber
+  email: nicky.comber@sourcegraph.com
   links: '[Linkedin](https://www.linkedin.com/in/nicole-comber-65219024)'
   description: 'Nicole lives in Buenos Aires with her partner Pablo and her daughter Juana. In her free time, she enjoys cooking, practicing yoga, travelling and spending time with family and friends.'
 
 dora_neumeier:
   name: Dora Neumeier
+  email: dora@sourcegraph.com
   github: doragrgic
   pronouns: she/her
   role: Compliance Manager
@@ -1497,6 +1651,7 @@ dora_neumeier:
 
 sarah_dunn:
   name: Sarah Dunn
+  email: sarah.dunn@sourcegraph.com
   github: sarahedunn
   pronouns: she/her
   role: Enterprise Account Executive
@@ -1506,6 +1661,7 @@ sarah_dunn:
 
 naman_kumar:
   name: Naman Kumar
+  email: naman.kumar@sourcegraph.com
   github: thenamankumar
   pronouns: he/him
   role: Software Engineer, IAM
@@ -1516,6 +1672,7 @@ naman_kumar:
 
 josé_taylor:
   name: José Taylor
+  email: jose.taylor@sourcegraph.com
   github: josetaylor06
   pronouns: he/him
   role: Enterprise Technical Advisor
@@ -1533,10 +1690,12 @@ paulo_almeida:
   location: São Paulo, Brazil 🇧🇷
   github: almeidapaulooliveira
   links: '[Website](https://paulo.digital), [LinkedIn](https://www.linkedin.com/in/paul--almeida/)'
+  email: paulo.almeida@sourcegraph.com
   description: 'Paulo is a designer that endeavors to produce unique experiences and elegant designs. He worked in branding, packaging, and graphic design and has been dedicated to UX disciplines in the last decade, from strategy to visual and interface design. Paulo is also a coding designer who thinks end-to-end the entire process. When not working, he is running on some adventure traveling the world. As a restless observer of the human being, he is always excited about developing thoughtful products that enhance life, work, and play.'
 
 ajay_uppaluri:
   name: Ajay Uppaluri
+  email: ajay.uppaluri@sourcegraph.com
   github: auppaluri1
   pronouns: He/Him
   role: Director, Sales Strategy & Operations
@@ -1551,6 +1710,7 @@ rakesh_joshi:
   role: Support Engineer
   reports_to: manager_support
   location: Melbourne, Australia
+  email: rakesh.joshi@sourcegraph.com
   github: rakeshjosh2003
   pronouns: He/Him
   links: '[LinkedIn](https://www.linkedin.com/in/rakesh-joshi-62a56416)'
@@ -1558,6 +1718,7 @@ rakesh_joshi:
 
 nathan_downs:
   name: Nathan Downs
+  email: nathan.downs@sourcegraph.com
   github: nathan-downs
   pronouns: he/him
   role: Lead Data Engineer
@@ -1567,6 +1728,7 @@ nathan_downs:
 
 randell_callahan:
   name: Randell Callahan
+  email: randell.callahan@sourcegraph.com
   github: Piszmog
   pronouns: he/him
   role: Software Engineer
@@ -1576,6 +1738,7 @@ randell_callahan:
 
 william_bezuidenhout:
   name: William Bezuidenhout
+  email: william.bezuidenhout@sourcegraph.com
   github: burmudar
   pronouns: he/him
   role: Software Engineer
@@ -1586,6 +1749,7 @@ william_bezuidenhout:
 
 aditya_kalie:
   name: Aditya Kalia
+  email: aditya.kalia@sourcegraph.com
   github: akalia25
   pronouns: he/him
   role: Data Engineer
@@ -1596,6 +1760,7 @@ aditya_kalie:
 
 gronk:
   name: Ralf 'gronk' Gronkowski
+  email: gronk@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/ralf-gronkowski-b74a90/)'
   github: gronk-sg
   pronouns: he/him
@@ -1611,6 +1776,7 @@ kalan_chan:
   location: Burnaby, BC, Canada 🇨🇦
   role: Software Engineer
   reports_to: engineering_manager_batch_changes
+  email: kalan.chan@sourcegraph.com
   github: kalanchan
   links: '[LinkedIn](https://www.linkedin.com/in/kalanchan/)'
   description: Kalan lives in Burnaby, also known as Vancouver to everyone outside of Metro Vancouver. He graduated from the University of Alberta with an Electrical Engineering degree, but soon after started self learning Software Development when he saw the light. On his spare time when he's not pushing pixels, Kalan enjoys biking, bouldering, reading and plane spotting.
@@ -1621,6 +1787,7 @@ miles_patton:
   location: Ljubljana, Slovenia 🇸🇮
   role: Tech Ops Support Specialist
   reports_to: tech_ops_manager
+  email: miles.patton@sourcegraph.com
   github: milespatton
   links: '[LinkedIn](https://www.linkedin.com/in/miles-g-patton/)'
   description: 'Miles grew up in Falmouth, Maine, and studied at the University of British Columbia in Vancouver, Canada. Now, he lives in Ljubljana, Slovenia where he enjoys everything outdoors - mainly hiking, climbing, sailing, and skiing. He loves to travel and has been to more than 30 countries around the world, discovering new cultures and foods along the way.'
@@ -1631,6 +1798,7 @@ megan_standrew:
   location: Chicago, IL, USA 🇺🇸
   role: UX Researcher
   reports_to: director_design
+  email: megan.standrew@sourcegraph.com
   github: meglynst
   links: '[LinkedIn](https://www.linkedin.com/in/meganstandrew/)'
   description: 'Megan grew up in Michigan and is a proud Anishinaabekwe from the Sault Ste. Marie Tribe of Chippewa Indians (Aanii!👋). She originally studied international studies and digital humanities before shifting to work in UX as a generalist turned researcher. Outside of work, Megan enjoys reading (fiction, non-fiction, poetry, comics, webtoons, basically everything), exploring new cafes in the Chicago area, attempting to learn new languages, and watching K-dramas.'
@@ -1641,6 +1809,7 @@ chris_concannon:
   location: San Francisco, CA, USA 🇺🇸
   role: Senior Customer Engineer
   reports_to: rd_ce_us_apj
+  email: chris.concannon@sourcegraph.com
   github: cconcannon
   links: '[LinkedIn](https://www.linkedin.com/in/csconcannon), [Website](https://blog.concannon.tech)'
   description: 'Chris lives in San Francisco 🌁 with his wife and their dog. He has a biomedical engineering degree from Duke University, and he spent several years as a clinical medical device professional before he became a software developer. Chris is an avid trail runner, and he thinks that running up a mountain at sunrise is the best way to start a day. He also enjoys skiing, backpacking, cycling, traveling, riding his motorcycle, and indulging in the fabulous local food, wines, and beers of the Bay Area.'
@@ -1650,6 +1819,7 @@ tom_pinckney:
   role: Head of Business Development
   location: San Francisco, CA
   reports_to: vp_sales
+  email: tom.pinckney@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/tom-pinckney)'
   description: Tom is a native Virgnian.  He came to California back in 2000 and has never left.  Tom lives in San Francisco with his wife and 7 and 12 year old boys and dog Sugar.  He has spent most of his career working in field based roles in high growth enterprise software companies.  He's responsible for the partner ecosystem at Sourcegraph.
 
@@ -1659,12 +1829,14 @@ gary_lee:
   reports_to: search_lead
   location: San Francisco, CA, USA 🇺🇸
   github: gl-srgr
+  email: gary.lee@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/gary-lee-68b28745/)'
   description: Gary lives in San Francisco, California and has worked as a Software Engineer on search products and solutions since 2015. Outside of work he plays drums in a rock band, practices martial arts, spends time with his dogs, and catches up on books.
 
 vincent_ruijter:
   name: Vincent Ruijter
   pronouns: he/him/his
+  email: vincent.ruijter@sourcegraph.com
   github: evict
   role: Security Engineer
   reports_to: engineering_manager_security
@@ -1677,10 +1849,12 @@ james_cotter:
   reports_to: engineering_manager_delivery
   location: Cork, Ireland 🇮🇪
   github: jac
+  email: james.cotter@sourcegraph.com
   description: James is a UCC Computer Science graduate born and raised in West Cork, Ireland. Previously he was a Software Engineering Intern at F5/NGINX, and Head Systems Administrator at UCC Netsoc, the college tech/gaming society. Outside of tech James enjoys sailing, gaming, D&D, and all things sci-fi.
 
 jamie_lindsay:
   name: Jamie Lindsay
+  email: jamie.lindsay@sourcegraph.com
   pronouns: she/her
   role: Sales Enablement Lead
   reports_to: senior_manager_value_engineering
@@ -1694,11 +1868,13 @@ jessie_seidler:
   reports_to: rsd_west
   location: Denver, CO, USA 🇺🇸
   github: JessieSeidler
+  email: jessie.seidler@sourcegraph.com
   links: '[LinkedIn](https://www.linkedin.com/in/jessieseidler/)'
   description: "A recent Denver transplant, Jessie spent the last 8 years in San Francisco establishing a career in sales with companies like Optimizely and Twilio. Jessie graduated from Boston College with an Honors BA in Sociology and Spanish. When she's not whipping up dank Italian food, you can find her outside biking, running, or backpacking. Jessie has been to 50 countries and counting! "
 
 sam_johns:
   name: Sam Johns
+  email: sam.johns@sourcegraph.com
   role: Senior Implementation Engineer
   reports_to: vp_technical_success
   location: Arlington, VA, USA 🇺🇸
@@ -1708,6 +1884,7 @@ sam_johns:
 
 will_dollman:
   name: Will Dollman
+  email: will.dollman@sourcegraph.com
   github: willdollman
   pronouns: he/him
   role: Security Engineer
@@ -1718,6 +1895,7 @@ will_dollman:
 
 bachi_degli_innocenti:
   name: Juliana (Bachi) Degli Innocenti
+  email: bachi.degli.innocenti@sourcegraph.com
   pronouns: she/her🇷
   role: Sr. Social Media Manager
   reports_to: director_global_communications
@@ -1728,6 +1906,7 @@ bachi_degli_innocenti:
 
 jacob_pleiness:
   name: Jacob Pleiness
+  email: jacob.pleiness@sourcegraph.com
   github: jdpleiness
   pronouns: he/him
   role: Software Engineer
@@ -1738,6 +1917,7 @@ jacob_pleiness:
 
 ted_moskalenko:
   name: Ted Moskalenko
+  email: ted@sourcegraph.com
   github: tdmosk
   pronouns: he/him
   role: Strategic Technical Advisor
@@ -1748,6 +1928,7 @@ ted_moskalenko:
 
 jon_galindo:
   name: Jon Galindo
+  email: jon.galindo@sourcegraph.com
   github: Galindo-J
   pronouns: he/him
   role: Senior Support Engineer
@@ -1758,6 +1939,7 @@ jon_galindo:
 
 sam_mandell:
   name: Samantha (Sam) Mandell
+  email: sam.mandell@sourcegraph.com
   github: srmandell
   pronouns: she/her
   role: Commercial Counsel
@@ -1766,6 +1948,7 @@ sam_mandell:
 
 cezary_bartoszuk:
   name: Cezary Bartoszuk
+  email: cezary.bartoszuk@sourcegraph.com
   github: cbart
   pronouns: he/him
   role: Software Engineer, repo-management
@@ -1775,6 +1958,7 @@ cezary_bartoszuk:
 
 louis_jarvis:
   name: Louis Jarvis
+  email: louis.jarvis@sourcegraph.com
   github: loujar
   pronouns: he/him
   role: Implementation Lead
@@ -1784,6 +1968,7 @@ louis_jarvis:
 
 julie_tibshirani:
   name: Julie Tibshirani
+  email: julie.tibshirani@sourcegraph.com
   github: jtibshirani
   pronouns: she/her
   role: Software Engineer
@@ -1794,6 +1979,7 @@ julie_tibshirani:
 
 peter_guy:
   name: Peter Guy
+  email: peter.guy@sourcegraph.com
   github: peterguy
   pronouns: he/him
   role: Software Engineer, repo-management
@@ -1804,6 +1990,7 @@ peter_guy:
 
 kevin_matthews:
   name: Kevin Matthews
+  email: kevin.matthews@sourcegraph.com
   github: CSMonkee
   pronouns: he/him
   role: Enterprise Technical Advisor
@@ -1814,6 +2001,7 @@ kevin_matthews:
 
 enrique_gonzalez:
   name: Enrique Gonzalez
+  email: enrique@sourcegraph.com
   github: enriquegh
   pronouns: he/him
   role: Senior Manager, Customer Support
@@ -1825,6 +2013,7 @@ enrique_gonzalez:
 
 James_Ghaedi:
   name: James Ghaedi
+  email: james.ghaedi@sourcegraph.com
   role: Account Executive, EMEA
   reports_to: regional_director_sales_emea
 
@@ -1849,6 +2038,7 @@ Jamie_Oconnell:
 
 Ryan_Aznar:
   name: Ryan Aznar
+  email: ryan.aznar@sourcegraph.com
   github: raznar
   pronouns: he/him/they
   role: Enterprise Technical Advisor
@@ -1859,6 +2049,7 @@ Ryan_Aznar:
 
 lauren_ross:
   name: Lauren Ross
+  email: lauren.ross@sourcegraph.com
   github: lauren-ross
   pronouns: she/her
   role: Senior People Partner
@@ -1869,6 +2060,7 @@ lauren_ross:
 
 Marc_LeBlanc:
   name: Marc LeBlanc
+  email: marc.leblanc@sourcegraph.com
   github: marcleblanc2
   pronouns: he/him
   role: Senior Support Engineer
@@ -1879,6 +2071,7 @@ Marc_LeBlanc:
 
 dominic_cooney:
   name: Dominic Cooney
+  email: dominic.cooney@sourcegraph.com
   github: dominiccooney
   reports_to: engineering_manager_code_intelligence
   location: Tokyo, Japan 🇯🇵
@@ -1889,6 +2082,7 @@ dominic_cooney:
 
 john_wesonga:
   name: John Wesonga
+  email: john.wesonga@sourcegraph.com
   github: johnwesonga
   reports_to: eng_lead
   location: Concord, CA, USA 🇺🇸
@@ -1898,6 +2092,7 @@ john_wesonga:
 
 erika_rice_scherpelz:
   name: Erika Rice Scherpelz
+  email: erikars@sourcegraph.com
   github: erikars
   pronouns: she/her
   role: Head of Search
@@ -1909,6 +2104,7 @@ erika_rice_scherpelz:
 
 nikki_golding:
   name: Nikki Golding
+  email: Nikki.Golding@sourcegraph.com
   github: NikkiGolding
   pronouns: she/her
   role: Regional Director, Customer Engineering
@@ -1920,6 +2116,7 @@ nikki_golding:
 
 auguste_rame:
   name: Auguste Rame
+  email: auguste.rame@sourcegraph.com
   github: SuperAuguste
   pronouns: he/him
   role: Software Engineering Intern, Code Intelligence
@@ -1930,6 +2127,7 @@ auguste_rame:
 
 anton_sviridov:
   name: Anton Sviridov
+  email: anton.sviridov@sourcegraph.com
   github: keynmol
   pronouns: he/him
   role: Software Engineering, Code Intelligence

--- a/src/lib/generatedMarkdown.js
+++ b/src/lib/generatedMarkdown.js
@@ -201,9 +201,6 @@ export async function generateTeamMembersList() {
     if (teamMember.description) {
       pageContent += `${String(teamMember.description)}\n`
     }
-    if (teamMember.email) {
-      pageContent += `- Email: [${String(teamMember.email)}](mailto:${String(teamMember.email)})\n`
-    }
     if (teamMember.github) {
       pageContent += `- GitHub: [${String(teamMember.github)}](https://github.com/${String(teamMember.github)})\n`
     }


### PR DESCRIPTION
Restore team emails in data/team.yml as we rely on it to determine slack ids when we post a build failre notification. This is temporary until we find an alternative