### PR TITLE
Update source support rotation

### DIFF
--- a/content/departments/engineering/teams/source/index.md
+++ b/content/departments/engineering/teams/source/index.md
@@ -17,3 +17,27 @@ We provide value to Sourcegraph by ensuring Sourcegraph can reliably index code 
 ## Contact
 
 - #ask-source channel or @source-support in Slack.
+
+## Emergency Contact
+
+We run an internal support rotation (see [Support Rotation in Team Source](support_rotation.md)]).
+
+You can page the person on support (and possibly wake them up in the middle of the night).
+
+But here are the rules:
+
+- If the issue is caused by an upgrade, the guidance is to downgrade first. (Cloud handled by Cloud team, self-hosted handled by CS, Delivery, and customer)
+- If the issue is caused by new setup with existing customer, wait until next business day.
+- If the issue is caused by new setup with prospect, wait until next business day.
+
+If you still think it's an emergency and the rules above won't be broken by contacting the person on support rotation:
+
+In Slack, use:
+
+```
+/genie alert "your emergency message" for source-support
+```
+
+## Internal Processes
+
+- [Support rotation](support_rotation.md)

--- a/content/departments/engineering/teams/source/support_rotation.md
+++ b/content/departments/engineering/teams/source/support_rotation.md
@@ -1,0 +1,29 @@
+# Support Rotation in Team Source
+
+In the Source team we run a support rotation.
+
+## What does it mean to be on support?
+
+When you are on support rotation, you are the team's first responder to support requests.
+
+It does *not* mean that you are alone and should fix every issue completely and by yourself. It means that you triage incoming issues, take a first stab at them and, if necessary, call the rest of the team for help, or escalate the issue further.
+
+Here are the expectations when you are on support rotation:
+
+1. Triaging and resolving support requests is your #1 priority for the week. You can plan to do other work, but if a support request comes in or needs work, then that's the #1 priority.
+1. Monitor #discuss-source and #ask-engineering for Source-related questions and bug reports.
+1. Acknowledge bug reports and questions. Even a simple "I'm on it, taking a look" in the Slack thread is good, since it lets others on the team know that you are working on it.
+1. Provide the next engineering on support with the status of all in-flight issues before their rotation begins: prepare to report status of support in sprint planning.
+1. Ask for help when you are stuck! Don't spend too much time trying to troubleshoot an issue alone and you get stuck, especially if it's high priority. Do your best, ask the team, and resolve the issue.
+1. If you have too many support requests, ask in #team-source for help or tag the EM.
+1. After resolving an issue, possibly do one of the following things:
+  - Create a ticket if there is follow-up work to be done that is not urgent.
+  - Extend the documentation if that would've prevented the issue.
+  - Create a backlog issue for an improvement, feature, tool, etc. that would have been useful to troubleshoot and solve the problem and find an owner for the issue.
+
+## Rotation
+
+- We switch support rotation every week.
+- Every engineer will be on rotation at some point.
+- We manage the rotation in the [source team in OpsGenie](https://sourcegraph.app.opsgenie.com/teams/dashboard/2dfa5270-6a5f-49f5-bc1a-abb6e20f9676/main).
+- This [configuration](https://github.com/sourcegraph/background-jobs/blob/6980e3fe98808ef27aaa771298384f7ad4b14d8c/slackgenie/config.yaml#L14-L15) ensures that the `@source-support` group in Slack gets updated to the person currently on support in OpsGenie.

--- a/content/departments/engineering/teams/source/support_rotation.md
+++ b/content/departments/engineering/teams/source/support_rotation.md
@@ -6,7 +6,7 @@ In the Source team we run a support rotation.
 
 When you are on support rotation, you are the team's first responder to support requests.
 
-It does *not* mean that you are alone and should fix every issue completely and by yourself. It means that you triage incoming issues, take a first stab at them and, if necessary, call the rest of the team for help, or escalate the issue further.
+It does _not_ mean that you are alone and should fix every issue completely and by yourself. It means that you triage incoming issues, take a first stab at them and, if necessary, call the rest of the team for help, or escalate the issue further.
 
 Here are the expectations when you are on support rotation:
 
@@ -17,9 +17,10 @@ Here are the expectations when you are on support rotation:
 1. Ask for help when you are stuck! Don't spend too much time trying to troubleshoot an issue alone and you get stuck, especially if it's high priority. Do your best, ask the team, and resolve the issue.
 1. If you have too many support requests, ask in #team-source for help or tag the EM.
 1. After resolving an issue, possibly do one of the following things:
-  - Create a ticket if there is follow-up work to be done that is not urgent.
-  - Extend the documentation if that would've prevented the issue.
-  - Create a backlog issue for an improvement, feature, tool, etc. that would have been useful to troubleshoot and solve the problem and find an owner for the issue.
+
+- Create a ticket if there is follow-up work to be done that is not urgent.
+- Extend the documentation if that would've prevented the issue.
+- Create a backlog issue for an improvement, feature, tool, etc. that would have been useful to troubleshoot and solve the problem and find an owner for the issue.
 
 ## Rotation
 


### PR DESCRIPTION
This is based on our 5.1 retrospective. It contains the rules that Ryan proposed and I also added something about support rotation in general. Most of that is from the old repo-management pages, but adjusted.