### PR TITLE
updates to cloud migration process for better clarity

### DIFF
--- a/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
+++ b/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
@@ -218,7 +218,13 @@ spec:
 +    enableAlerting: false
 ```
 
-4. Commit and submit your changes as a pull request. After merging and confirming the apply in Terraform Cloud, proceed with scaling down the instance:
+4. Commit and submit your changes as a pull request. After merging, apply the monitoring stack changes in Terraform Cloud or via mi2:
+
+```sh
+mi2 instance tfc deploy -auto-approve -force-ignore-stack-dependencies -target monitoring
+```
+
+5. Once monitoring has been disabled, proceed with scaling down the instance:
 
 ```sh
 mi2 instance scale-down

--- a/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
+++ b/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
@@ -1,7 +1,5 @@
 # On-prem data migration to Sourcegraph Cloud
 
-> [!WARNING] This process is still a work-in-progress. For more details, see [RFC 760](https://docs.google.com/document/d/1IAgXmv2TbtU_rWXtph-KFc3qbqswREIAxO1rGALuoMQ/edit#) and the [tracking issue](https://github.com/sourcegraph/customer/issues/1525), or cc @bobheadxi (Robert Lin).
-> This page was adapted only on a best-effort basis for Cloud v2 - it has currently not yet been thoroughly tested for Cloud v2.
 
 This process describes the current state of how to do a full data migration of an on-prem instance to a [Cloud v2](./index.md) instance.
 On-prem-to-Cloud data migrations are currently owned by [Implementation Engineering](../../../technical-success/ie/index.md), but the process is documented in Cloud as it pertains to Cloud infrastructure.

--- a/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
+++ b/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
@@ -1,6 +1,5 @@
 # On-prem data migration to Sourcegraph Cloud
 
-
 This process describes the current state of how to do a full data migration of an on-prem instance to a [Cloud v2](./index.md) instance.
 On-prem-to-Cloud data migrations are currently owned by [Implementation Engineering](../../../technical-success/ie/index.md), but the process is documented in Cloud as it pertains to Cloud infrastructure.
 

--- a/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
+++ b/content/departments/cloud/technical-docs/v2.0/onprem_data_migration.md
@@ -37,6 +37,7 @@ First, the operator must [create an instance](./creation_process.md) with the co
 ### Create a data migration Cloud Storage bucket
 
 1. In the [`cloud-data-migrations`](https://github.com/sourcegraph/cloud-data-migrations) repository, copy the `template/` directory, naming it corresponding to the customer.
+
 - Fill out all `$CUSTOMER` variables and set all unset variables in `terraform.tfvars` as documented.
 - Commit your changes, open a pull request in `cloud-data-migrations`, and merge the changes after review.
 
@@ -199,14 +200,16 @@ Audit logs are generated for bucket access in the project's logs, under log entr
 ## Execute data migration
 
 ### Disable alerting and scale down cloud instance
+
 Once the database backups and instance summary have been uploaded by the customer, the first step before processing the migration is to disable the instance alerting and scale down the Cloud instance.
 
 1. Update mi2 to the latest version:
+
 ```
 sg cloud install
 ```
 
-2. Extract the Cloud instance from the control plane, following the instructions in the *"Extract instance from control plane (break glass)"* section in the instance-specific dashboard from [go/cloud-ops](https://cloud-ops.sgdev.org/dashboard/environments/prod)
+2. Extract the Cloud instance from the control plane, following the instructions in the _"Extract instance from control plane (break glass)"_ section in the instance-specific dashboard from [go/cloud-ops](https://cloud-ops.sgdev.org/dashboard/environments/prod)
 
 3. Disable alerting by editing the instance `config.yaml` in [`sourcegraph/cloud`](https://github.com/sourcegraph/cloud) as follows. Make sure to deploy the terraform changes as well.
 
@@ -380,6 +383,6 @@ Then regenerate Terraform manifests:
 mi2 generate cdktf
 ```
 
-Finally, backfill the instance to the control plane following the instructions in the *"Backfill instance into control plane"* section in the instance-specific dashboard from [go/cloud-ops](https://cloud-ops.sgdev.org/dashboard/environments/prod)
+Finally, backfill the instance to the control plane following the instructions in the _"Backfill instance into control plane"_ section in the instance-specific dashboard from [go/cloud-ops](https://cloud-ops.sgdev.org/dashboard/environments/prod)
 
 Then commit your changes as a pull request. Once it has been merged, confirm the changes have been applied in Terraform Cloud.


### PR DESCRIPTION
- Reorganized instructions in chronological order into three main groups: 
  - steps to initialize a cloud data migration bucket
  - steps to collect snapshot data from the customer on a synchronous call
  - steps to process data migration on the cloud instance
- Added note to ensure that the latest mi2 binary is installed before proceeding with data migration (common paper cut)
- Added note to verify that all deployments/ sts have been scaled up after processing data migration to (accounting for prometheus being scaled down due to disabling alerting)
- Added note for backfilling instance to Cloud control plane after completing data migration
- various misc formatting changes