### PR TITLE
Add capitalization rules for product integrations

### DIFF
--- a/content/company-info-and-process/communication/content_guidelines/style_and_mechanics.md
+++ b/content/company-info-and-process/communication/content_guidelines/style_and_mechanics.md
@@ -128,6 +128,8 @@ All-caps should be used sparingly and only for specific purposes (all-caps copy 
 
 Render proper nouns as their creators/trademarks prefer: Docker, Bitbucket, GitLab, GitHub, React, Git, JavaScript, TypeScript.
 
+If it's displayed within another product (e.g. a VS Code extension or Slack App) match the capitalization norms of that product.
+
 ## Contractions
 
 Use contractions like “we’ll” or “there’s!” They make our writing more conversational.


### PR DESCRIPTION
We want to feel like like first-class integrations when we’re adding UI to other people’s products. This adds a note to our capitalization rules to allow and encourage this.