### PR TITLE
msp: add runtime and BigQuery docs

### DIFF
--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -19,7 +19,7 @@ MSP supports single-container:
 From a simple service configuration YAML ([examples](https://github.com/sourcegraph/managed-services/tree/main/services)) and the `sg msp` toolchain for managing configuration, we currently support:
 
 - Generating infrastructure-as-code, deployed via [Terraform Cloud](#terraform-cloud)
-- Service initialization and runtime boilerplate via [sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform), which includes:
+- [Service initialization and runtime boilerplate](#building-a-new-service) via [sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform), which includes:
   - initialization of OpenTelemetry tracing and metrics, logging, and error reporting
   - integration guidance for provisioned data backends like Redis and PostgreSQL
 - Provisioning of data backends, configured with secure, highly available defaults and regular backups out of the box where applicable:

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -19,10 +19,13 @@ MSP supports single-container:
 From a simple service configuration YAML ([examples](https://github.com/sourcegraph/managed-services/tree/main/services)) and the `sg msp` toolchain for managing configuration, we currently support:
 
 - Generating infrastructure-as-code, deployed via [Terraform Cloud](#terraform-cloud)
-- Service initialization and runtime boilerplate via [sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform)
-- Provisioning of data backends, configured with secure, highly available defaults and regular backups out of the box:
+- Service initialization and runtime boilerplate via [sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform), which includes:
+  - initialization of OpenTelemetry tracing and metrics, logging, and error reporting
+  - integration guidance for provisioned data backends like Redis and PostgreSQL
+- Provisioning of data backends, configured with secure, highly available defaults and regular backups out of the box where applicable:
   - [Redis](https://cloud.google.com/memorystore/docs/redis/memorystore-for-redis-overview) for ephemereal data and synchronization between instances of a service.
   - [PostgreSQL](https://cloud.google.com/sql/postgresql?hl=en) for persistent, relational data.
+  - [BigQuery](https://cloud.google.com/bigquery?hl=en) dataset and tables for high-volume analytics and usage data specific to your feature.
 - Service-specific features
   - Configuring a domain and TLS through Cloudflare and GCP load balancing
   - Scaling capabilities backed by [Cloud Run](https://cloud.google.com/run?hl=en)
@@ -32,7 +35,31 @@ From a simple service configuration YAML ([examples](https://github.com/sourcegr
 
 See [our GitHub roadmap](https://github.com/orgs/sourcegraph/projects/375/views/1) and [2023 Q3 Managed Services Platform (MSP) proof-of-concept update](https://docs.google.com/document/d/1DSqKqCgXW2m0TCVBmDSasY2Hxb9cp9Uv_NgF4MEfAto/edit) for more details on things we will be adding to MSP.
 
-## Creating and configuring services
+## Building a new service
+
+Before deploying a service, you will need to build it!
+The Core Services team recommends building your service in Go to leverage the service initialization and runtime boilerplate provided by the standalone [github.com/sourcegraph/sourcegraph/lib/managedservicesplatform](https://github.com/sourcegraph/sourcegraph/tree/main/lib/managedservicesplatform) module.
+
+The `runtime.Start` function outlines the expected "contract" the MSP runtime expects services to fulfill:
+
+```go
+import (
+  "github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
+
+  // Your implementation!
+  "github.com/sourcegraph/my-service/service"
+)
+
+func main() {
+  runtime.Start[service.Config](service.Service{})
+}
+```
+
+In your implementation of `runtime.Service`, the primary entrypoint `Initialize` provides a `runtime.Contract` that is pre-configured with MSP defaults and offers helpers to connecting to MSP-provisioned resources. For example, to serve your service, you must use `(runtime.Contract).Port`, and to get a securely authenticated PostgreSQL connection, you can use `(runtime.Contract).PostgreSQL.OpenDatabase(...)`.
+
+A full example service is available in [`cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/main/cmd/msp-example) that makes use of most MSP functionality.
+
+## Creating and configuring infrastructure for services
 
 Refer to the [sourcegraph/managed-services README](https://github.com/sourcegraph/managed-services/blob/main/README.md) for all documentation for creating configuring MSP deployments and using `sg msp`.
 


### PR DESCRIPTION
Initial BQ support was added in https://github.com/sourcegraph/sourcegraph/pull/58541