### PR TITLE
chores(nix): Add flake support for running the dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Ask in the [#handbook channel](https://app.slack.com/client/T02FSM7DL/CQ44Y7F4G)
 1. Install [asdf](https://asdf-vm.com/)
 1. Run `asdf plugin add nodejs && asdf plugin add pnpm && asdf install`
 
+### Using Nix
+
+1. Install [Nix](https://nixos.org/download) and [enable flakes](https://nixos.wiki/wiki/Flakes) or use the [Determinate Systems Installer](https://github.com/DeterminateSystems/nix-installer)
+2. Run `nix shell`
+
 ### Running the website locally
 
 Run:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710159071,
+        "narHash": "sha256-CT0WKgcmlcWZPZL/sSSICN/Vbm4Of0ZDgxc0GFf6sYU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0fbcc4b2e8571f4af39be41752581ea09dd9ab06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils/";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+    (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+        with pkgs;
+        {
+          devShells.default = mkShell {
+            buildInputs = [ pkgs.nodejs pkgs.nodePackages.pnpm ];
+          };
+        }
+      );
+}


### PR DESCRIPTION
Added a flake.nix which includes `nodejs` and `pnpm` so that development can happen with Nix instead of `asdf`

Included updates to the README to describe the process