### PR TITLE
Update amplitude docs on handbook

### DIFF
--- a/content/departments/data-analytics/amplitude.md
+++ b/content/departments/data-analytics/amplitude.md
@@ -33,6 +33,16 @@ Our Amplitude pipeline is connected to our `dotcom_events.events` table. The pip
 
 The entire pipeline runs every hour so it can take up to 1 hour for data to start appearing in Amplitude.
 
+#### Derived Properties
+Within Amplitude we have built some derived properties that make it easier to extract our specific keys from our nested data fields and use them for analysis. Current derived properties include:
+1. charCount
+2. linesOfCode
+3. is_sourcegraph_teammate
+4. feature_flag:enable_simple_search
+5. cody_client_version
+
+If you have any derived properties you would like to create, please reach out to the Data&Analytics Team.
+
 ## Using Amplitude FAQs
 
 ### How do I find what we call an event in the Sourcegraph code?

--- a/content/departments/data-analytics/amplitude.md
+++ b/content/departments/data-analytics/amplitude.md
@@ -1,6 +1,5 @@
 # Amplitude
 
-NOTE: we are currenlty only sending `dotcom_events.events` data to Amplitude and are not supporting our Managed Instance event-level data pipeline to Amplitude. This will change after August 31th, 2023 once we've decided to either continue using Amplitude or another alternative.
 
 ## How do I get started?
 
