### PR TITLE
Team name change

### DIFF
--- a/content/departments/engineering/index.md
+++ b/content/departments/engineering/index.md
@@ -55,7 +55,7 @@ The following functional teams work across the above dev teams:
 
 ## Slack channels
 
-- #engineering
+- #team-engineering
 - #eng-announce
 - #eng-leads
 - #ask-engineering


### PR DESCRIPTION
* Change from #engineering -> #team-engineering to match channel name.