### PR TITLE
Removing hyperlink to training page

### DIFF
--- a/content/company-info-and-process/working-at-sourcegraph/index.md
+++ b/content/company-info-and-process/working-at-sourcegraph/index.md
@@ -5,6 +5,5 @@
 - [Impact reviews](../../departments/people-talent/people-ops/process/teammate-sentiment/impact-reviews/index.md)
 - [Leaving](../../departments/people-talent/people-ops/process/leaving.md)
 - [Teammate development](teammate-development/index.md)
-  - [Training](teammate-development/training/index.md)
 - [Recognition and #thanks Channel best practices](../../benefits-pay-perks/benefits-perks/celebrate.md#regular-thanks-and-recognition-via-our-thanks-channel)
 - [Career Ladders](career-frameworks.md)


### PR DESCRIPTION
This is prior to deleting the outdated training page altogether