### PR TITLE
Add "Successful engineers at Sourcegraph"

### DIFF
--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -26,6 +26,12 @@ These are the expectations for ICs _after they have completed their onboarding_.
 We expect every engineer to eventually reach at least level 3.
 It is the responsibility of your manager to track this, and to ensure that you are given the support and opportunities needed for career growth.
 
+## Successful engineers at Sourcegraph
+
+In order to make the level descriptions below a bit more tangle, we also have the following document: [Successful engineers at Sourcegraph](./successful-engineers.md).
+
+The goal of that document is to drive home that point that the ladder is not a series of checkboxes to be checked-off sequentially. There are many different ways to have impact across multiple levels here.
+
 ## When do I get promoted?
 
 When your manager can make the case that you’ve had at least one quarter of high performance at your current level, and one quarter performing at the next level, in all three of the categories. It takes time to demonstrate the “consistently” implicit in the expectations, and we don’t want to promote anyone to a level in which they will struggle.

--- a/content/departments/engineering/dev/career-development/framework.md
+++ b/content/departments/engineering/dev/career-development/framework.md
@@ -28,9 +28,7 @@ It is the responsibility of your manager to track this, and to ensure that you a
 
 ## Successful engineers at Sourcegraph
 
-In order to make the level descriptions below a bit more tangle, we also have the following document: [Successful engineers at Sourcegraph](./successful-engineers.md).
-
-The goal of that document is to drive home that point that the ladder is not a series of checkboxes to be checked-off sequentially. There are many different ways to have impact across multiple levels here.
+In order to make the level descriptions below a bit more tangible, we also have the following document: [Successful engineers at Sourcegraph](./successful-engineers.md).
 
 ## When do I get promoted?
 

--- a/content/departments/engineering/dev/career-development/index.md
+++ b/content/departments/engineering/dev/career-development/index.md
@@ -1,3 +1,4 @@
 # Engineering career development
 
-- [Career development framework](framework.md)
+- [Career development framework](./framework.md)
+- [Successful engineers at Sourcegraph](./successful-engineers.md)

--- a/content/departments/engineering/dev/career-development/successful-engineers.md
+++ b/content/departments/engineering/dev/career-development/successful-engineers.md
@@ -8,57 +8,56 @@ The most successful engineers check a lot of the boxes most of the time.
 
 1. **Great programmers**
 
-    They can write code in the languages they work with as well as the best in the world.
-    They know their tools enough to use them to maximum efficiency.
-    They know what they don't know.
-
+   They can write code in the languages they work with as well as the best in the world.
+   They know their tools enough to use them to maximum efficiency.
+   They know what they don't know.
 
 2. **Continuously improve things around them**
 
-    They leave codebases in a better state than they found them.
-    They improve processes.
-    They ask “do we still need this?” about code, features, products, processes.
+   They leave codebases in a better state than they found them.
+   They improve processes.
+   They ask “do we still need this?” about code, features, products, processes.
 
 3. **Unblock themselves**
 
-    They ask for help – as early as needed.
-    They debug and try alternative approaches.
-    They know how to continue working while waiting for an answer from a colleague in a different timezone.
+   They ask for help – as early as needed.
+   They debug and try alternative approaches.
+   They know how to continue working while waiting for an answer from a colleague in a different timezone.
 
 4. **Get better on their own**
 
-    If left alone, they will find ways to get better and improve. If you nudge them and give them tips and directions, they get even better.
+   If left alone, they will find ways to get better and improve. If you nudge them and give them tips and directions, they get even better.
 
 5. **Ship value to customers; they don’t write code for code’s sake**
 
-    They know that delivering value to the customers is all that counts in the end.
-    They really want their work to end up in the hands of customers, where it’s used successfully.
-    They see Engineering as a business function and understand that Engineering isn’t there to serve Engineering, it’s there to serve the business and provide value to it.
+   They know that delivering value to the customers is all that counts in the end.
+   They really want their work to end up in the hands of customers, where it’s used successfully.
+   They see Engineering as a business function and understand that Engineering isn’t there to serve Engineering, it’s there to serve the business and provide value to it.
 
 6. **Great communicators**
 
-    Slack, RFCs, code reviews, GitHub comments, commit messages, pull requests, Zoom calls—they know that all of these are forms of communication and they know in which situations and how to use each medium best.
+   Slack, RFCs, code reviews, GitHub comments, commit messages, pull requests, Zoom calls—they know that all of these are forms of communication and they know in which situations and how to use each medium best.
 
