### PR TITLE
core-services: refresh team page

### DIFF
--- a/content/departments/engineering/teams/core-services/index.md
+++ b/content/departments/engineering/teams/core-services/index.md
@@ -1,6 +1,20 @@
 # Core Services Team
 
-Proposed [team charter](https://docs.google.com/document/d/1fBUQ0oM5yncXX6nLL0paUsCsM5DdNFIMsVCdsAc8jgE/edit#heading=h.9gynem1vq4vu).
+The Sourcegraph Core Services team:
+
+- Builds tooling and operate infrastructure that enables Sourcegraph Engineers to launch and support their own customer-facing services
+- Operates shared/company-wide services
+
+Our mid-term goals are to:
+
+- Build robust tooling, infrastructure, and best practices for Sourcegraph-managed services
+- Support services operated by other teams on infrastructure and tooling we built
+- Build new services required to make Sourcegraph/Cody successful
+- Support existing services with custom infrastructure, and eventually enable migration to standardised architecture - in particular, strip Sourcegraph.com down into a "plain old Sourcegraph instance" so we can more easily migrate it to standardised architecture
+
+For specific, current examples of our work and ownership, see [Ownership areas](#ownership-areas) and [go/whodoinotify, filtering by the "Core Services" team](https://www.appsheet.com/start/24237f2b-0a37-45c8-bd7c-c14d35d2c811?platform=desktop#viewStack%5B0%5D%5Bidentifier%5D%5BType%5D=Control&viewStack%5B0%5D%5Bidentifier%5D%5BName%5D=Services&viewStack%5B0%5D%5BmutableState%5D%5BControlName%5D=Services&viewStack%5B0%5D%5BmutableState%5D%5BRoot%5D=fastTable&viewStack%5B0%5D%5BmutableState%5D%5BDataStamp%5D=2024-03-29T12:36:37.6658472Z&viewStack%5B0%5D%5BmutableState%5D%5BGroupBy%5D%5B0%5D%5BColumn%5D=Service%20Level&viewStack%5B0%5D%5BmutableState%5D%5BGroupBy%5D%5B0%5D%5BOrder%5D=Ascending&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B0%5D=attribute&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B1%5D=Team&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B2%5D%5B7157b796%5D=true&appName=WhoDoINotify-668547298).
+
+To reach out to us, please use #discuss-core-services.
 
 ## Leadership
 
@@ -10,6 +24,52 @@ Proposed [team charter](https://docs.google.com/document/d/1fBUQ0oM5yncXX6nLL0pa
 
 {{generator:product_team.ship_core_services}}
 
-## [Managed Services](./managed-services/index.md)
+## Ownership areas
 
-## [Google Front End (GFE)](./google-front-end/index.md)
+For detailed ownership, see [go/whodoinotify, filtering by the "Core Services" team](https://www.appsheet.com/start/24237f2b-0a37-45c8-bd7c-c14d35d2c811?platform=desktop#viewStack%5B0%5D%5Bidentifier%5D%5BType%5D=Control&viewStack%5B0%5D%5Bidentifier%5D%5BName%5D=Services&viewStack%5B0%5D%5BmutableState%5D%5BControlName%5D=Services&viewStack%5B0%5D%5BmutableState%5D%5BRoot%5D=fastTable&viewStack%5B0%5D%5BmutableState%5D%5BDataStamp%5D=2024-03-29T12:36:37.6658472Z&viewStack%5B0%5D%5BmutableState%5D%5BGroupBy%5D%5B0%5D%5BColumn%5D=Service%20Level&viewStack%5B0%5D%5BmutableState%5D%5BGroupBy%5D%5B0%5D%5BOrder%5D=Ascending&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B0%5D=attribute&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B1%5D=Team&viewStack%5B0%5D%5BmutableState%5D%5BUserDefinedFilters%5D%5B0%5D%5B2%5D%5B7157b796%5D=true&appName=WhoDoINotify-668547298)
+
+At a higher level, our core ownership areas include:
+
+- [Managed Services Platform (MSP)](./managed-services/platform.md) and [Managed Services](./managed-services/index.md) as a whole:
+  - Tooling to bootstrap and operate new services on cloud infrastructure
+  - Deployment pipelines, observability tooling for managed services
+  - Support infrastructure for existing standalone managed services
+  - API gateway and other API concerns
+- [Sourcegraph Accounts (accounts.sourcegraph.com)](./sams/index.md): Sourcegraph-wide and service-to-service authentication
+- [Telemetry Gateway](../../managed-services/telemetry-gateway.md): Centralised event/analytics proxies and related SDKs
+- [Sourcegraph.com infrastructure](../../dev/process/deployments/instances.md#dotcom):
+  - [Sourcegraph.com playbooks](../../dev/process/deployments/playbooks.md#sourcegraphcom)
+  - [Google Front End (GFE)](./google-front-end/index.md)
+
+## Processes
+
+### Team planning
+
+Planning processes align with those used throughout the [Infrastructure org](../../infrastructure/index.md).
+[go/ship-okrs](https://www.appsheet.com/start/ce3ca2b6-cf8f-4367-a386-28a3e9856cb9#viewStack%5B0%5D%5Bidentifier%5D%5BType%5D=Control&viewStack%5B0%5D%5Bidentifier%5D%5BName%5D=Welcome) tracks all Infrastructure key results and objectives, including Core Services.
+go/ship-okrs also maintains a record of weekly updates towards key results and objectives.
+
+### Issue tracking
+
+The team does issue tracking within the [Core Services GitHub project board (go/core-services-board)](https://github.com/orgs/sourcegraph/projects/405/views/1).
+This board tracks projects from across the Sourcegraph GitHub organization, as we track issues in several repositories based on relevancy:
+
+- [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph): issues related to services housed in the monorepo (Telemetry Gateway, Pings, etc.). All Core Services issues in this repository are labelled `team/core-services`.
+- Private: [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services): issues related to Managed Services Platform (MSP)
+- Private: [`sourcegraph/sourcegraph-accounts`](https://github.com/sourcegraph/sourcegraph-accounts): issues related to Sourcegraph Accounts Management System
+
+How board columns should be used are directly documented in column descriptions within the project board.
+
+#### Project views
+
+For key results and objectives derived from [team planning](#team-planning), DRIs are expected to maintain [project views](https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project) within the shared project board with appropriate filters to capture any relevant work (label, "tracked by", and so on).
+These views should be prefixed with `KR:`.
+
+For ad-hoc support with 3 days+ of work, we can choose to create views to track related requests and work, divided by category, for example `Support: Telemetry Gateway`.
+
+### Recurring meetings
+
+The Core Services team hosts a weekly team sync, with meeting notes available [here](https://docs.google.com/document/d/1ZJfSZX3VG3TJ5kXoa72SAdV55udnyt7MsILC1HWduw4/edit).
+Each week we review [issue tracking](#issue-tracking), discuss technical topics, areas of concern, active cross-team discussions, and do some general bantering.
+
+If you have something you would like to discuss synchronously with the team, please reach out to #discuss-core-services and we'd be happy to arrange for you join a session.

--- a/content/departments/engineering/teams/core-services/managed-services/index.md
+++ b/content/departments/engineering/teams/core-services/managed-services/index.md
@@ -1,21 +1,39 @@
-# Managed Services
+# Core Services Managed Services
 
-A big part of the Core Services team is developing and maintaining our managed cloud services infrastructure.
-Going forward, new managed services - internal and external - should aim to be deployed using [MSP (Managed Services Platform)](./platform.md).
+A core part of [Core Services](../index.md) team responsibilities are developing and maintaining our managed cloud services infrastructure.
 
-Guidance for MSP incidents is available in [Managed Services incident response](./incidents.md).
+## Managed Services Platform
+
+The Sourcegraph Managed Services Platform (**MSP**) is the standardized tooling and infrastructure for deploying and operating managed Sourcegraph services.
+Going forward, new managed services built by Sourcegraph - internal and external - should aim to be deployed using MSP.
+To learn more about, see [the Managed Services Platform page](./platform.md).
+
+For a complete listing of managed services, see [Managed Services infrastructure](../../../managed-services/index.md).
 
 ## [Cody Gateway](../../cody/cody-gateway/index.md)
 
-> [!NOTE] Cody Gateway infrastructure is owned by the Core Services team, but the service is owned by #discuss-cody-services.
+> [!NOTE] Only Cody Gateway infrastructure is owned by the Core Services team, but the service is owned by #discuss-cody-services.
+
+Cody Gateway infrastructure is currently a hand-rolled deployment defined in [`sourcegraph/infrastructure/cody-gateway`](https://github.com/sourcegraph/infrastructure/tree/main/cody-gateway).
+This infrastructure setup was a [direct precursor to Managed Services Platform](https://docs.google.com/document/d/1w4ZKg4R05mZGJwGTMBkUWfrFtg4sgwHO4hm-tc0g12w/edit).
 
 ## [Pings service](./pings.md)
 
-## [Telemetry Gateway](./telemetry-gateway.md)
+> [!NOTE] Only Pings infrastructure is owned by the Core Services team, but the service is owned by #discuss-analytics.
+
+The Pings service is the service that collects [ping requests](https://docs.sourcegraph.com/admin/pings) from all Sourcegraph instances, and is available at `pings.sourcegraph.com`.
+
+## [Telemetry Gateway](../../../managed-services/telemetry-gateway.md)
+
+The Telemetry Gateway service is the service that ingests [telemetry v2 events](https://sourcegraph.com/doc/dev/background-information/telemetry) from all Sourcegraph instances, as well as other managed services.
 
 ## [Sourcegraph Accounts Management System](../sams/index.md)
 
+[Sourcegraph Accounts Management System (SAMS)](https://docs.google.com/document/d/16F6uvfM9EknpcuAQQ8kIPOZ9gHo0Lx4lgprw_5sWJEs/edit) is the centralized accounts system for all of the Sourcegraph-operated systems.
+
 ## Sourcergaph.com Google OIDC
+
+> [!WARNING] This has been replaced by [Sourcegraph Accounts Management System](../sams/index.md), which is now the identity provider for Sourcegraph.com logins.
 
 The GCP project that manages our [Google OIDC authentication integration](https://console.cloud.google.com/apis/credentials/oauthclient/394401733494-3ekkk0qr3qvg7b3l1imqcgsh3ej710eq.apps.googleusercontent.com?project=sourcegraph-com-ggl-oidc) ("Sign in with Google") for Sourcergraph.com. We put the integration in a standalone project for a dedicated public-facing [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent?project=sourcegraph-com-ggl-oidc).
 

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -5,6 +5,8 @@ MSP takes a service specification and generates Terraform manifests and adjacent
 
 By adopting MSP for your managed service, it will benefit from [an expanding set of features and integrations](#features), alignment with infrastructure and security best practices at Sourcegraph, and support from the [Core Services team](../index.md).
 
+For interacting with existing MSP services, see [operating services](#operating-services).
+
 ## Use cases
 
 Any "managed service" - internal or customer-facing, for testing or for production - can be operated on Managed Services Platform!


### PR DESCRIPTION
Our team page is quite naked at the moment, this gives it a much-needed refresh:

1. Team abstract + mid-term goals, based loosely on @rafax's [proposed charter](https://docs.google.com/document/d/1fBUQ0oM5yncXX6nLL0paUsCsM5DdNFIMsVCdsAc8jgE/edit#heading=h.9gynem1vq4vu) a while ago and some stuff off the top of my head
2. `Ownership areas`, which links to go/ship-okrs but also gives a high-level overview of things we own
3. `Processes`, which covers: `Team planning`, `Issue tracking` and `Project views, and `Recurring meetings` to start
4. Refresh the team managed services page, renaming it to `Core Services Managed Services` to avoid confusion with the other ones

Preview: https://deploy-preview-8795--sourcegraph-handbook.netlify.app//departments/engineering/teams/core-services/