### PR TITLE
Create page for CLAs (Contributor License Agreements)

### DIFF
--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -12,23 +12,23 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](../licenses/#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
-[sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
-[sourcegraph/zoekt](https://github.com/sourcegraph/zoekt)
-[sourcegraph/conc](https://github.com/sourcegraph/conc)
+* [sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
+* [sourcegraph/zoekt](https://github.com/sourcegraph/zoekt)
+* [sourcegraph/conc](https://github.com/sourcegraph/conc)
 
 ### Which Sourcegraph repositories DO require a CLA?
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](../licenses/#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 
-[sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
+* [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
 
 ### Why do some projects require a CLA and others don’t?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -16,9 +16,9 @@ For permissively licensed projects, contributors do **not** need to sign a CLA g
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
-* [sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
-* [sourcegraph/zoekt](https://github.com/sourcegraph/zoekt)
-* [sourcegraph/conc](https://github.com/sourcegraph/conc)
+- [sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
+- [sourcegraph/zoekt](https://github.com/sourcegraph/zoekt)
+- [sourcegraph/conc](https://github.com/sourcegraph/conc)
 
 ### Which Sourcegraph repositories DO require a CLA?
 
@@ -28,7 +28,7 @@ Read more about copyleft licenses [here](../licenses/#not-allowed-licenses-copyl
 
 ### What repository owned by Sourcegraph requires a CLA?
 
-* [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
+- [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
 
 ### Why do some projects require a CLA and others don’t?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -12,19 +12,19 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](/departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
 [sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
-[sourcegraph/zoekt](https://github.com/sourcegraph/zoekt) \
+[sourcegraph/zoekt](https://github.com/sourcegraph/zoekt)
 [sourcegraph/conc](https://github.com/sourcegraph/conc)
 
 ### Which Sourcegraph repositories DO require a CLA?
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](/departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -12,7 +12,7 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](./licenses#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](licenses#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
@@ -24,7 +24,7 @@ For permissively licensed projects, contributors do **not** need to sign a CLA g
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](./licenses#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](licenses#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -4,10 +4,9 @@ CLA stands for Contributor License Agreement. It is a [legal document](https://s
 
 The primary purposes of a CLA are:
 
-* To ensure the contributor has the right to license their contribution under the project's license. This avoids legal issues if someone contributes code they don't have rights to.
-* Ensure the project has the rights to use, modify, and redistribute the contributed code. 
-* To protect the project from contributors trying to revoke the license or enforce their patents against it. 
-
+- To ensure the contributor has the right to license their contribution under the project's license. This avoids legal issues if someone contributes code they don't have rights to.
+- Ensure the project has the rights to use, modify, and redistribute the contributed code.
+- To protect the project from contributors trying to revoke the license or enforce their patents against it.
 
 ## FAQ
 
@@ -33,7 +32,7 @@ Read more about copyleft licenses [here](https://handbook.sourcegraph.com/depart
 
 ### Why do some projects require a CLA and others don’t?
 
-We decided not to add CLAs to permissive open source projects to onboard contributors faster and show that we are committed to keeping the project open source. 
+We decided not to add CLAs to permissive open source projects to onboard contributors faster and show that we are committed to keeping the project open source.
 
 ### What is the link to the CLA form?
 
@@ -41,6 +40,6 @@ To sign the Sourcegraph CLA, please fill out [this form](https://forms.gle/Ynmet
 
 ### Who has signed the form already?
 
-You can view all contributors that have signed here: [https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot](https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot)  
+You can view all contributors that have signed here: [https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot](https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot)
 
 You can read more about [CLA-bot here](https://docs.sourcegraph.com/dev/contributing/accepting_contribution#cla-bot).

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -1,0 +1,46 @@
+# CLA
+
+CLA stands for Contributor License Agreement. It is a [legal document](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/CLA.txt) that some open source projects require contributors to sign before they can contribute code. \
+
+The primary purposes of a CLA are:
+
+* To ensure the contributor has the right to license their contribution under the project's license. This avoids legal issues if someone contributes code they don't have rights to.
+* Ensure the project has the rights to use, modify, and redistribute the contributed code. 
+* To protect the project from contributors trying to revoke the license or enforce their patents against it. 
+
+
+## FAQ
+
+### Which Sourcegraph repositories DO NOT require a CLA?
+
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](https://handbook.sourcegraph.com/departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
+
+### Examples of Sourcegraph repositories that DO NOT require CLAs:
+
+[sourcegraph/cody](https://sourcegraph.com/github.com/sourcegraph/cody)
+[sourcegraph/zoekt](https://github.com/sourcegraph/zoekt) \
+[sourcegraph/conc](https://github.com/sourcegraph/conc)
+
+### Which Sourcegraph repositories DO require a CLA?
+
+For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
+
+Read more about copyleft licenses [here](https://handbook.sourcegraph.com/departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
+
+### What repository owned by Sourcegraph requires a CLA?
+
+[sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph)
+
+### Why do some projects require a CLA and others don’t?
+
+We decided not to add CLAs to permissive open source projects to onboard contributors faster and show that we are committed to keeping the project open source. 
+
+### What is the link to the CLA form?
+
+To sign the Sourcegraph CLA, please fill out [this form](https://forms.gle/YnmetmopXNxFxsDUA).
+
+### Who has signed the form already?
+
+You can view all contributors that have signed here: [https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot](https://sourcegraph.com/github.com/sourcegraph/clabot-config@main/-/blob/.clabot)  
+
+You can read more about [CLA-bot here](https://docs.sourcegraph.com/dev/contributing/accepting_contribution#cla-bot).

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -12,7 +12,7 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](../licenses/#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](./licenses#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
@@ -24,7 +24,7 @@ For permissively licensed projects, contributors do **not** need to sign a CLA g
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](../licenses/#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](./licenses#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -1,6 +1,6 @@
 # CLA
 
-CLA stands for Contributor License Agreement. It is a [legal document](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/CLA.txt) that some open source projects require contributors to sign before they can contribute code. \
+CLA stands for Contributor License Agreement. It is a [legal document](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/CLA.txt) that some open source projects require contributors to sign before they can contribute code.
 
 The primary purposes of a CLA are:
 
@@ -12,7 +12,7 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](https://handbook.sourcegraph.com/departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](/departments/engineering/dev/process/licenses/#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
@@ -24,7 +24,7 @@ For permissively licensed projects, contributors do **not** need to sign a CLA g
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](https://handbook.sourcegraph.com/departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](/departments/engineering/dev/process/licenses/#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 

--- a/content/departments/engineering/dev/process/contributor-license-agreement.md
+++ b/content/departments/engineering/dev/process/contributor-license-agreement.md
@@ -12,7 +12,7 @@ The primary purposes of a CLA are:
 
 ### Which Sourcegraph repositories DO NOT require a CLA?
 
-For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](licenses#allowed-licenses-permissive-licenses).
+For permissively licensed projects, contributors do **not** need to sign a CLA given that permissive license terms govern the use of such contributions. Read more about permissive licenses [here](licenses.md#allowed-licenses-permissive-licenses).
 
 ### Examples of Sourcegraph repositories that DO NOT require CLAs:
 
@@ -24,7 +24,7 @@ For permissively licensed projects, contributors do **not** need to sign a CLA g
 
 For all (a) proprietary or (b) copyleft-licensed projects, contributors need to sign a CLA. To reduce the burden on contributors, limiting the CLA requirement to only contributions or changes involving 10 or more lines of code is ok.
 
-Read more about copyleft licenses [here](licenses#not-allowed-licenses-copyleft-licenses).
+Read more about copyleft licenses [here](licenses.md#not-allowed-licenses-copyleft-licenses).
 
 ### What repository owned by Sourcegraph requires a CLA?
 

--- a/content/departments/engineering/dev/process/index.md
+++ b/content/departments/engineering/dev/process/index.md
@@ -10,3 +10,4 @@
 - [Tracking issues](tracking_issues.md)
 - [Escalation Engineering Rotation](escalation-engineer-rotation.md)
 - [Pull-Request compliance and requirements](pullrequest-compliance.md)
+- [Contributor License Agreement](contributor-license-agreement.md)


### PR DESCRIPTION
The following PR was a collab with @tammy-zhu. It came up when there was a question about whether `sourcegraph/sg.vim` needed a CLA or not. This handbook page will be the SoT for anything CLA related going forward.