@@ -8,14 +7,6 @@ NOTE: we are currenlty only sending `dotcom_events.events` data to Amplitude and
 2. Read the [Sourcegraph <> Amplitude FAQs](#faqs), view team-specific spaces below, or reach out in #analytics for help if you have any questions getting started viewing dashboards.
 3. Read the [Amplitude help center](https://help.amplitude.com/hc/en-us) and Amplitude docs for [building analyses](https://help.amplitude.com/hc/en-us/categories/360003165371-Build-and-share-your-analysis) and/or check out some of our [tutorials](https://drive.google.com/drive/folders/1cdcUe2e4bnYjxr9xqV6-pCsOOPIEMqGI). As a reminder, you can always post in #analytics-review if you have a work-in-progress analysis you want someone else's eyes on. to get started building your own charts.
 4. Look at all the [Team Spaces](https://analytics.amplitude.com/sourcegraph/team-spaces) and join whichever ones are relevant to you. Learn more about Team Spaces [here](#what-are-team-spaces).
-
-### Sales/CE
-
-View the [Sales/CE team space](https://analytics.amplitude.com/sourcegraph/space/4e3e79k/all?source=move%20item%20butter%20bar) which contains dashboards such as the [instance overview](https://analytics.amplitude.com/sourcegraph/dashboard/isnxhtb?source=team%20space%20item%20table) to understand event-level managed instance data
-
-### Product/engineering
-
-View the [Product/engineering team space](https://analytics.amplitude.com/sourcegraph/space/4e3e79k/all?source=move%20item%20butter%20bar), and check out some example charts [in this folder](https://analytics.amplitude.com/sourcegraph/space/dn45t5b/all?source=move%20item%20butter%20bar) to get a sense for what you can do with Amplitude.
 
 ## Why are we using Amplitude?
 
@@ -29,27 +20,18 @@ Looker is very flexible in that we can set it up for any purpose we'd like. The 
 
 Anything not based directly on analyzing event-level data is in Looker. This includes [pings from on-prem instances](https://docs.sourcegraph.com/admin/pings), anything we get from the [Cloud Postgres database](https://github.com/sourcegraph/sourcegraph/blob/main/internal/database/schema.md) and any data from third-parties tools (such as Google Analytics and Salesforce).
 
-| Type of analysis                  | Tool      | Example                                                                                     |
-| --------------------------------- | --------- | ------------------------------------------------------------------------------------------- |
-| Retention drivers                 | Amplitude | [Link](https://analytics.amplitude.com/sourcegraph/chart/rqbignv?source=search)             |
-| On-prem instances/pings           | Looker    | [Link](https://sourcegraph.looker.com/dashboards/427?Products%20Purchased=&Account%20name=) |
-| Managed instance event-level data | Amplitude | [Link](https://analytics.amplitude.com/sourcegraph/dashboard/isnxhtb?source=workspace)      |
-
 Any analysis we conducted in Looker before we started using Amplitude we can continue doing in Looker. We'll still maintain existing Looker dashboards and visualizations. Amplitude will help us conduct new and different analyses regarding product analytics.
 
 ## Data
 
 ### Pipeline
 
-1. Events are stored in the [dotcom_events.events_usage](https://console.cloud.google.com/bigquery?project=telligentsourcegraph&_ga=2.7211002.912372869.1639779794-1385560724.1639779794&pli=1&ws=!1m5!1m4!4m3!1stelligentsourcegraph!2sdotcom_events!3sevents_usage)
+Our Amplitude pipeline is connected to our `dotcom_events.events` table. The pipeline works like so:
+1. A scheduled BigQuery [query](https://console.cloud.google.com/bigquery?tc=us:64b02e2a-0000-2155-80f9-001a11446b5e&project=telligentsourcegraph&ws=!1m0) runs hourly to extract the latest rows from `dotcom_events.events` and export the results to a [Google Cloud Storage bucket](https://console.cloud.google.com/storage/browser/amplitude-events-dotcom;tab=objects?forceOnBucketsSortingFiltering=true&project=telligentsourcegraph&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22)))
+2. Amplitude has a GCS connector set up that checks this bucket every hour and loads any new data into Amplitude.
+3. The exported event data is now available in Amplitude for analysis and reporting.
 
-### Adding events to the data usage pipeline
-
-Usage events are filtered by an allowlist for egress which is documented [here](https://docs.sourcegraph.com/dev/background-information/data-usage-pipeline).
-
-### Adding events to Amplitude
-
-WIP
+The entire pipeline runs every hour so it can take up to 1 hour for data to start appearing in Amplitude.
 
 ## Using Amplitude FAQs
 

--- a/content/departments/data-analytics/amplitude.md
+++ b/content/departments/data-analytics/amplitude.md
@@ -1,6 +1,5 @@
 # Amplitude
 
-
 ## How do I get started?
 
 1. Login to [our workspace](https://analytics.amplitude.com/sourcegraph) (named `Sourcegraph`). If you don't have an account, post in #it-tech-ops or request one during login.
@@ -27,7 +26,8 @@ Any analysis we conducted in Looker before we started using Amplitude we can con
 ### Pipeline
 
 Our Amplitude pipeline is connected to our `dotcom_events.events` table. The pipeline works like so:
-1. A scheduled BigQuery [query](https://console.cloud.google.com/bigquery?tc=us:64b02e2a-0000-2155-80f9-001a11446b5e&project=telligentsourcegraph&ws=!1m0) runs hourly to extract the latest rows from `dotcom_events.events` and export the results to a [Google Cloud Storage bucket](https://console.cloud.google.com/storage/browser/amplitude-events-dotcom;tab=objects?forceOnBucketsSortingFiltering=true&project=telligentsourcegraph&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22)))
+
+1. A scheduled BigQuery [query](https://console.cloud.google.com/bigquery?tc=us:64b02e2a-0000-2155-80f9-001a11446b5e&project=telligentsourcegraph&ws=!1m0) runs hourly to extract the latest rows from `dotcom_events.events` and export the results to a [Google Cloud Storage bucket](<https://console.cloud.google.com/storage/browser/amplitude-events-dotcom;tab=objects?forceOnBucketsSortingFiltering=true&project=telligentsourcegraph&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))>)
 2. Amplitude has a GCS connector set up that checks this bucket every hour and loads any new data into Amplitude.
 3. The exported event data is now available in Amplitude for analysis and reporting.
 

--- a/content/departments/data-analytics/amplitude.md
+++ b/content/departments/data-analytics/amplitude.md
@@ -34,7 +34,9 @@ Our Amplitude pipeline is connected to our `dotcom_events.events` table. The pip
 The entire pipeline runs every hour so it can take up to 1 hour for data to start appearing in Amplitude.
 
 #### Derived Properties
+
 Within Amplitude we have built some derived properties that make it easier to extract our specific keys from our nested data fields and use them for analysis. Current derived properties include:
+
 1. charCount
 2. linesOfCode
 3. is_sourcegraph_teammate


### PR DESCRIPTION
Update the Amplitude handbook page to reflect the current pipeline and remove expired links of old Amplitude charts. 