### PR TITLE
Clarify steps for gaining access to dotcom in TFC workspace

### DIFF
--- a/content/departments/engineering/teams/devops/update_sg_website_config.md
+++ b/content/departments/engineering/teams/devops/update_sg_website_config.md
@@ -23,7 +23,7 @@ To update the non-sensitive configuration, follow these steps:
 
 Our site configuration contains many secrets like OAuth credentials. It is [stored in GSM](https://console.cloud.google.com/security/secret-manager/secret/SITE_JSON/versions?project=sourcegraph-dev) in the `sourcegraph-dev` project. The secrets are synced to the cluster using [Terraform](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/infrastructure/-/blob/cloud/gsm-secrets.tf), and is managed in the [dotcom workspace](https://app.terraform.io/app/sourcegraph/workspaces/dotcom) on Terraform Cloud.
 
-> [!NOTE] syncing new secret versions requires access to Terraform Cloud. Reach out to #ask-security to get access, or request #discuss-dev-infra or #ask-security to run the workspace for you.
+> [!NOTE] syncing new secret versions requires access to Terraform Cloud. You can request access via Entitle, use "Terraform Cloud: Infrastructure - Core Servcies - Member". Or, kindly request someone from #discuss-dev-infra or #discuss-security to run the workspace for you.
 
 To update secrets in site config for our Dotcom deployment, follow these steps:
 


### PR DESCRIPTION
- Update the Slack channel for #discuss-security
- Mention that you can self-service gaining access via Entitle

Does this look/sound right?

