### PR TITLE
Update Security notification wording

### DIFF
--- a/content/departments/security/vulnerability-management-process.md
+++ b/content/departments/security/vulnerability-management-process.md
@@ -186,7 +186,7 @@ The SLA for remediation depends on the severity:
 
 ## 5. Disclosure
 
-Once vulnerabilities are patched it is our responsibility to properly disclose them to our users and customers. We disclose vulnerabilities through GitHub security advisories, the CHANGELOG and the Security Notifications mailing list.
+Once vulnerabilities are patched it is our responsibility to properly disclose them to our users and customers. We disclose vulnerabilities through GitHub security advisories, the CHANGELOG and (optionally) the Security Notifications mailing list.
 
 ### Publishing GitHub Security advisories
 
@@ -211,7 +211,7 @@ Write a short entry in the CHANGELOG such as `Patched low risk information discl
 
 ### Notifying the Security Notifications mailing list
 
-When a new security update is published on GitHub, a notification email should be sent out to our [Subscription- Sourcegraph Security Notifications list](https://app.hubspot.com/contacts/2762526/lists/1091?query=subscription). To send new emails to the mailing list:
+When a new security update is published on GitHub we have the option of sending out a notification email to our [Subscription- Sourcegraph Security Notifications list](https://app.hubspot.com/contacts/2762526/lists/1091?query=subscription). This is not an onbligation and should be reserved for high-impact vulnerabilities. To send new emails to the mailing list:
 
 1. Log into [Hubspot](https://app.hubspot.com/reports-dashboard/2762526/view/276356), head over to the Marketing tab and select `Email` from the dropdown.
 2. Once on the [Email section of Hubspot](https://app.hubspot.com/email/2762526/manage/state/all?search=security), search for “security” and it should pull up a previously sent security update.


### PR DESCRIPTION
Based on a recent convo with the team we prefer to make the Security mailing list emails optional.