### PR TITLE
Updating team page - removing departing teammate

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -61,37 +61,25 @@ joe_chen:
   links: '[LinkedIn](https://www.linkedin.com/in/jiahua-joe-chen-86218a81/)'
   description: Joe lives in his little dark room. Prior to Sourcegraph, Joe created the Gogs project, a painless self-hosted Git service. Joe graduated with a MS in Software Development from Boston University.
 
-thorsten_ball:
-  name: Thorsten Ball
-  pronouns: he/him
-  role: Engineering Manager, Source & APIs
-  reports_to: eng_lead
-  manager_role_slug: engineering_manager_source_apis
-  location: Aschaffenburg, Bavaria, Germany 🇩🇪
-  github: mrnugget
-  email: thorsten@sourcegraph.com
-  links: '[@thorstenball](https://twitter.com/thorstenball), [LinkedIn](https://www.linkedin.com/in/thorsten-ball-3142b652), [thorstenball.com](https://thorstenball.com)'
-  description: "Thorsten started his career as a software engineer after dropping out of college where he studied philosophy. Since then he's mainly worked for startups (flinc, ioki) in the mobility space before starting at Sourcegraph. In his spare time, he's also a writer and wrote and self-published [two](https://interpreterbook.com) [books](https://compilerbook.com) about his favorite pet topics: interpreters & compilers. He lives together with his wife and daughter in a small-ish city in Germany. He met his wife, who happened to hail from the same small town in Germany, in Australia while he was working at a shipyard."
-
-thorsten_ball_source:
-  name: Thorsten Ball
-  pronouns: he/him/his
+erika_rice_scherpelz_source:
+  name: Erika Rice Scherpelz
+  pronouns: she/her/hers
   role: Engineering Manager, Source
-  reports_to: eng_lead
+  reports_to: ceo
   manager_role_slug: source_lead
   hide_on_team_page: true
 
-thorsten_ball_apis:
-  name: Thorsten Ball
-  pronouns: he/him/his
+erika_rice_scherpelz_apis:
+  name: Erika Rice Scherpelz
+  pronouns: she/her/hers
   role: Engineering Manager, APIs
   reports_to: eng_lead
   manager_role_slug: apis_lead
   hide_on_team_page: true
 
-thorsten_ball_search_platform:
-  name: Thorsten Ball
-  pronouns: he/him/his
+erika_rice_scherpelz_search_platform:
+  name: Erika Rice Scherpelz
+  pronouns: she/her/hers
   role: Engineering Manager, Search Platform (interim)
   reports_to: eng_lead
   manager_role_slug: search_platform_lead
@@ -1585,7 +1573,7 @@ erika_rice_scherpelz:
   email: erikars@sourcegraph.com
   github: erikars
   pronouns: she/her
-  role: Head of Search
+  role: ceo
   reports_to: eng_lead
   location: Bellevue, Washington, USA 🇺🇸
   links: '[The FLUX Review](https://read.fluxcollective.org/), [LinkedIn](https://www.linkedin.com/in/erikars)'


### PR DESCRIPTION
Updating Thorsten's manager slugs to Erika since his direct reports listed on this page now report into her.