### PR TITLE
add basic troubleshooting doc for okta verify

### DIFF
--- a/content/departments/tech-ops/tools/Okta/main.md
+++ b/content/departments/tech-ops/tools/Okta/main.md
@@ -201,6 +201,8 @@ If you are having problems with being asked for multiple MFA authentications dur
 
 For Okta help, setup, and integration questions: #ask-it-tech-ops Slack channel or <techops@sourcegraph.com>
 
+You can also try following the steps in the [Okta Verify Troubleshooting document](okta-verify-troubleshooting-steps.md) if Okta Verify isn't working properly.
+
 ## I have setup my MFA in AWS but I am still getting errors on aws cli
 
 Please follow these instructions: [AWS CLI MFA setup](../../../security/knowledge-base/AWS-CLI-MFA.md)

--- a/content/departments/tech-ops/tools/Okta/okta-verify-troubleshooting-steps.md
+++ b/content/departments/tech-ops/tools/Okta/okta-verify-troubleshooting-steps.md
@@ -1,0 +1,41 @@
+# Troubleshooting Issues with Okta Verify
+
+Sometimes you may encounter issues when using Okta Verify. This short guide will help you troubleshoot and resolve common problems. 
+
+## Check Device Health in Okta Verify Settings
+
+A quick way to identify the issue might be to check the health of the device in the Okta Verify settings.
+
+1. Right-click the Okta Verify icon in your taskbar.
+2. Click 'Settings'.
+3. In the settings menu, click 'Device Health'.
+4. Observe any indications of issues. If a recommendation is provided, follow the given steps to resolve the problem.
+
+## Restart the Browser
+
+Often, issues can be resolved by simply restarting your browser. This can clear out any temporary data or cached files that might be causing problems.
+
+1. Close all the tabs you have open.
+2. Completely exit the browser.
+3. Reopen the browser and try accessing Okta Verify again.
+
+## Device Updates
+
+Sometimes, problems with Okta Verify can be due to the device itself not being up-to-date.
+
+1. Check for any system updates for your device.
+2. If an update is available, install it.
+3. Once the update is complete, try accessing Okta Verify again.
+
+## Reboot the Machine
+
+If none of the previous steps helped, try rebooting your machine. This can solve a host of issues by clearing temporary files and freeing up system resources.
+
+1. Save any open files and close all programs.
+2. Restart your device.
+3. Once your device has rebooted, try accessing Okta Verify again.
+
+---
+
+If you're still encountering issues with Okta Verify after trying all of these steps, consider reaching out to Tech Ops support.
+

--- a/content/departments/tech-ops/tools/Okta/okta-verify-troubleshooting-steps.md
+++ b/content/departments/tech-ops/tools/Okta/okta-verify-troubleshooting-steps.md
@@ -1,6 +1,6 @@
 # Troubleshooting Issues with Okta Verify
 
-Sometimes you may encounter issues when using Okta Verify. This short guide will help you troubleshoot and resolve common problems. 
+Sometimes you may encounter issues when using Okta Verify. This short guide will help you troubleshoot and resolve common problems.
 
 ## Check Device Health in Okta Verify Settings
 
@@ -38,4 +38,3 @@ If none of the previous steps helped, try rebooting your machine. This can solve
 ---
 
 If you're still encountering issues with Okta Verify after trying all of these steps, consider reaching out to Tech Ops support.
-


### PR DESCRIPTION
This PR adds basic troubleshooting steps for teammates that are having issues with Okta Verify. This document is publicly available in the handbook so it doesn't require a functioning Okta Verify setup to read.