-    They know that communication counts a lot in an async/remote communication and that communication is the work at times and not just something that gets in the way of coding.
+   They know that communication counts a lot in an async/remote communication and that communication is the work at times and not just something that gets in the way of coding.
 
 7. **Share their work regularly**
 
-    They know that sharing work and progress is not about boasting; it’s about keeping others in the loop and fostering moments of “Ah, I remember when $name shared how they did $project, maybe we can take this approach”
+   They know that sharing work and progress is not about boasting; it’s about keeping others in the loop and fostering moments of “Ah, I remember when $name shared how they did $project, maybe we can take this approach”
 
 8. **Find work and problems to solve**
 
-    They look around them and at the company goals and find ways that we can do better.
-    They are aware of where the business is headed and what our customers want.
-    They advocate for their work, seeking the alignment that is needed to decide whether or not now is the right time for that work.
-    They propose fixes and solutions, product ideas and roadmap additions.
-    They will be busy improving our product and codebase even if the rest of the company goes offline for 4 weeks.
-    They are skeptical of red tape.
+   They look around them and at the company goals and find ways that we can do better.
+   They are aware of where the business is headed and what our customers want.
+   They advocate for their work, seeking the alignment that is needed to decide whether or not now is the right time for that work.
+   They propose fixes and solutions, product ideas and roadmap additions.
+   They will be busy improving our product and codebase even if the rest of the company goes offline for 4 weeks.
+   They are skeptical of red tape.
 
 9. **Have a sense of urgency**
 
-    They know that we’re a startup that has to move fast.
-    When someone says “next week” they ask “why not tomorrow?”
-    They know that a sense of urgency is not about shipping hacks, but about finding the quickest solutions with the right tradeoffs for the problem at hand: they don't build out a full system where a prototype is all that's needed, but they also don't bring a hack to solve a systemic problem like security.
+   They know that we’re a startup that has to move fast.
+   When someone says “next week” they ask “why not tomorrow?”
+   They know that a sense of urgency is not about shipping hacks, but about finding the quickest solutions with the right tradeoffs for the problem at hand: they don't build out a full system where a prototype is all that's needed, but they also don't bring a hack to solve a systemic problem like security.
 
 10. **Not solo players**
 

--- a/content/departments/engineering/dev/career-development/successful-engineers.md
+++ b/content/departments/engineering/dev/career-development/successful-engineers.md
@@ -1,0 +1,73 @@
+# Successful engineers at Sourcegraph
+
+The following is an idealized archetype of a successful engineer at Sourcegraph. Its purpose is to give engineers something to strive towards – regardless of which level they are currently on.
+
+It’s a combination of attributes that multiple successful engineers, on various levels, show at different times in varying degrees. Nobody checks all boxes all the time and how exactly these items play out may vary by level.
+
+The most successful engineers check a lot of the boxes most of the time.
+
+1. **Great programmers**
+
+    They can write code in the languages they work with as well as the best in the world.
+    They know their tools enough to use them to maximum efficiency.
+    They know what they don't know.
+
+
+2. **Continuously improve things around them**
+
+    They leave codebases in a better state than they found them.
+    They improve processes.
+    They ask “do we still need this?” about code, features, products, processes.
+
+3. **Unblock themselves**
+
+    They ask for help – as early as needed.
+    They debug and try alternative approaches.
+    They know how to continue working while waiting for an answer from a colleague in a different timezone.
+
+4. **Get better on their own**
+
+    If left alone, they will find ways to get better and improve. If you nudge them and give them tips and directions, they get even better.
+
+5. **Ship value to customers; they don’t write code for code’s sake**
+
+    They know that delivering value to the customers is all that counts in the end.
+    They really want their work to end up in the hands of customers, where it’s used successfully.
+    They see Engineering as a business function and understand that Engineering isn’t there to serve Engineering, it’s there to serve the business and provide value to it.
+
+6. **Great communicators**
+
+    Slack, RFCs, code reviews, GitHub comments, commit messages, pull requests, Zoom calls—they know that all of these are forms of communication and they know in which situations and how to use each medium best.
+
+    They know that communication counts a lot in an async/remote communication and that communication is the work at times and not just something that gets in the way of coding.
+
+7. **Share their work regularly**
+
+    They know that sharing work and progress is not about boasting; it’s about keeping others in the loop and fostering moments of “Ah, I remember when $name shared how they did $project, maybe we can take this approach”
+
+8. **Find work and problems to solve**
+
+    They look around them and at the company goals and find ways that we can do better.
+    They are aware of where the business is headed and what our customers want.
+    They advocate for their work, seeking the alignment that is needed to decide whether or not now is the right time for that work.
+    They propose fixes and solutions, product ideas and roadmap additions.
+    They will be busy improving our product and codebase even if the rest of the company goes offline for 4 weeks.
+    They are skeptical of red tape.
+
+9. **Have a sense of urgency**
+
+    They know that we’re a startup that has to move fast.
+    When someone says “next week” they ask “why not tomorrow?”
+    They know that a sense of urgency is not about shipping hacks, but about finding the quickest solutions with the right tradeoffs for the problem at hand: they don't build out a full system where a prototype is all that's needed, but they also don't bring a hack to solve a systemic problem like security.
+
+10. **Not solo players**
+
+    They know that a team is more than a collection of individuals that share a ticket board.
+    They value a well-running team and try their best to make it a well-running team because they know that a group of engineers working together on a codebase over time is one of the best ways to continuously ship value to customers.
+    They work with Product, Design, Security, CE, TS and other departments not because they have to but because they know that their input will improve their work.
+
+11. **Care about the whole software lifecycle**
+
+    They care about shipping software from end to end: from planning, to coding, to demoing, to docs, to announcement, to getting it in the hands of customers, to helping customers use it, and to making improvements over time.
+
+    They think actively about the consequences their choices will have on all parts of this life cycle: is this a breaking change? Does this need to be backwards-compatible? Do we need a slow rollout here? How do we test this at scale – can we test this at scale? When and how do we need to loop in the Security team? How do we enable CE? What do we/CE/TS/customers do if it breaks?

