### PR TITLE
cloud: update instructions for determining Project ID

### DIFF
--- a/content/departments/cloud/index.md
+++ b/content/departments/cloud/index.md
@@ -353,19 +353,4 @@ More context [here](https://docs.google.com/document/d/14S3jn0bV03WdeT1H36omvtGJ
 - **Public Code Host** is the code host that is publicly accessible on internet - a user can CURL it via IP or open the URL in the browser. This also includes a code host with a public interface but restricts access to IP allowlist. The Sourcegraph instance can access this code host without using VPC Peering, VPN or other methods. Of course, accessing this code host is protected by authentication and authorization mechanisms
 
 ### FAQ: How do I figure out the GCP Project ID for a customer?
-
-The best way to determine the project ID for a given customer is to look up the customer in the `deploy-sourcegraph-managed` repo using the following query on S2:
-
-```
-repo:^github\.com/sourcegraph/deploy-sourcegraph-managed$ file:config\.yaml lang:yaml customer: :[_\n]
-```
-
-The `customer` field should allow you identify the correct GCP project. If it's still unclear, a Cloud team member can help on Slack in the [#cloud](https://sourcegraph.slack.com/archives/C03JR7S7KRP) channel.
-
-Alternatively, users with `gcloud` access can run:
-
-```
-gcloud projects list --filter='labels.mi-security=true' --format="json(projectId,labels)"
-```
-
-and search the results for the customer name. The `domain` field should include the customer's domain name allowing the project ID to be identified.
+To identify the Project ID for a given customer, refer to the table found at http://go/cloud-ops.

--- a/content/departments/cloud/index.md
+++ b/content/departments/cloud/index.md
@@ -353,4 +353,5 @@ More context [here](https://docs.google.com/document/d/14S3jn0bV03WdeT1H36omvtGJ
 - **Public Code Host** is the code host that is publicly accessible on internet - a user can CURL it via IP or open the URL in the browser. This also includes a code host with a public interface but restricts access to IP allowlist. The Sourcegraph instance can access this code host without using VPC Peering, VPN or other methods. Of course, accessing this code host is protected by authentication and authorization mechanisms
 
 ### FAQ: How do I figure out the GCP Project ID for a customer?
+
 To identify the Project ID for a given customer, refer to the table found at http://go/cloud-ops.


### PR DESCRIPTION
These instructions were out of date and referred to MI 1.1. The process is different (and easier!) now in v2.