### PR TITLE
Make it explicit that SDLC is tied to SOC2

### DIFF
--- a/content/departments/engineering/sdlc.md
+++ b/content/departments/engineering/sdlc.md
@@ -1,5 +1,9 @@
 ## Software Product Lifecycle
 
+<!-- The content of this page relates to SOC2, please ask a review from @doragrgic when making non trivial changes. -->
+
+<span class="badge badge-note">SOC2/IC-98</span>
+
 Each phase of the software product lifecycle has a label we use to communicate
 to our customers a) the quality we're aiming for and b) the support we're able
 to provide. These labels are assigned to major features of our software


### PR DESCRIPTION
Follow-up to https://sourcegraph.slack.com/archives/C0EPTDE9L/p1692717672860469?thread_ts=1692640813.948269&cid=C0EPTDE9L 

On top of the comment, I reused the badges we have in a few places to make it explicit as well. 

<img width="886" alt="CleanShot 2023-08-22 at 17 39 19@2x" src="https://github.com/sourcegraph/handbook/assets/10151/74a3b65d-276e-487c-9cde-4686ba178f5b">
