### PR TITLE
core-services: init telemetry gateway docs and stub MSP page

### DIFF
--- a/content/departments/engineering/teams/core-services/managed-services/index.md
+++ b/content/departments/engineering/teams/core-services/managed-services/index.md
@@ -1,11 +1,18 @@
 # Managed Services
 
 A big part of the Core Services team is developing and maintaining our managed cloud services infrastructure.
+Going forward, new managed services - internal and external - should aim to be deployed using [MSP (Managed Services Platform)](./platform.md).
+
+## [Cody Gateway](../../cody/cody-gateway/index.md)
+
+> [!NOTE] Cody Gateway infrastructure is owned by the Core Services team, but the service is owned by #discuss-apis
 
 ## [Pings service](./pings.md)
+
+## [Telemetry Gateway](./telemetry-gateway.md)
 
 ## Sourcergaph.com Google OIDC
 
 The GCP project that manages our [Google OIDC authentication integration](https://console.cloud.google.com/apis/credentials/oauthclient/394401733494-3ekkk0qr3qvg7b3l1imqcgsh3ej710eq.apps.googleusercontent.com?project=sourcegraph-com-ggl-oidc) ("Sign in with Google") for Sourcergraph.com. We put the integration in a standalone project for a dedicated public-facing [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent?project=sourcegraph-com-ggl-oidc).
 
-_Please use [Entitle](https://app.entitle.io/request?targetType=resource&duration=10800&justification=Add%20your%20justifications%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=9434ed31-8a2a-425d-a9e7-899b257f3ddf&roleId=5ba5e5cf-53d2-496b-8d25-52b8fc92e637&grantMethodId=5ba5e5cf-53d2-496b-8d25-52b8fc92e637) to request access to this project._
+> [!NOTE] Please use [Entitle](https://app.entitle.io/request?targetType=resource&duration=10800&justification=Add%20your%20justifications%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=9434ed31-8a2a-425d-a9e7-899b257f3ddf&roleId=5ba5e5cf-53d2-496b-8d25-52b8fc92e637&grantMethodId=5ba5e5cf-53d2-496b-8d25-52b8fc92e637) to request access to this project.

--- a/content/departments/engineering/teams/core-services/managed-services/pings.md
+++ b/content/departments/engineering/teams/core-services/managed-services/pings.md
@@ -36,7 +36,7 @@ The following Entitle requests are needed to get access to Pings service infrast
 
 ### Deployment
 
-The Pings service infrastructure is defined in [`sourcegraph/managed-services/services/pings`](https://github.com/sourcegraph/managed-services/tree/main/services/pings) utilizing Managed Services Platforms.
+The Pings service infrastructure is defined in [`sourcegraph/managed-services/services/pings`](https://github.com/sourcegraph/managed-services/tree/main/services/pings) utilizing [Managed Services Platform](./platform.md).
 
 #### Modify deployment manifest
 

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -1,0 +1,8 @@
+# Sourcegraph Managed Services Platform
+
+The Sourcegraph Managed Services Platform (**MSP**) is the standardized tooling and infrastructure for deploying and operating managed Sourcegraph services.
+It takes a service specification and generates
+
+All assets are managed in [souregraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
+
+> [!WARNING] This project and page is a work in progress. For some context, see [go/rfc-msp](http://go/rfc-msp).

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -3,6 +3,6 @@
 The Sourcegraph Managed Services Platform (**MSP**) is the standardized tooling and infrastructure for deploying and operating managed Sourcegraph services.
 It takes a service specification and generates
 
-All assets are managed in [souregraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
+All assets are managed in [sourcegraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
 
 > [!WARNING] This project and page is a work in progress. For some context, see [go/rfc-msp](http://go/rfc-msp).

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -1,7 +1,7 @@
-# Sourcegraph Managed Services Platform
+# Sourcegraph Managed Services Platform (MSP)
 
 The Sourcegraph Managed Services Platform (**MSP**) is the standardized tooling and infrastructure for deploying and operating managed Sourcegraph services.
-It takes a service specification and generates
+It takes a service specification and generates Terraform manifests and adjacent resources required to operate a service.
 
 All assets are managed in [sourcegraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
 

--- a/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
@@ -4,6 +4,7 @@ The Telemetry Gateway service is the service that ingests [telemetry v2 events](
 
 - As of 5.2.0, [certain flags can be configured](https://docs.sourcegraph.com/dev/background-information/telemetry#enabling-telemetry-export) to export events that have been instrumented with the new APIs to Telemetry Gateway.
 - For Sourcegraph instances that prior to 5.2.0, no events are exported.
+  A [custom mechanism did exist for exporting events specifically from Cloud instances](https://docs.sourcegraph.com/dev/background-information/data-usage-pipeline) based on individual service agreements with customers - the new telemetry events will supersede this mechanism.
 
 ## Service images
 

--- a/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
@@ -1,0 +1,80 @@
+# Telemetry Gateway
+
+The Telemetry Gateway service is the service that ingests [telemetry v2 events](https://docs.sourcegraph.com/dev/background-information/telemetry) from all Sourcegraph instances, and is available at `telemetry-gateway.sourcegraph.com`.
+
+- As of 5.2.0, [certain flags can be configured](https://docs.sourcegraph.com/dev/background-information/telemetry#enabling-telemetry-export) to export events that have been instrumented with the new APIs to Telemetry Gateway.
+- For Sourcegraph instances that prior to 5.2.0, no events are exported.
+
+## Service images
+
+Source code for Telemetry Gateway service is in [sourcegraph/sourcegraph/cmd/telemetry-gateway](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/telemetry-gateway).
+The image gets built the same way as any other Sourcegraph service, i.e. with `insiders`, the standard `main`-branch and `main-dry-run` tags.
+
+## Local development
+
+For local development, please refer to its [How to set up Telemetry Gateway locally](https://docs.sourcegraph.com/dev/how-to/telemetry_gateway).
+
+## Operations
+
+> [!NOTE]
+> To get access to most resources, you’ll need to [request infrastructure access](#infrastructure-access).
+
+Here is a list of useful quick links:
+
+- Prod instance: `telemetry-gateway.sourcegraph.com` - currently only accepts real Sourcegraph licenses.
+  - [Terraform Cloud workspaces](https://app.terraform.io/app/sourcegraph/workspaces?project=prj-9XNnACvkeM1VWteC)
+  - [Cloud Run service (metrics overview)](https://console.cloud.google.com/run/detail/us-central1/telemetry-gateway/metrics?project=telemetry-gateway-prod-acae)
+  - [Service logs](https://cloudlogging.app.goo.gl/kficDmGcZdMJHPQL9)
+  - [GCP alerts](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-prod-acae)
+  - [GCP errors](https://console.cloud.google.com/errors?project=telemetry-gateway-prod-acae)
+- Dev instance: `telemetry-gateway.sgdev.org` - currently only accepts `dev-private` licenses.
+  - [Terraform Cloud workspaces](https://app.terraform.io/app/sourcegraph/workspaces?project=prj-nxL7Ti7x8xp6oZTU)
+  - [Cloud Run service (metrics overview)](https://console.cloud.google.com/run/detail/us-central1/telemetry-gateway/metrics?project=telemetry-gateway-dev-0050)
+  - [Service logs](https://cloudlogging.app.goo.gl/4oVGWGz1FQKVt5vm9)
+  - [GCP alerts](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-dev-0050)
+  - [GCP errors](https://console.cloud.google.com/errors?project=telemetry-gateway-dev-0050)
+
+### Infrastructure access
+
+The following Entitle requests are needed to get access to Telemetry Gateway service infrastructure:
+
+- [GCP project - Prod Editor](https://app.entitle.io/request?targetType=resource&duration=21600&justification=Justification%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=271c1799-6172-4099-8fe1-b186ac05aa06&roleId=da83e573-1cae-4e83-a132-3d2c6065ecbb&grantMethodId=da83e573-1cae-4e83-a132-3d2c6065ecbb)
+
+All engineers should have access to the dev project by default.
+
+### Deployment
+
+The Telemetry Gateway service infrastructure is defined in [`sourcegraph/managed-services/services/telemetry-gateway`](https://github.com/sourcegraph/managed-services/tree/main/services/telemetry-gateway) utilizing [Managed Services Platform](./platform.md).
+
+#### Modify deployment manifest
+
+> [!WARNING]
+> Due to the early-stage shape of Managed Services Platforms, we have yet to roll out standardized playbook. Please reach out to #team-core-services for modifying the deployment manifest. Instructions in this section are generally assumed with an upfront setup.
+
+To modify the deployment manifest:
+
+1. Update `service.yaml` file
+1. In the repository root, run `sg msp generate services/telemetry-gateway/service.yaml prod`
+1. Stage changes and make a pull request
+1. The Terraform Cloud rolls out changes
+
+#### Use a different image tag
+
+To specify a Docker image tag other than the default, update the `service.yaml`:
+
+```diff
+ - id: prod
+   ...
+   deploy:
+     type: manual
++    manual:
++      tag: 218287_2023-05-10_5.0-5bd03cd18e71
+```
+
+### Observability
+
+> [!NOTE] More stuff coming soon on this front
+
+#### Metrics
+
+The deployment's [Cloud Run metrics overview page](https://console.cloud.google.com/run/detail/us-central1/telemetry-gateway/metrics?project=telemetry-gateway-prod-acae) provides basic observability into the service provided out-of-the-box by Cloud Run, such as instance count and resource utilization.

--- a/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
@@ -54,7 +54,7 @@ The Telemetry Gateway service infrastructure is defined in [`sourcegraph/managed
 To modify the deployment manifest:
 
 1. Update `service.yaml` file
-1. In the repository root, run `sg msp generate services/telemetry-gateway/service.yaml prod`
+1. Anywhere in the repository, run `sg msp generate telemetry-gateway prod`
 1. Stage changes and make a pull request
 1. The Terraform Cloud rolls out changes
 


### PR DESCRIPTION
Fairly minimal for now - will follow up

Points to parts https://github.com/sourcegraph/sourcegraph/pull/56868
Part of https://github.com/sourcegraph/sourcegraph/issues/56869