### PR TITLE
Add missing info about Go installation

### DIFF
--- a/content/departments/engineering/dev/process/product_documentation.md
+++ b/content/departments/engineering/dev/process/product_documentation.md
@@ -27,6 +27,8 @@ cd sourcegraph
 ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080
 ```
 
+Make sure that `Go` is installed locally. You can follow the steps [here →](https://go.dev/doc/install)
+
 Navigate the browser to [https://localhost:5080](https://localhost:5080) to view the documentation.
 
 ## Best practices


### PR DESCRIPTION
The installation of Go is a missing pre-requisite step in our docs contributing guide. This PR adds this missing info.