--- a/content/departments/engineering/dev/career-development/successful-engineers.md
+++ b/content/departments/engineering/dev/career-development/successful-engineers.md
@@ -9,19 +9,25 @@ The most successful engineers check a lot of the boxes most of the time.
 1. **Great programmers**
 
    They can write code in the languages they work with as well as the best in the world.
+
    They know their tools enough to use them to maximum efficiency.
+
    They know what they don't know.
 
 2. **Continuously improve things around them**
 
    They leave codebases in a better state than they found them.
+
    They improve processes.
+
    They ask “do we still need this?” about code, features, products, processes.
 
 3. **Unblock themselves**
 
    They ask for help – as early as needed.
+
    They debug and try alternative approaches.
+
    They know how to continue working while waiting for an answer from a colleague in a different timezone.
 
 4. **Get better on their own**
@@ -31,7 +37,9 @@ The most successful engineers check a lot of the boxes most of the time.
 5. **Ship value to customers; they don’t write code for code’s sake**
 
    They know that delivering value to the customers is all that counts in the end.
+
    They really want their work to end up in the hands of customers, where it’s used successfully.
+
    They see Engineering as a business function and understand that Engineering isn’t there to serve Engineering, it’s there to serve the business and provide value to it.
 
 6. **Great communicators**
@@ -47,22 +55,31 @@ The most successful engineers check a lot of the boxes most of the time.
 8. **Find work and problems to solve**
 
    They look around them and at the company goals and find ways that we can do better.
+
    They are aware of where the business is headed and what our customers want.
+
    They advocate for their work, seeking the alignment that is needed to decide whether or not now is the right time for that work.
+
    They propose fixes and solutions, product ideas and roadmap additions.
+
    They will be busy improving our product and codebase even if the rest of the company goes offline for 4 weeks.
+
    They are skeptical of red tape.
 
 9. **Have a sense of urgency**
 
    They know that we’re a startup that has to move fast.
+
    When someone says “next week” they ask “why not tomorrow?”
+
    They know that a sense of urgency is not about shipping hacks, but about finding the quickest solutions with the right tradeoffs for the problem at hand: they don't build out a full system where a prototype is all that's needed, but they also don't bring a hack to solve a systemic problem like security.
 
 10. **Not solo players**
 
     They know that a team is more than a collection of individuals that share a ticket board.
+
     They value a well-running team and try their best to make it a well-running team because they know that a group of engineers working together on a codebase over time is one of the best ways to continuously ship value to customers.
+
     They work with Product, Design, Security, CE, TS and other departments not because they have to but because they know that their input will improve their work.
 
 11. **Care about the whole software lifecycle**


### PR DESCRIPTION
I added the document as-is in Markdown form and then linked to it from
the index.

I also think it should be linked-to on the ladder page (because that's
what most people look at), but I think that page will be reworked anyway
(should be, I think), so I only added 2 clumsy paragraphs.

## Screenshot to prove that formatting is correct

<img width="617" alt="screenshot_2023-10-25_12 05 54@2x" src="https://github.com/sourcegraph/handbook/assets/1185253/01e85c10-c089-46c4-a1d3-11f43812dffd">


