### PR TITLE
Add Wolfi docs to handbook

### DIFF
--- a/content/departments/security/tooling/index.md
+++ b/content/departments/security/tooling/index.md
@@ -9,6 +9,12 @@ If you want to document sensitive information, you can either:
 - Add it to the `docs` folder in the [infrastructure repository](https://github.com/sourcegraph/infrastructure/tree/main/security/docs).
   This option is better for technical documentation.
 
+## Wolfi
+
+- [Overview of Wolfi](./wolfi/index.md)
+- [Wolfi packages](./wolfi/packages.md)
+- [Wolfi base images](./wolfi/images.md)
+
 ## Processes
 
 - [Blocking IPs in Cloudflare](https://docs.google.com/document/d/17FV8pjbJNrhAtW9lvGIbJ1jSkXe0mRw4ci7w0084RBE/edit#heading=h.jpz7uaphhdtk)

--- a/content/departments/security/tooling/wolfi/images.md
+++ b/content/departments/security/tooling/wolfi/images.md
@@ -1,4 +1,4 @@
-# Wolfi base images
+# Wolfi Base Images
 
 When writing a Dockerfile, you typically base your image on an upstream release such as Alpine. Historically, we've used our [alpine-3.14](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/alpine-3.14/Dockerfile) base image for this purpose.
 
@@ -10,9 +10,9 @@ Base images are defined using an apko YAML configuration file, found under [wolf
 
 These configuration files can be processed with apko, which will generate a base image. You can build these locally using [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
 
-## Making Changes
+## How to...
 
-### Updating base image packages
+### Update base image packages
 
 In order to pull in updated packages with new features or fixed vulnerabilities, we need to periodically rebuild the base images.
 
@@ -22,7 +22,7 @@ This is currently a two-step process, but will be automated in the future:
   - This will trigger Buildkite to rebuild the base images and publish them.
 - Currently we use the `latest` label, but we will switch to using a `sha256` tag once deployed in production. Update the relevant Dockerfiles with the new base image's `sha256` hash, commit the change, and merge to main.
 
-### Modifying an existing base image
+### Modify an existing base image
 
 To modify a base image to add packages, users, or directories:
 
@@ -32,7 +32,7 @@ To modify a base image to add packages, users, or directories:
 - Once happy with changes, create a PR and merge to main. Buildkite will detect the changes and rebuild the base image.
 - Currently we use the `latest` label on Wolfi images, but we will switch to using a `sha256` tag once deployed in production. Update the relevant Dockerfiles with the new base image's `sha256` hash, commit the change, and merge to main.
 
-### Creating a new base image
+### Create a new base image
 
 If your new image does not have any dependencies, use the [`sourcegraph`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/sourcegraph.yaml) base image.
 

--- a/content/departments/security/tooling/wolfi/images.md
+++ b/content/departments/security/tooling/wolfi/images.md
@@ -1,0 +1,49 @@
+
+# Wolfi base images
+
+When writing a Dockerfile, you typically base your image on an upstream release such as Alpine. Historically, we've used our [alpine-3.14](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/alpine-3.14/Dockerfile) base image for this purpose.
+
+Wolfi base images are built *from scratch* using [apko](https://github.com/chainguard-dev/apko/tree/main). This allows the image to be fully customised - for instance, an image doesn't need to include a shell or apk-tools.
+
+## How base images are built
+
+Base images are defined using an apko YAML configuration file, found under [wolfi-images](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/wolfi-images).
+
+These configuration files can be processed with apko, which will generate a base image. You can build these locally using [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+
+## Making Changes
+
+### Updating base image packages
+
+In order to pull in updated packages with new features or fixed vulnerabilities, we need to periodically rebuild the base images.
+
+This is currently a two-step process, but will be automated in the future:
+
+- Run the [`wolfi-images/rebuild-images.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@will/wolfi-docs/-/blob/wolfi-images/rebuild-images.sh?L1) script (with an optional argument to just update one base image), commit the updated YAML files, and merge to main.
+  - This will trigger Buildkite to rebuild the base images and publish them.
+- Currently we use the `latest` label, but we will switch to using a `sha256` tag once deployed in production. Update the relevant Dockerfiles with the new base image's `sha256` hash, commit the change, and merge to main.
+
+### Modifying an existing base image
+
+To modify a base image to add packages, users, or directories:
+
+- Update its apko YAML configuration file, which can be found under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/)
+- Build and testing it locally using [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+  - You can use this local image in your Dockerfiles, or exec into it directly.
+- Once happy with changes, create a PR and merge to main. Buildkite will detect the changes and rebuild the base image.
+- Currently we use the `latest` label on Wolfi images, but we will switch to using a `sha256` tag once deployed in production. Update the relevant Dockerfiles with the new base image's `sha256` hash, commit the change, and merge to main.
+
+### Creating a new base image
+
+If your new image does not have any dependencies, use the [`sourcegraph`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/sourcegraph.yaml) base image.
+
+Otherwise, you can create a new base image configuration file:
+
+- Duplicate [`sourcegraph.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/sourcegraph.yaml) as a starting point.
+- Add any required packages, users, directory structure, or metadata.
+  - See [apko file format](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md) for a full list of supported configuration.
+  - See the other images under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/) and [`chainguard-images/images`](https://github.com/chainguard-images/images/tree/main/images) for examples and best practices.
+- Build your image locally with [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+- Commit your updated YAML file and merge it to main. Buildkite will build and publish your new image.
+
+Once complete, treat the published image it as a standard base image, and use it in your Dockerfile.

--- a/content/departments/security/tooling/wolfi/images.md
+++ b/content/departments/security/tooling/wolfi/images.md
@@ -1,9 +1,8 @@
-
 # Wolfi base images
 
 When writing a Dockerfile, you typically base your image on an upstream release such as Alpine. Historically, we've used our [alpine-3.14](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/alpine-3.14/Dockerfile) base image for this purpose.
 
-Wolfi base images are built *from scratch* using [apko](https://github.com/chainguard-dev/apko/tree/main). This allows the image to be fully customised - for instance, an image doesn't need to include a shell or apk-tools.
+Wolfi base images are built _from scratch_ using [apko](https://github.com/chainguard-dev/apko/tree/main). This allows the image to be fully customised - for instance, an image doesn't need to include a shell or apk-tools.
 
 ## How base images are built
 

--- a/content/departments/security/tooling/wolfi/index.md
+++ b/content/departments/security/tooling/wolfi/index.md
@@ -1,0 +1,40 @@
+# Wolfi
+
+Sourcegraph is in the process of migrating from Alpine-based Docker images to Wolfi-based images. This page covers the migration, and highlight changes to our images build process.
+
+For information on how to build packages and base images, see the Handbook.
+
+## What is Wolfi?
+
+[Wolfi](https://github.com/wolfi-dev) is a stripped-down open Linux distro designed for cloud-native containers. It has several key features that make it a good fit for distributing Sourcegraph:
+
+* A distroless build system that lets us build containers with only the precise dependencies we need, reducing attack surface area and the number of components that need to be kept patched.
+* A package repository that receives fast security patches and splits larger dependencies into smaller packages, keeping our images minimal and secure.
+* High quality build-time SBOM (software bill of materials) support, allowing us to be transparent about our image composition.
+
+## Why have we adopted Wolfi?
+
+Adopting Wolfi helps significantly reduce the number of unpatched vulnerabilities in our container images, and move faster to patch them when new issues our found.
+
+For full details, see [RFC 768: Harden container images by switching from Alpine to Wolfi](https://docs.google.com/document/d/1yQsXU7ekqPGjdkKItXKxROVNcJAYiGg3ZA70zJcLzIQ/edit#).
+
+## How is the build process different from Alpine to Wolfi?
+
+In our Alpine images, most of the work is done in the Dockerfile: packages are installed; third-party dependencies are fetched, built, and installed; users and directories are created; and binaries are copied.
+
+When building Wolfi images, most of this work is done **outside** of the Dockerfile:
+
+- All third-party dependencies are [packaged](packages.md) as APKs (Alpine Packages, a format that Wolfi uses).
+- Dependencies, user accounts, directory structure, and permissions are combined into a pre-built [base image](images.md).
+- The Dockerfile then only copies over Sourcegraph Go binaries, any configuration, and sets the entrypoint.
+
+In short, all dependencies are pre-installed in a Wolfi base image. The Dockerfile is the final step that just adds on the Sourcegraph code.
+
+## What are base images?
+
+Rather than using a customised upstream image like our [alpine-3.14](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/alpine-3.14/Dockerfile) base image, Wolfi base images are built from scratch using a [configuration file](https://github.com/sourcegraph/sourcegraph/tree/main/wolfi-images). This allows the image to be fully customised - for instance, an image doesn't need to include a shell or apk-tools.
+
+## More Information
+
+- [Wolfi packages](packages.md) details how we package dependencies and manage our package repository.
+- [Wolfi base images](images.md) details how we configure and build each base image.

--- a/content/departments/security/tooling/wolfi/index.md
+++ b/content/departments/security/tooling/wolfi/index.md
@@ -8,9 +8,9 @@ For information on how to build packages and base images, see the Handbook.
 
 [Wolfi](https://github.com/wolfi-dev) is a stripped-down open Linux distro designed for cloud-native containers. It has several key features that make it a good fit for distributing Sourcegraph:
 
-* A distroless build system that lets us build containers with only the precise dependencies we need, reducing attack surface area and the number of components that need to be kept patched.
-* A package repository that receives fast security patches and splits larger dependencies into smaller packages, keeping our images minimal and secure.
-* High quality build-time SBOM (software bill of materials) support, allowing us to be transparent about our image composition.
+- A distroless build system that lets us build containers with only the precise dependencies we need, reducing attack surface area and the number of components that need to be kept patched.
+- A package repository that receives fast security patches and splits larger dependencies into smaller packages, keeping our images minimal and secure.
+- High quality build-time SBOM (software bill of materials) support, allowing us to be transparent about our image composition.
 
 ## Why have we adopted Wolfi?
 

--- a/content/departments/security/tooling/wolfi/index.md
+++ b/content/departments/security/tooling/wolfi/index.md
@@ -2,7 +2,7 @@
 
 Sourcegraph is in the process of migrating from Alpine-based Docker images to Wolfi-based images. This page covers the migration, and highlight changes to our images build process.
 
-For information on how to build packages and base images, see the Handbook.
+For information on how to build and update packages and base images, see [More Information](#more-information).
 
 ## What is Wolfi?
 

--- a/content/departments/security/tooling/wolfi/packages.md
+++ b/content/departments/security/tooling/wolfi/packages.md
@@ -1,0 +1,84 @@
+# Wolfi Packages
+
+## What are packages, and why do we use them?
+
+Linux packages are bundles of software and related files that are designed to be easily installed and managed.
+
+As well as using common packages from the Wolfi repository, we package all our third-party dependencies. This makes it easier to add and modify dependencies, reduces build times, and increases security. This page focuses on how we package these third-party dependencies.
+
+For full details on why we package third-party dependencies, see [RFC 769: Package container build dependencies as Alpine packages](https://docs.google.com/document/d/1VFxBECDErU5bR5uPDsiYREC_qfHDEDyOSaDTaH83nZU/edit#).
+
+## Finding and building packages
+
+Sourcegraph's container images use Wolfi, and the [Wolfi package repository](https://github.com/wolfi-dev/os) contains most common packages. If you need to add a new dependency to an image, you can search this repository by using `apk search`.
+
+If we require a less common dependency such as `ctags` or `p4-fusion`, we also build our own packages. All third-party dependencies should be packaged, rather than fetching and building dependencies in Dockerfiles. This reduces build times, helps protect against supply-chain attacks, and prevents build failures caused by download timeouts or URL changes.
+
+Dependencies are packaged using [Melange](https://github.com/chainguard-dev/melange), using a declarative YAML file. Melange follows a sequence of build instructions (known as "pipelines"), and runs in a sandbox to ensure isolation.
+
+All Sourcegraph package configs are stored in [sourcegraph.git/wolfi-packages](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/wolfi-packages).
+
+## How dependencies are packaged
+
+Dependencies are typically packaged in one of two ways:
+* Binary releases: download a precompiled binary of the dependency at a specific version, check its SHA checksum, and then move it to the final directory path. See the [p4cli package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@760db946dd9c3b23af69f2036b7a8c11e38307b4/-/blob/wolfi-packages/p4cli.yaml?L20-29) for an example.
+* Source releases: download the source code of the dependency at a specific version, check its SHA checksum, build the binary, then move it to the final directory. See the [syntect-server](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/syntect-server.yaml?L29-45) package for an example.
+
+## Updating an existing packaged dependency
+
+It's common to need to update a package to the most recent release in order to pull in new features or security patches.
+
+1. Find the relevant package manifest YAML file in [sourcegraph.git/wolfi-packages](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/wolfi-packages).
+
+2. Update the [`package.version`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L3) field to the latest version. This is usually substituted in a URL within the pipeline's [`fetch` step](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L30) as `${{package.version}}`. You will also need to update the [`expected-sha256`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L31), which can be found by downloading the release and running `sha256sum <file_name>`.
+
+  *  Depending on the package, this step may download a binary or source code. Projects release code in different ways, so the pipeline may check out a Git repository on a specific branch or download a `.tar.gz` file containing source code.
+
+3. Try building the package locally with the [`local-build.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh) script. If successful, it will generate an `.apk` file under `wolfi-packages/packages/x86_64/`.
+
+4. Push your branch and create a PR. Buildkite will build the new version of the package, which you can [test](#testing-packages). Once merged to `main`, it will be added to the [Sourcegraph package repository](#sourcegraph-package-repository).
+
+## Creating a new package
+
+Creating a new package should be an infrequent activity. Search the Wolfi package repository first, and if you're looking to build a common package then consider asking Chainguard to add it to the Wolfi repository. Feel free to reach out to #ask-security for assistance.
+
+
+
+When creating a new package, the rough workflow is:
+
+- Determine how the dependency will be fetched and built.
+  - If a binary release is available, this is often the simplest way.
+  - If only source releases are available, you'll need to download the source of a versioned release and build it.
+  - Projects typically include a Makefile, or building instructions in their README or INSTALL.
+- Add metadata such as the package name, version, and license.
+- Iterate by [building](#building-packages) the package locally using [`local-build.sh <your-package.yaml>`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh)
+- [Test your new package](#testing-packages)
+- Once confident the package works as expected, create a PR and merge to `main` to add it to the Sourcegraph package repository.
+
+## Packaging Tips
+
+### Building packages
+
+- The [wolfi-packages/](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/tree/wolfi-packages) directory and [Wolfi OS](https://github.com/wolfi-dev/os) repository are full of examples to base your package on.
+- Read through the [Melange documentation](https://edu.chainguard.dev/open-source/melange/overview/).
+- The [Melange documentation](https://edu.chainguard.dev/open-source/melange/melange-pipelines/) contains a list of available pipeline steps, which are common building blocks for building packages.
+  - It can also be useful to refer to the [code that these pipelines run](https://github.com/chainguard-dev/melange/tree/main/pkg/build/pipelines).
+- Spin up a dev Wolfi image with and run the build steps manually in there. This is useful for debugging, or for speeding up iteration on slow-building dependencies.
+  - `docker run -it --entrypoint /bin/sh  us.gcr.io/sourcegraph-dev/wolfi-sourcegraph-dev-base:latest`
+
+### Testing packages
+
+- `.apk` files are just `.tar.gz` files, so can be extracted with `tar zxvf package.apk`. This is useful for checking their contents.
+  - When building locally with [`local-build.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh), packages are built under `wolfi-packages/packages/x86_64/`.
+- Always try installing the package in a container, as this ensures that all runtime dependencies can be satisfied.
+
+## Sourcegraph package repository
+
+We maintain our own package repository for custom dependencies that aren't in the Wolfi repository.
+
+This is implemented as a GCP bucket. Buildkite is used to build and upload packages, as well as to [build and sign](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/scripts/wolfi/build-repo-index.sh) the repository index.
+
+Currently, all packages are uploaded directly to the main Sourcegraph package repo. To provide an isolated development environment, in the future we plan to separate our dev and production repos:
+
+- The `main/` directory only contains packages built from the main branch.
+- Each branch which updates package manifests will have its own `branch-name` repository.

--- a/content/departments/security/tooling/wolfi/packages.md
+++ b/content/departments/security/tooling/wolfi/packages.md
@@ -6,13 +6,13 @@ Linux packages are bundles of software and related files that are designed to be
 
 As well as using common packages from the Wolfi repository, we package all our third-party dependencies. This makes it easier to add and modify dependencies, reduces build times, and increases security. This page focuses on how we package these third-party dependencies.
 
-For full details on why we package third-party dependencies, see [RFC 769: Package container build dependencies as Alpine packages](https://docs.google.com/document/d/1VFxBECDErU5bR5uPDsiYREC_qfHDEDyOSaDTaH83nZU/edit#).
+For full details on why we use packages, see [RFC 769: Package container build dependencies as Alpine packages](https://docs.google.com/document/d/1VFxBECDErU5bR5uPDsiYREC_qfHDEDyOSaDTaH83nZU/edit#).
 
 ## Finding and building packages
 
-Sourcegraph's container images use Wolfi, and the [Wolfi package repository](https://github.com/wolfi-dev/os) contains most common packages. If you need to add a new dependency to an image, you can search this repository by using `apk search`.
+Sourcegraph's container images use Wolfi, and the [Wolfi package repository](https://github.com/wolfi-dev/os) contains many common packages. If you need to add a new dependency to an image, you can search this repository by using `apk search`.
 
-If we require a less common dependency such as `ctags` or `p4-fusion`, we also build our own packages. All third-party dependencies should be packaged, rather than fetching and building dependencies in Dockerfiles. This reduces build times, helps protect against supply-chain attacks, and prevents build failures caused by download timeouts or URL changes.
+If we require a less common dependency such as `ctags` or `p4-fusion`, we can also build our own packages. All third-party dependencies should be packaged, rather than fetching and building dependencies in Dockerfiles.
 
 Dependencies are packaged using [Melange](https://github.com/chainguard-dev/melange), using a declarative YAML file. Melange follows a sequence of build instructions (known as "pipelines"), and runs in a sandbox to ensure isolation.
 
@@ -25,7 +25,9 @@ Dependencies are typically packaged in one of two ways:
 - Binary releases: download a precompiled binary of the dependency at a specific version, check its SHA checksum, and then move it to the final directory path. See the [p4cli package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@760db946dd9c3b23af69f2036b7a8c11e38307b4/-/blob/wolfi-packages/p4cli.yaml?L20-29) for an example.
 - Source releases: download the source code of the dependency at a specific version, check its SHA checksum, build the binary, then move it to the final directory. See the [syntect-server](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/syntect-server.yaml?L29-45) package for an example.
 
-## Updating an existing packaged dependency
+## How to...
+
+### Update an existing packaged dependency
 
 It's common to need to update a package to the most recent release in order to pull in new features or security patches.
 
@@ -39,7 +41,7 @@ It's common to need to update a package to the most recent release in order to p
 
 4. Push your branch and create a PR. Buildkite will build the new version of the package, which you can [test](#testing-packages). Once merged to `main`, it will be added to the [Sourcegraph package repository](#sourcegraph-package-repository).
 
-## Creating a new package
+### Create a new package
 
 Creating a new package should be an infrequent activity. Search the Wolfi package repository first, and if you're looking to build a common package then consider asking Chainguard to add it to the Wolfi repository. Feel free to reach out to #ask-security for assistance.
 

--- a/content/departments/security/tooling/wolfi/packages.md
+++ b/content/departments/security/tooling/wolfi/packages.md
@@ -21,8 +21,9 @@ All Sourcegraph package configs are stored in [sourcegraph.git/wolfi-packages](h
 ## How dependencies are packaged
 
 Dependencies are typically packaged in one of two ways:
-* Binary releases: download a precompiled binary of the dependency at a specific version, check its SHA checksum, and then move it to the final directory path. See the [p4cli package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@760db946dd9c3b23af69f2036b7a8c11e38307b4/-/blob/wolfi-packages/p4cli.yaml?L20-29) for an example.
-* Source releases: download the source code of the dependency at a specific version, check its SHA checksum, build the binary, then move it to the final directory. See the [syntect-server](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/syntect-server.yaml?L29-45) package for an example.
+
+- Binary releases: download a precompiled binary of the dependency at a specific version, check its SHA checksum, and then move it to the final directory path. See the [p4cli package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@760db946dd9c3b23af69f2036b7a8c11e38307b4/-/blob/wolfi-packages/p4cli.yaml?L20-29) for an example.
+- Source releases: download the source code of the dependency at a specific version, check its SHA checksum, build the binary, then move it to the final directory. See the [syntect-server](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/syntect-server.yaml?L29-45) package for an example.
 
 ## Updating an existing packaged dependency
 
@@ -32,7 +33,7 @@ It's common to need to update a package to the most recent release in order to p
 
 2. Update the [`package.version`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L3) field to the latest version. This is usually substituted in a URL within the pipeline's [`fetch` step](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L30) as `${{package.version}}`. You will also need to update the [`expected-sha256`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@321e0e9d01fa23b83bef57c1e69076866094af20/-/blob/wolfi-packages/comby.yaml?L31), which can be found by downloading the release and running `sha256sum <file_name>`.
 
-  *  Depending on the package, this step may download a binary or source code. Projects release code in different ways, so the pipeline may check out a Git repository on a specific branch or download a `.tar.gz` file containing source code.
+- Depending on the package, this step may download a binary or source code. Projects release code in different ways, so the pipeline may check out a Git repository on a specific branch or download a `.tar.gz` file containing source code.
 
 3. Try building the package locally with the [`local-build.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh) script. If successful, it will generate an `.apk` file under `wolfi-packages/packages/x86_64/`.
 
@@ -41,8 +42,6 @@ It's common to need to update a package to the most recent release in order to p
 ## Creating a new package
 
 Creating a new package should be an infrequent activity. Search the Wolfi package repository first, and if you're looking to build a common package then consider asking Chainguard to add it to the Wolfi repository. Feel free to reach out to #ask-security for assistance.
-
-
 
 When creating a new package, the rough workflow is:
 


### PR DESCRIPTION
Add docs covering wolfi background info, base images, and packages to the handbook.

Up for debate: should some of this (or all of it?) be on docs.sourcegraph.com instead?