### PR TITLE
Update engineering slack channels

### DIFF
--- a/content/departments/engineering/index.md
+++ b/content/departments/engineering/index.md
@@ -30,11 +30,11 @@ The Engineering department at Sourcegraph consists of:
 ## Slack channels
 
 - #team-engineering
-- #eng-announce
-- #ask-engineering
+- #announce-engineering
+- #discuss-engineering
 - #buildkite-main
-- #dev-chat
-- #dev-urandom
+- #chat-dev
+- #chat-dev-urandom
 
 ## Processes
 


### PR DESCRIPTION
This update is made to reflect current team channel names in Slack.