### PR TITLE
Fix slack link to release-guild channel

### DIFF
--- a/content/departments/engineering/dev/process/releases/index.md
+++ b/content/departments/engineering/dev/process/releases/index.md
@@ -76,7 +76,7 @@ security incident or other critical issue affecting the usage of Sourcegraph.
 #### Requesting a patch
 
 1. To request a patch release, please fill out a [patch release request](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution%2Cpatch-release-request&template=request_patch_release.md&title=).
-2. Notify the release guild (#release-guild)
+2. Notify the release guild (#ask-release-guild)
 
 ## Key concepts and components
 

--- a/content/departments/engineering/guilds/release_guild.md
+++ b/content/departments/engineering/guilds/release_guild.md
@@ -3,7 +3,7 @@
 The release guild is a collection of teammates that serve as [release captain](../dev/process/releases/index.md#release-captain) for Sourcegraph releases. The guild
 was formed to establish a cross-team working group of engineers that own the release process.
 
-The release guild can be found in the slack channel #release-guild.
+The release guild can be found in the slack channel #ask-release-guild.
 
 {{generator:guild_roster.release_guild}}
 


### PR DESCRIPTION
Update to reflect Slack convention changes from a few months ago.