### PR TITLE
core-services/msp: docs update

### DIFF
--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -3,11 +3,42 @@
 The Sourcegraph Managed Services Platform (**MSP**) is the standardized tooling and infrastructure for deploying and operating managed Sourcegraph services.
 It takes a service specification and generates Terraform manifests and adjacent resources required to operate a service.
 
+By adopting MSP for your managed service, it will benefit from [an expanding set of features and integrations](#features), alignment with infrastructure and security best practices at Sourcegraph, and support from the [Core Services team](../index.md).
+
 All assets are managed in [sourcegraph/managed-services](https://github.com/sourcegraph/managed-services), and the tooling is being developed in [sourcegraph/sourcegraph/dev/sg/msp](https://github.com/sourcegraph/sourcegraph/tree/main/dev/sg/msp).
 
 > [!WARNING] This project and page is a work in progress. For some context, see [go/rfc-msp](http://go/rfc-msp).
 
-## Entitle
+## Features
+
+MSP supports single-container:
+
+- stateless, horizontally scaling services
+- schedule cron jobs
+
+From a simple service configuration YAML ([examples](https://github.com/sourcegraph/managed-services/tree/main/services)), we currently support:
+
+- `sg msp` toolchain for managing configuration
+- Generating infrastructure-as-code, deployed via [Terraform Cloud](#terraform-cloud)
+- Service initialization and runtime boilerplate via [sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform)
+- Provisioning of external dependencies:
+  - Redis backed by [Cloud Memorystore](https://cloud.google.com/memorystore/docs/redis/memorystore-for-redis-overview)
+- Service-specific features
+  - Configuring a domain and TLS through Cloudflare and GCP load balancing
+  - Scaling capabilities backed by [Cloud Run](https://cloud.google.com/run?hl=en)
+- Job-specific features
+  - Executions backed by [Cloud Run Jobs](https://cloud.google.com/run/docs/create-jobs)
+  - Cron scheduling
+
+See [our GitHub roadmap](https://github.com/orgs/sourcegraph/projects/375/views/1) and [2023 Q3 Managed Services Platform (MSP) proof-of-concept update](https://docs.google.com/document/d/1DSqKqCgXW2m0TCVBmDSasY2Hxb9cp9Uv_NgF4MEfAto/edit) for more details on things we will be adding to MSP.
+
+## Creating and configuring services
+
+Refer to the [sourcegraph/managed-services README](https://github.com/sourcegraph/managed-services/blob/main/README.md) for all documentation for creating configuring MSP deployments and using `sg msp`.
+
+## Operating services
+
+### Entitle
 
 For MSP service environments other than `category: test`, access needs to be requested through Entitle.
 The test environment ("Engineering Projects" GCP folder) should have access granted to engineers by default.
@@ -22,3 +53,7 @@ This role is created org-level [in `gcp/org/customer-roles/msp.tf` in the infras
   - Resource: name of MSP project you are interested in
   - Role: `mspServiceEditor`
   - Duration: choose your own adventure!
+
+### Terraform Cloud
+
+Terraform Cloud workspaces for MSP [can be found using the `msp` workspace tag](https://app.terraform.io/app/sourcegraph/workspaces?tag=msp).


### PR DESCRIPTION
Add a slightly more extensive marketing spiel, and points to https://github.com/sourcegraph/managed-services for usage docs, which I'm working on improving: https://github.com/sourcegraph/managed-services/pull/62

Part of https://github.com/sourcegraph/sourcegraph/issues/56850