### PR TITLE
devinfra: add a priority section for support

### DIFF
--- a/content/departments/engineering/teams/devinfra/index.md
+++ b/content/departments/engineering/teams/devinfra/index.md
@@ -52,6 +52,19 @@ Find out more about the Developer Infrastructure team's mission, vision, and str
 
 Also see [org-wide areas of ownership](../../dev/process/engineering_ownership.md#developer-experience) and our [team processes](processes.md).
 
+## Support levels
+
+The team operate across a broad range of responsibilities, so it's best to reason in terms of how much a given issue affects others.
+The below list gives an overview of the commonly encountered scenarios, but isn't meant to be exhaustive.
+
+- *P0*: Issues that are affecting at least a third of the engineering team and that have no immediate workaround.
+- *P0*: Issues the CI where a given build is affecting other builds, i.e breaking isolation.
+- *P0*: Issues caused by Bazel, affecting releases (broken release or preventing it to be created).
+- *P1*: Issues with CI or local environment that are threating another team objectives.
+- *P2*: Issues causing intermittent failures in CI.
+- *P3*: Default priorities for support requests when created.
+- *P4*: Issues that can wait, usually QoL improvements.
+
 ## Contact
 
 For **questions** and **discussions** about anything related to developer experience, post a message in the [#discuss-dev-infra channel](https://sourcegraph.slack.com/archives/C01N83PS4TU).

--- a/content/departments/engineering/teams/devinfra/index.md
+++ b/content/departments/engineering/teams/devinfra/index.md
@@ -57,13 +57,13 @@ Also see [org-wide areas of ownership](../../dev/process/engineering_ownership.m
 The team operate across a broad range of responsibilities, so it's best to reason in terms of how much a given issue affects others.
 The below list gives an overview of the commonly encountered scenarios, but isn't meant to be exhaustive.
 
-- *P0*: Issues that are affecting at least a third of the engineering team and that have no immediate workaround.
-- *P0*: Issues the CI where a given build is affecting other builds, i.e breaking isolation.
-- *P0*: Issues caused by Bazel, affecting releases (broken release or preventing it to be created).
-- *P1*: Issues with CI or local environment that are threating another team objectives.
-- *P2*: Issues causing intermittent failures in CI.
-- *P3*: Default priorities for support requests when created.
-- *P4*: Issues that can wait, usually QoL improvements.
+- _P0_: Issues that are affecting at least a third of the engineering team and that have no immediate workaround.
+- _P0_: Issues the CI where a given build is affecting other builds, i.e breaking isolation.
+- _P0_: Issues caused by Bazel, affecting releases (broken release or preventing it to be created).
+- _P1_: Issues with CI or local environment that are threating another team objectives.
+- _P2_: Issues causing intermittent failures in CI.
+- _P3_: Default priorities for support requests when created.
+- _P4_: Issues that can wait, usually QoL improvements.
 
 ## Contact
 


### PR DESCRIPTION
Recently, there's been a case where it was not immediate in the team that a problem we were dealing with was a P0 for us. This PR intends to clarify the most common scenarios where for the support handled by the dev-infra team. 