### PR TITLE
managed-services: add docs to msp editor role

### DIFF
--- a/content/departments/engineering/teams/core-services/managed-services/pings.md
+++ b/content/departments/engineering/teams/core-services/managed-services/pings.md
@@ -7,7 +7,7 @@ The Pings service is the service that collects [ping requests](https://docs.sour
 
 ## Service images
 
-Source code for Pings service is in [sourcegraph/sourcegraph/cmd/pings](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/pings). The image gets built the same way as any other Sourcegraph service, i.e. with ` insiders`, the standard `main`-branch and `main-dry-run` tags.
+Source code for Pings service is in [sourcegraph/sourcegraph/cmd/pings](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/pings). The image gets built the same way as any other Sourcegraph service, i.e. with `insiders`, the standard `main`-branch and `main-dry-run` tags.
 
 ## Local development
 
@@ -31,8 +31,7 @@ Here is a list of useful quick links:
 
 The following Entitle requests are needed to get access to Pings service infrastructure:
 
-- [GCP project - Editor](https://app.entitle.io/request?targetType=resource&duration=10800&justification=Justification%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=d94da8c3-76eb-451a-9cbb-973ac3bc44b1&roleId=2a1e9779-05d6-4f3f-976b-046ab0c91259&grantMethodId=2a1e9779-05d6-4f3f-976b-046ab0c91259)
-- [GCP project - Cloud Run Admin](https://app.entitle.io/request?targetType=resource&duration=10800&justification=Justification%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=d94da8c3-76eb-451a-9cbb-973ac3bc44b1&roleId=2d83db53-9330-4778-88b4-a3f1193fc3d1&grantMethodId=2d83db53-9330-4778-88b4-a3f1193fc3d1)
+- [GCP Project - MSP Service Editor](https://app.entitle.io/request?targetType=resource&duration=43200&justification=TODO&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=d94da8c3-76eb-451a-9cbb-973ac3bc44b1&roleId=8b60a711-976c-4e56-9f8b-cb2c989faca4&grantMethodId=8b60a711-976c-4e56-9f8b-cb2c989faca4) (see [MSP Entitle](./platform.md#entitle))
 
 ### Deployment
 

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -6,3 +6,19 @@ It takes a service specification and generates Terraform manifests and adjacent 
 All assets are managed in [sourcegraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
 
 > [!WARNING] This project and page is a work in progress. For some context, see [go/rfc-msp](http://go/rfc-msp).
+
+## Entitle
+
+For MSP service environments using `category: external` (or without configuring `category`), access needs to be requested through Entitle.
+Other environments should have access granted to engineers by default.
+
+Entitle access to a production MSP project is most easily provisioned through the `mspServiceEditor` custom role.
+This role is created org-level [in `gcp/org/customer-roles/msp.tf` in the infrastructure repo](https://github.com/sourcegraph/infrastructure/blob/main/gcp/custom-roles/msp.tf) and available in Entitle by following the steps:
+
+- Go to [app.entitle.io/request](https://app.entitle.io/request) and select **Specific Permission**
+- Fill out the following:
+  - Integration: `GCP Production Projects`
+  - Resource types: `Project`
+  - Resource: name of MSP project you are interested in
+  - Role: `mspServiceEditor`
+  - Duration: choose your own adventure!

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -9,7 +9,7 @@ All assets are managed in [sourcegraph/managed-services](https://github.com/sour
 
 ## Entitle
 
-For MSP service environments using `category: external` (or without configuring `category`), access needs to be requested through Entitle.
+For MSP service environments other than `category: test`, access needs to be requested through Entitle.
 Other environments should have access granted to engineers by default.
 
 Entitle access to a production MSP project is most easily provisioned through the `mspServiceEditor` custom role.

--- a/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/teams/core-services/managed-services/telemetry-gateway.md
@@ -39,7 +39,7 @@ Here is a list of useful quick links:
 
 The following Entitle requests are needed to get access to Telemetry Gateway service infrastructure:
 
-- [GCP project - Prod Editor](https://app.entitle.io/request?targetType=resource&duration=21600&justification=Justification%20here&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=271c1799-6172-4099-8fe1-b186ac05aa06&roleId=da83e573-1cae-4e83-a132-3d2c6065ecbb&grantMethodId=da83e573-1cae-4e83-a132-3d2c6065ecbb)
+- [GCP Project - MSP Service Editor](https://app.entitle.io/request?targetType=resource&duration=43200&justification=TODO&integrationId=134476cb-0bd6-4c6d-a89f-e1550988bdd7&resourceId=271c1799-6172-4099-8fe1-b186ac05aa06&roleId=b1bc8eac-3893-4847-a4a0-16dadb068bf2&grantMethodId=b1bc8eac-3893-4847-a4a0-16dadb068bf2) (see [MSP Entitle](./platform.md#entitle))
 
 All engineers should have access to the dev project by default.
 


### PR DESCRIPTION
The better way to get Entitle access to MSP projects, now fully controlled by us :)