### PR TITLE
Update TA team norms, segmentation

### DIFF
--- a/content/departments/technical-success/ta/team-culture/team-norms.md
+++ b/content/departments/technical-success/ta/team-culture/team-norms.md
@@ -19,7 +19,7 @@ Today, the following segments are considered managed:
 | ---------------- | ---------------------------------------- |
 | Strategic        | 10k+ devs, any amount of ARR spend       |
 | Enterprise       | 1.5k - 10k devs, any amount of ARR spend |
-| Commercial       | 0 - 1.5k devs, <$100k ARR spend          |
+| Commercial       | 0 - 1.5k devs, >$100k ARR spend          |
 
 ### Unmanaged
 
@@ -29,7 +29,7 @@ Today, the following segment is considered unmanaged:
 
 | Customer Segment | Segment definition              |
 | ---------------- | ------------------------------- |
-| Commercial       | 0 - 1.5k devs, >$100k ARR spend |
+| Commercial       | 0 - 1.5k devs, <$100k ARR spend |
 
 ## Scaled Success Program
 


### PR DESCRIPTION
Fix typo where the ARR less than, greater than were inverted for the Commercial and Scaled segments