### PR TITLE
Add placeholder accepted CVEs for 5.1.2 release

### DIFF
--- a/content/departments/security/tooling/trivy/5-1-2.md
+++ b/content/departments/security/tooling/trivy/5-1-2.md
@@ -1,0 +1,17 @@
+# Accepted CVEs for Sourcegraph 5.1.2
+
+| CVE ID | Affected Images | CVE Severity | CVSS Base Score | [Sourcegraph Assessment](../../../engineering/dev/policies/vulnerability-management-policy.md#severity-levels) | CVSS Environmental Score | Details |
+| ------ | --------------- | ------------ | --------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------ | ------- |
+|        |                 |              |                 |                                                                                                                |                          |         |
+
+**No known CVEs in Sourcegraph 5.1.2**
+
+## Known False Positives
+
+Some scanners incorrectly identify false positives in our images:
+
+| Vulnerability ID                                                                                                                                                                                                                                                           | Affected Images                                                      | Note                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [CVE-2023-27561](https://www.cve.org/CVERecord?id=CVE-2023-27561)                                                                                                                                                                                                          | sourcegraph/cadvisor                                                 | False positive - this is patched in `github.com/opencontainers/runc/libcontainer@v1.1.5` |
+| [CVE-2022-0543](https://www.cve.org/CVERecord?id=CVE-2022-0543), [CVE-2022-3734](https://www.cve.org/CVERecord?id=CVE-2022-3734)                                                                                                                                           | sourcegraph/redis-cache, sourcegraph/redis-store, sourcegraph/server | False positive - these vulnerabilities are specific to Windows and Debian releases       |
+| [CVE-2022-31107](https://www.cve.org/CVERecord?id=CVE-2022-31107), [CVE-2022-31123](https://www.cve.org/CVERecord?id=CVE-2022-31123), [CVE-2022-31130](https://www.cve.org/CVERecord?id=CVE-2022-31130), [CVE-2022-39201](https://www.cve.org/CVERecord?id=CVE-2022-39201) | sourcegraph/grafana, sourcegraph/server                              | False positive - these vulnerabilities have been patched by Chainguard                   |

--- a/content/departments/security/tooling/trivy/index.md
+++ b/content/departments/security/tooling/trivy/index.md
@@ -118,6 +118,7 @@ or that we have accepted as low risk. You can find more details about these belo
 
 ### 5.1
 
+- [5.1.2](./5-1-2.md)
 - [5.1.1](./5-1-1.md)
 - [5.1.0](./5-1-0.md)
 


### PR DESCRIPTION
TODO:
- [x] trivy-diff scan against release candidate
- [x] snyk scan on pre-release-candidate (`:792a406cb5b1_2023-06-30`) - 0 vulns