### PR TITLE
Remove reference to GitHub issue in design templates

### DIFF
--- a/content/departments/product/design/software_systems/templates/extra-large-template.md
+++ b/content/departments/product/design/software_systems/templates/extra-large-template.md
@@ -34,9 +34,7 @@
   - [ ] External users - Link, Link
 
   ### Define
-  - [ ] Product document or RFC - Link
-  - [ ] Design challenge - Link
-  - [ ] GitHub issue
+  - [ ] PRD and/or RFC - Link
 
   ### Design
   - [ ] user journey map - Link

--- a/content/departments/product/design/software_systems/templates/extra-small-template.md
+++ b/content/departments/product/design/software_systems/templates/extra-small-template.md
@@ -19,9 +19,6 @@
   ### Discover
   - [ ] Product and/or engineering provide direction and/or feedback
 
-  ### Define
-  - [ ] GitHub issue
-
   ### Design
   - [ ] High fidelity design using design system or low fidelity design as
   required - Link

--- a/content/departments/product/design/software_systems/templates/large-template.md
+++ b/content/departments/product/design/software_systems/templates/large-template.md
@@ -31,9 +31,7 @@
   - [ ] External users - Link, Link
 
   ### Define
-  - [ ] Product document or RFC - Link
-  - [ ] Design challenge - Link
-  - [ ] GitHub issue
+  - [ ] PRD and/or RFC - Link
 
   ### Design
   - [ ] user journey map - Link

--- a/content/departments/product/design/software_systems/templates/medium-template.md
+++ b/content/departments/product/design/software_systems/templates/medium-template.md
@@ -31,9 +31,7 @@
   - [ ] External users - Link, Link
 
   ### Define
-  - [ ] Product document or RFC - Link
-  - [ ] GitHub issue
-  - [ ] Design challenge
+  - [ ] PRD and/or RFC - Link
 
   ### Design
   - [ ] Low fidelity design - Link

--- a/content/departments/product/design/software_systems/templates/small-template.md
+++ b/content/departments/product/design/software_systems/templates/small-template.md
@@ -21,10 +21,6 @@
   - [ ] Existing customer feedback - Link
   - [ ] Product and/or engineering provide direction and/or feedback
 
-  ### Define
-  - [ ] GitHub issue
-  - [ ] Design challenge
-
   ### Design
   - [ ] Low fidelity design - Link
   - [ ] High fidelity design using design system - Figma


### PR DESCRIPTION
Removes the reference to GitHub issues in design issue templates as the reference is duplicative with the issue itself. 