### PR TITLE
Updated Slack channel name on Customer Support Onboarding page

### DIFF
--- a/content/departments/technical-success/support/onboarding/customer-support-onboarding.md
+++ b/content/departments/technical-success/support/onboarding/customer-support-onboarding.md
@@ -2,7 +2,7 @@
 
 Welcome to Sourcegraph and the Customer Support team! This document provides an overview of the outcomes you will achieve while you work on your onboarding. The specific tasks in support of these outcomes are found in [Process Street](https://app.process.st/reports). If you ever feel like an outcome is not true, share that with your manager or the team, and we will figure out how to make sure it is true and improve the onboarding for the next new teammate.
 
-As you go through onboarding, take your time. The first few weeks are all about learning, not doing. It will feel like you have nothing to show for your first few weeks and that is by design. It's okay to take your time and just focus on settling in. It can be reading intensive, so please know you can share your thoughts, reactions, and questions in our #customer-support-internal Slack channel, talk with your [onboarding buddy](../../../people-talent/buddy-program.md), talk with your [onboarding mentor](cs-onboard-mentor.md), talk with your manager, or talk with anyone else on the team. Doing so can make it a little more interactive and less tedious.
+As you go through onboarding, take your time. The first few weeks are all about learning, not doing. It will feel like you have nothing to show for your first few weeks and that is by design. It's okay to take your time and just focus on settling in. It can be reading intensive, so please know you can share your thoughts, reactions, and questions in our #team-customer-support Slack channel, talk with your [onboarding buddy](../../../people-talent/buddy-program.md), talk with your [onboarding mentor](cs-onboard-mentor.md), talk with your manager, or talk with anyone else on the team. Doing so can make it a little more interactive and less tedious.
 
 ## By the end of your first week, the following will be true...
 
@@ -10,7 +10,7 @@ As you go through onboarding, take your time. The first few weeks are all about 
 - You understand Sourcegraph’s purpose and how you/your role supports us achieving it
 - You understand what is expected of you in your role and what it means to be a successful support engineer
 - You have started to get to know your teammates
-- You understand how to make edits to an handbook page
+- You understand how to make edits to a handbook page
 - You have a sense of what tools you will be using and for what
 
 ## By the end of your second week, the following will be true...
@@ -24,7 +24,7 @@ As you go through onboarding, take your time. The first few weeks are all about 
 
 ## By the end of your third week, the following will be true...
 
-- You are starting to understand the day-to-day of an support engineer
+- You are starting to understand the day-to-day of a support engineer
 
 ## By the end of your fourth week, the following will be true...
 


### PR DESCRIPTION
- Changed #customer-support-internal to #team-customer-support, the name which is currently in Slack
- fixed 2 typos (a support engineer vs. an support engineer and a handbook vs. an handbook)