### PR TITLE
Clarify doc for creating a CI build for ext prs

### DIFF
--- a/content/departments/engineering/dev/process/external_contributions.md
+++ b/content/departments/engineering/dev/process/external_contributions.md
@@ -25,6 +25,7 @@ If the PR changes, pull changes into the branch, and run the above command again
 Alternatively, you can directly request a build for a specific commit:
 
 ```sh
+gh pr checkout $PR_NUMBER
 sg ci build --commit $COMMIT
 ```
 


### PR DESCRIPTION
If you skim through the docs a bit too quickly, you might assume it's either the first two commands or only one command in the alterative, which is not going to work. 