### PR TITLE
msp: rollout docs

### DIFF
--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.683871 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.536381 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Build Tracker infrastructure.
@@ -17,25 +17,25 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                       |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                              |
-| Owners           | **dev-experience**                                                                                                                                                            |
-| Service kind     | Cloud Run service                                                                                                                                                             |
-| Environments     | [prod](#prod)                                                                                                                                                                 |
-| Docker image     | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                                                                     |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker)                                          |
-| Rollout Pipeline | [build-tracker-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
+|     PROPERTY     |                                                                                     DETAILS                                                                                     |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                                |
+| Owners           | **dev-experience**                                                                                                                                                              |
+| Service kind     | Cloud Run service                                                                                                                                                               |
+| Environments     | [prod](#prod)                                                                                                                                                                   |
+| Docker image     | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                                                                       |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker)                                            |
+| Rollout Pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 
 ## Environments
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
-| Deployment Type     | rollout                                                                                                |
+| Deployment Type     | `rollout`                                                                                              |
 | Resources           | [prod Redis](#prod-redis)                                                                              |
 | Slack notifications | [#alerts-build-tracker-prod](https://sourcegraph.slack.com/archives/alerts-build-tracker-prod)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=build-tracker-prod-59bf) |
@@ -45,8 +45,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -56,8 +56,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -71,8 +71,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -28,8 +28,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Rollout
 
-|     PROPERTY      |                                                                                     DETAILS                                                                                     |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 | Stages            | [prod](#prod)                                                                                                                                                                   |
 
@@ -39,8 +39,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment type     | `rollout`                                                                                              |
@@ -53,8 +53,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -64,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -79,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.536381 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.663413 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Build Tracker infrastructure.
@@ -17,22 +17,30 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                                |
-| Owners           | **dev-experience**                                                                                                                                                              |
-| Service kind     | Cloud Run service                                                                                                                                                               |
-| Environments     | [prod](#prod)                                                                                                                                                                   |
-| Docker image     | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                                                                       |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker)                                            |
-| Rollout Pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
+| Owners       | **dev-experience**                                                                                                                   |
+| Service kind | Cloud Run service                                                                                                                    |
+| Environments | [prod](#prod)                                                                                                                        |
+| Docker image | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                            |
+| Source code  | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker) |
+
+## Rollout
+
+|     PROPERTY      |                                                                                     DETAILS                                                                                     |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
+| Stages            | [prod](#prod)                                                                                                                                                                   |
+
+Changes to Build Tracker are continuously delivered to the first stage ([prod](#prod)) of the delivery pipeline.
 
 ## Environments
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | `rollout`                                                                                              |
@@ -45,8 +53,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -56,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -71,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                     DETAILS                                                                                     |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                                |
 | Owners           | **dev-experience**                                                                                                                                                              |
 | Service kind     | Cloud Run service                                                                                                                                                               |
@@ -31,8 +31,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | `rollout`                                                                                              |
@@ -45,8 +45,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -56,8 +56,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -71,8 +71,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.663413 +0000 UTC
+Last updated: 2024-04-05 21:23:32.75374 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -28,8 +28,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Rollout
 
-| PROPERTY          | DETAILS                                                                                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                     DETAILS                                                                                     |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 | Stages            | [prod](#prod)                                                                                                                                                                   |
 
@@ -39,11 +39,11 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
-| Deployment Type     | `rollout`                                                                                              |
+| Deployment type     | `rollout`                                                                                              |
 | Resources           | [prod Redis](#prod-redis)                                                                              |
 | Slack notifications | [#alerts-build-tracker-prod](https://sourcegraph.slack.com/archives/alerts-build-tracker-prod)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=build-tracker-prod-59bf) |
@@ -53,8 +53,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -64,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -79,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -28,8 +28,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Rollout
 
-|     PROPERTY      |                                                                                     DETAILS                                                                                     |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 | Stages            | [prod](#prod)                                                                                                                                                                   |
 
@@ -39,8 +39,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | `rollout`                                                                                              |
@@ -53,8 +53,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -64,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -79,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.054341 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.683871 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Build Tracker infrastructure.
@@ -17,23 +17,25 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
-| Owners       | **dev-experience**                                                                                                                   |
-| Service kind | Cloud Run service                                                                                                                    |
-| Environments | [prod](#prod)                                                                                                                        |
-| Docker image | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                            |
-| Source code  | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker) |
+|     PROPERTY     |                                                                                    DETAILS                                                                                    |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                              |
+| Owners           | **dev-experience**                                                                                                                                                            |
+| Service kind     | Cloud Run service                                                                                                                                                             |
+| Environments     | [prod](#prod)                                                                                                                                                                 |
+| Docker image     | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                                                                     |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker)                                          |
+| Rollout Pipeline | [build-tracker-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 
 ## Environments
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
+| Deployment Type     | rollout                                                                                                |
 | Resources           | [prod Redis](#prod-redis)                                                                              |
 | Slack notifications | [#alerts-build-tracker-prod](https://sourcegraph.slack.com/archives/alerts-build-tracker-prod)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=build-tracker-prod-59bf) |
@@ -43,8 +45,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +56,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -69,8 +71,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.75374 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.786117 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Build Tracker infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -26,10 +26,10 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Docker image | `us.gcr.io/sourcegraph-dev/build-tracker`                                                                                            |
 | Source code  | [`github.com/sourcegraph/sourcegraph` - `dev/build-tracker`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/dev/build-tracker) |
 
-## Rollout
+## Rollouts
 
-| PROPERTY          | DETAILS                                                                                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                     DETAILS                                                                                     |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 | Stages            | [prod](#prod)                                                                                                                                                                   |
 
@@ -39,8 +39,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment type     | `rollout`                                                                                              |
@@ -53,8 +53,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -64,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -79,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))     |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -28,8 +28,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Rollouts
 
-|     PROPERTY      |                                                                                     DETAILS                                                                                     |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`build-tracker-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/build-tracker-us-central1-rollout?project=build-tracker-prod-59bf) |
 | Stages            | [prod](#prod)                                                                                                                                                                   |
 
@@ -39,8 +39,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment type     | `rollout`                                                                                              |
@@ -53,8 +53,8 @@ Changes to Build Tracker are continuously delivered to the first stage ([prod](#
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -64,8 +64,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -79,8 +79,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/build-tracker.md
+++ b/content/departments/engineering/managed-services/build-tracker.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                    DETAILS                                                                                    |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `build-tracker` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/build-tracker/service.yaml))                                              |
 | Owners           | **dev-experience**                                                                                                                                                            |
 | Service kind     | Cloud Run service                                                                                                                                                             |
@@ -31,8 +31,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`build-tracker-prod-59bf`](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | rollout                                                                                                |
@@ -45,8 +45,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -56,8 +56,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Build Tracker prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=build-tracker-prod-59bf) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=build-tracker-prod-59bf)                                                                                                                                                                                                                                          |
@@ -71,8 +71,8 @@ sg msp logs build-tracker prod
 
 #### prod Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=build-tracker-prod-59bf) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                               |
-|---------------------|----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
 | Deployment Type     | `subscription`                                                                                     |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY |                                                         DETAILS                                                         |
-|----------|-------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.666325 +0000 UTC
+Last updated: 2024-04-05 21:23:32.754931 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                               |
+|---------------------|----------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
-| Deployment Type     | `subscription`                                                                                     |
+| Deployment type     | `subscription`                                                                                     |
 | Resources           | [prod Redis](#prod-redis)                                                                          |
 | Slack notifications | [#alerts-cloud-ops-prod](https://sourcegraph.slack.com/archives/alerts-cloud-ops-prod)             |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-ops-prod-dd32) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                         DETAILS                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                               |
-|---------------------|----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
 | Deployment type     | `subscription`                                                                                     |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY |                                                         DETAILS                                                         |
-|----------|-------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.055697 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.685004 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Cloud Ops Dashboard infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                               |
+|---------------------|----------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
+| Deployment Type     | subscription                                                                                       |
 | Resources           | [prod Redis](#prod-redis)                                                                          |
 | Slack notifications | [#alerts-cloud-ops-prod](https://sourcegraph.slack.com/archives/alerts-cloud-ops-prod)             |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-ops-prod-dd32) |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -69,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                         DETAILS                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.754931 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.787559 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Cloud Ops Dashboard infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                               |
+|---------------------|----------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
 | Deployment type     | `subscription`                                                                                     |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                         DETAILS                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                               |
-|---------------------|----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
 | Deployment Type     | subscription                                                                                       |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY |                                                         DETAILS                                                         |
-|----------|-------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.685004 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.537472 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Cloud Ops Dashboard infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                               |
+|---------------------|----------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
-| Deployment Type     | subscription                                                                                       |
+| Deployment Type     | `subscription`                                                                                     |
 | Resources           | [prod Redis](#prod-redis)                                                                          |
 | Slack notifications | [#alerts-cloud-ops-prod](https://sourcegraph.slack.com/archives/alerts-cloud-ops-prod)             |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-ops-prod-dd32) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                         DETAILS                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-ops.md
+++ b/content/departments/engineering/managed-services/cloud-ops.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.537472 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.666325 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Cloud Ops Dashboard infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-ops` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-ops/service.yaml))   |
 | Owners       | **cloud**                                                                                                                  |
 | Service kind | Cloud Run service                                                                                                          |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                            |
-| ------------------- | -------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                               |
+|---------------------|----------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-ops-prod-dd32`](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)          |
 | Category            | **internal**                                                                                       |
 | Deployment Type     | `subscription`                                                                                     |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Ops Dashboard prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-ops-prod-dd32) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-ops-prod-dd32)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs cloud-ops prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                         DETAILS                                                         |
+|----------|-------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=cloud-ops-prod-dd32) |
 
 #### prod Terraform Cloud

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.538339 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.667309 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Cloud Relay infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                           DETAILS                                                            |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                                |
+|---------------------|------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
 | Deployment Type     | `manual`                                                                                             |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.667309 +0000 UTC
+Last updated: 2024-04-05 21:23:32.755863 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                           DETAILS                                                            |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                                |
+|---------------------|------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
-| Deployment Type     | `manual`                                                                                             |
+| Deployment type     | `manual`                                                                                             |
 | Resources           |                                                                                                      |
 | Slack notifications | [#alerts-cloud-relay-prod](https://sourcegraph.slack.com/archives/alerts-cloud-relay-prod)           |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-relay-prod-bd4c) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.755863 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.788768 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Cloud Relay infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                           DETAILS                                                            |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                                |
+|---------------------|------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
 | Deployment type     | `manual`                                                                                             |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.685847 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.538339 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Cloud Relay infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                           DETAILS                                                            |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                                |
+|---------------------|------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
-| Deployment Type     | manual                                                                                               |
+| Deployment Type     | `manual`                                                                                             |
 | Resources           |                                                                                                      |
 | Slack notifications | [#alerts-cloud-relay-prod](https://sourcegraph.slack.com/archives/alerts-cloud-relay-prod)           |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-relay-prod-bd4c) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                           DETAILS                                                            |
-|--------------|------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                                |
-|---------------------|------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
 | Deployment type     | `manual`                                                                                             |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                           DETAILS                                                            |
-|--------------|------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                                |
-|---------------------|------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
 | Deployment Type     | `manual`                                                                                             |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.056963 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.685847 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Cloud Relay infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                           DETAILS                                                            |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                                |
+|---------------------|------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
+| Deployment Type     | manual                                                                                               |
 | Resources           |                                                                                                      |
 | Slack notifications | [#alerts-cloud-relay-prod](https://sourcegraph.slack.com/archives/alerts-cloud-relay-prod)           |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cloud-relay-prod-bd4c) |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cloud-relay.md
+++ b/content/departments/engineering/managed-services/cloud-relay.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                           DETAILS                                                            |
-|--------------|------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cloud-relay` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cloud-relay/service.yaml)) |
 | Owners       | **cloud**                                                                                                                    |
 | Service kind | Cloud Run service                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                                |
-|---------------------|------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cloud-relay-prod-bd4c`](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)        |
 | Category            | **internal**                                                                                         |
 | Deployment Type     | manual                                                                                               |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cloud Relay prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                              DETAILS                                                                                                                                                               |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cloud-relay-prod-bd4c) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cloud-relay-prod-bd4c)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                              DETAILS                                                               |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | manual                                                                                                 |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,8 +95,8 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
 | Deployment Type     | manual                                                                                                  |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.686832 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.539209 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Cody Analytics infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                              DETAILS                                                               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
-| Deployment Type     | manual                                                                                                 |
+| Deployment Type     | `manual`                                                                                               |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-cody-analytics-dev](https://sourcegraph.slack.com/archives/alerts-cody-analytics-dev)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-dev-bd34) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,11 +95,11 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
-| Deployment Type     | manual                                                                                                  |
+| Deployment Type     | `manual`                                                                                                |
 | Resources           |                                                                                                         |
 | Slack notifications | [#alerts-cody-analytics-prod](https://sourcegraph.slack.com/archives/alerts-cody-analytics-prod)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-prod-da5a) |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.539209 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.6684 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Cody Analytics infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                              DETAILS                                                               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | `manual`                                                                                               |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,8 +95,8 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
 | Deployment Type     | `manual`                                                                                                |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.6684 +0000 UTC
+Last updated: 2024-04-05 21:23:32.756783 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                              DETAILS                                                               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
-| Deployment Type     | `manual`                                                                                               |
+| Deployment type     | `manual`                                                                                               |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-cody-analytics-dev](https://sourcegraph.slack.com/archives/alerts-cody-analytics-dev)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-dev-bd34) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,11 +95,11 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
-| Deployment Type     | `manual`                                                                                                |
+| Deployment type     | `manual`                                                                                                |
 | Resources           |                                                                                                         |
 | Slack notifications | [#alerts-cody-analytics-prod](https://sourcegraph.slack.com/archives/alerts-cody-analytics-prod)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-prod-da5a) |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                              DETAILS                                                               |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
 | Deployment Type     | `manual`                                                                                               |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,8 +95,8 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
 | Deployment Type     | `manual`                                                                                                |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.058102 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.686832 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Cody Analytics infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                              DETAILS                                                               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
+| Deployment Type     | manual                                                                                                 |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-cody-analytics-dev](https://sourcegraph.slack.com/archives/alerts-cody-analytics-dev)         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-dev-bd34) |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -94,10 +95,11 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
+| Deployment Type     | manual                                                                                                  |
 | Resources           |                                                                                                         |
 | Slack notifications | [#alerts-cody-analytics-prod](https://sourcegraph.slack.com/archives/alerts-cody-analytics-prod)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=cody-analytics-prod-da5a) |
@@ -107,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -118,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.756783 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.789779 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Cody Analytics infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                            |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                              DETAILS                                                               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
 | Deployment type     | `manual`                                                                                               |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,8 +95,8 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
 | Deployment type     | `manual`                                                                                                |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/cody-analytics.md
+++ b/content/departments/engineering/managed-services/cody-analytics.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                              DETAILS                                                               |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `cody-analytics` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/cody-analytics/service.yaml)) |
 | Owners       | **cody-strat**                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                  |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`cody-analytics-dev-bd34`](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)      |
 | Category            | **test**                                                                                               |
 | Deployment type     | `manual`                                                                                               |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Cody Analytics dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-dev-bd34) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-dev-bd34)                                                                                                                                                                                                                                          |
@@ -95,8 +95,8 @@ sg msp tfc view cody-analytics dev
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`cody-analytics-prod-da5a`](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)     |
 | Category            | **external**                                                                                            |
 | Deployment type     | `manual`                                                                                                |
@@ -109,8 +109,8 @@ sg msp tfc view cody-analytics dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -120,8 +120,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Analytics prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=cody-analytics-prod-da5a) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=cody-analytics-prod-da5a)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                 DETAILS                                                                 |
-|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                              |
-|---------------------|---------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
 | Deployment Type     | manual                                                                                            |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.540636 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.669822 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Entitler infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                 DETAILS                                                                 |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                              |
+|---------------------|---------------------------------------------------------------------------------------------------|
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
 | Deployment Type     | `manual`                                                                                          |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                 DETAILS                                                                 |
-|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                              |
-|---------------------|---------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
 | Deployment type     | `manual`                                                                                          |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.688226 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.540636 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Entitler infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                 DETAILS                                                                 |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                              |
+|---------------------|---------------------------------------------------------------------------------------------------|
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
-| Deployment Type     | manual                                                                                            |
+| Deployment Type     | `manual`                                                                                          |
 | Resources           |                                                                                                   |
 | Slack notifications | [#alerts-entitler-prod](https://sourcegraph.slack.com/archives/alerts-entitler-prod)              |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=entitler-prod-0516) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.758125 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.791212 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Entitler infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                 DETAILS                                                                 |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                              |
+|---------------------|---------------------------------------------------------------------------------------------------|
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
 | Deployment type     | `manual`                                                                                          |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                 DETAILS                                                                 |
-|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                              DETAILS                                              |
-|---------------------|---------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
 | Deployment Type     | `manual`                                                                                          |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.059926 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.688226 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Entitler infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                 DETAILS                                                                 |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                              |
+|---------------------|---------------------------------------------------------------------------------------------------|
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
+| Deployment Type     | manual                                                                                            |
 | Resources           |                                                                                                   |
 | Slack notifications | [#alerts-entitler-prod](https://sourcegraph.slack.com/archives/alerts-entitler-prod)              |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=entitler-prod-0516) |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/entitler.md
+++ b/content/departments/engineering/managed-services/entitler.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.669822 +0000 UTC
+Last updated: 2024-04-05 21:23:32.758125 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                 DETAILS                                                                 |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `entitler` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/entitler/service.yaml))                  |
 | Owners       | **security**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                       |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                              DETAILS                                              |
+|---------------------|---------------------------------------------------------------------------------------------------|
 | Project ID          | [`entitler-prod-0516`](https://console.cloud.google.com/run?project=entitler-prod-0516)           |
 | Category            | **internal**                                                                                      |
-| Deployment Type     | `manual`                                                                                          |
+| Deployment type     | `manual`                                                                                          |
 | Resources           |                                                                                                   |
 | Slack notifications | [#alerts-entitler-prod](https://sourcegraph.slack.com/archives/alerts-entitler-prod)              |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=entitler-prod-0516) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Entitler prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                             DETAILS                                                                                                                                                             |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=entitler-prod-0516)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=entitler-prod-0516) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=entitler-prod-0516)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.689009 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.541482 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Cody Gatekeeper infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                               |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
-| Deployment Type     | subscription                                                                                        |
+| Deployment Type     | `subscription`                                                                                      |
 | Resources           |                                                                                                     |
 | Slack notifications | [#alerts-gatekeeper-prod](https://sourcegraph.slack.com/archives/alerts-gatekeeper-prod)            |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=gatekeeper-prod-1c93) |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.758936 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.79204 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Cody Gatekeeper infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                               |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
 | Deployment type     | `subscription`                                                                                      |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.060906 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.689009 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Cody Gatekeeper infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                               |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
+| Deployment Type     | subscription                                                                                        |
 | Resources           |                                                                                                     |
 | Slack notifications | [#alerts-gatekeeper-prod](https://sourcegraph.slack.com/archives/alerts-gatekeeper-prod)            |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=gatekeeper-prod-1c93) |
@@ -41,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -52,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
 | Deployment Type     | subscription                                                                                        |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.541482 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.670631 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Cody Gatekeeper infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                               |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
 | Deployment Type     | `subscription`                                                                                      |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
 | Deployment Type     | `subscription`                                                                                      |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                          DETAILS                                                           |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                               DETAILS                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
 | Deployment type     | `subscription`                                                                                      |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/gatekeeper.md
+++ b/content/departments/engineering/managed-services/gatekeeper.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.670631 +0000 UTC
+Last updated: 2024-04-05 21:23:32.758936 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                          DETAILS                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `gatekeeper` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/gatekeeper/service.yaml)) |
 | Owners       | **cody-services**                                                                                                          |
 | Service kind | Cloud Run job                                                                                                              |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                               DETAILS                                               |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | Project ID          | [`gatekeeper-prod-1c93`](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)    |
 | Category            | **internal**                                                                                        |
-| Deployment Type     | `subscription`                                                                                      |
+| Deployment type     | `subscription`                                                                                      |
 | Resources           |                                                                                                     |
 | Slack notifications | [#alerts-gatekeeper-prod](https://sourcegraph.slack.com/archives/alerts-gatekeeper-prod)            |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=gatekeeper-prod-1c93) |
@@ -42,8 +42,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +53,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Cody Gatekeeper prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run job](https://console.cloud.google.com/run/jobs?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                      |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_job%22;summaryFields=labels%252F%2522run.googleapis.com%252Fexecution_name%2522,jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=gatekeeper-prod-1c93) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=gatekeeper-prod-1c93)                                                                                                                                                                                                                                     |

--- a/content/departments/engineering/managed-services/index.md
+++ b/content/departments/engineering/managed-services/index.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.700757 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.553025 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 These pages contain generated operational guidance for the infrastructure of the 13 [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services (across 19 environments) currently in operation at Sourcegraph.

--- a/content/departments/engineering/managed-services/index.md
+++ b/content/departments/engineering/managed-services/index.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.553025 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.682136 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 These pages contain generated operational guidance for the infrastructure of the 13 [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services (across 19 environments) currently in operation at Sourcegraph.

--- a/content/departments/engineering/managed-services/index.md
+++ b/content/departments/engineering/managed-services/index.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.077069 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.700757 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 These pages contain generated operational guidance for the infrastructure of the 13 [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services (across 19 environments) currently in operation at Sourcegraph.

--- a/content/departments/engineering/managed-services/index.md
+++ b/content/departments/engineering/managed-services/index.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.682136 +0000 UTC
+Last updated: 2024-04-05 21:23:32.770792 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 

--- a/content/departments/engineering/managed-services/index.md
+++ b/content/departments/engineering/managed-services/index.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.770792 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.803917 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 These pages contain generated operational guidance for the infrastructure of the 13 [Managed Services Platform (MSP)](../teams/core-services/managed-services/platform.md) services (across 19 environments) currently in operation at Sourcegraph.

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                   DETAILS                                                                                   |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                                |
 | Owners           | **core-services**                                                                                                                                                           |
 | Service kind     | Cloud Run service                                                                                                                                                           |
@@ -38,8 +38,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -51,8 +51,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -62,8 +62,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -77,14 +77,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -103,8 +103,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -136,8 +136,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-|      PROPERTY       |                                                                    DETAILS                                                                    |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                                     |
@@ -150,8 +150,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -161,8 +161,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -176,14 +176,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                |
-|-----------|-------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -202,8 +202,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.689915 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.54237 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for MSP Testbed infrastructure.
@@ -17,15 +17,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                              |
-| Owners           | **core-services**                                                                                                                                                         |
-| Service kind     | Cloud Run service                                                                                                                                                         |
-| Environments     | [test](#test), [robert](#robert)                                                                                                                                          |
-| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                   |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                          |
-| Rollout Pipeline | [msp-testbed-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
+|     PROPERTY     |                                                                                   DETAILS                                                                                   |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                                |
+| Owners           | **core-services**                                                                                                                                                           |
+| Service kind     | Cloud Run service                                                                                                                                                           |
+| Environments     | [test](#test), [robert](#robert)                                                                                                                                            |
+| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                     |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                            |
+| Rollout Pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/README.md
@@ -38,11 +38,11 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ### test
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
-| Deployment Type     | rollout                                                                                                                           |
+| Deployment Type     | `rollout`                                                                                                                         |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |
@@ -51,8 +51,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -62,8 +62,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -77,14 +77,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -103,8 +103,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -136,11 +136,11 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-| PROPERTY            | DETAILS                                                                                                                                       |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                                    DETAILS                                                                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
-| Deployment Type     | rollout                                                                                                                                       |
+| Deployment Type     | `rollout`                                                                                                                                     |
 | Resources           | [robert Redis](#robert-redis), [robert PostgreSQL instance](#robert-postgresql-instance), [robert BigQuery dataset](#robert-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-robert](https://sourcegraph.slack.com/archives/alerts-msp-testbed-robert)                                                |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-robert-7be9)                                        |
@@ -150,8 +150,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -161,8 +161,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -176,14 +176,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                               |
-| --------- | ----------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                DETAILS                                                |
+|-----------|-------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -202,8 +202,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.54237 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.671578 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for MSP Testbed infrastructure.
@@ -17,15 +17,14 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                                |
-| Owners           | **core-services**                                                                                                                                                           |
-| Service kind     | Cloud Run service                                                                                                                                                           |
-| Environments     | [test](#test), [robert](#robert)                                                                                                                                            |
-| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                     |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                            |
-| Rollout Pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
+|   PROPERTY   |                                                             DETAILS                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
+| Owners       | **core-services**                                                                                                                |
+| Service kind | Cloud Run service                                                                                                                |
+| Environments | [test](#test), [robert](#robert)                                                                                                 |
+| Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
+| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/README.md
@@ -34,12 +33,23 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 This is a test environment used by the Core Services team for experimenting with MSP infrastructure changes.
 Each Core Services teammate generally focuses their experiments on an individual environment of this service.
 
+## Rollout
+
+|     PROPERTY      |                                                                                   DETAILS                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
+| Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
+
+Changes to MSP Testbed are continuously delivered to the first stage ([test](#test)) of the delivery pipeline.
+
+Promotion of a release to the next stage in the pipeline must be done manually using the GCP Delivery pipeline UI.
+
 ## Environments
 
 ### test
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -51,8 +61,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -62,8 +72,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -77,14 +87,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -103,8 +113,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -136,8 +146,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-| PROPERTY            | DETAILS                                                                                                                                       |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                                    DETAILS                                                                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                                     |
@@ -150,8 +160,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -161,8 +171,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -176,14 +186,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                               |
-| --------- | ----------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                DETAILS                                                |
+|-----------|-------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -202,8 +212,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                             DETAILS                                                              |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       | **core-services**                                                                                                                |
 | Service kind | Cloud Run service                                                                                                                |
@@ -35,8 +35,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ## Rollout
 
-|     PROPERTY      |                                                                                   DETAILS                                                                                   |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 | Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
@@ -48,8 +48,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
 | Deployment type     | `rollout`                                                                                                                         |
@@ -61,8 +61,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -72,8 +72,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -87,14 +87,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -113,8 +113,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -146,8 +146,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-|      PROPERTY       |                                                                    DETAILS                                                                    |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                                     |
@@ -160,8 +160,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -171,8 +171,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -186,14 +186,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                |
-|-----------|-------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -212,8 +212,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                             DETAILS                                                              |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       | **core-services**                                                                                                                |
 | Service kind | Cloud Run service                                                                                                                |
@@ -35,8 +35,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ## Rollouts
 
-|     PROPERTY      |                                                                                   DETAILS                                                                                   |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 | Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
@@ -48,8 +48,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **internal**                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                         |
@@ -62,8 +62,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -73,8 +73,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -88,14 +88,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -114,8 +114,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -147,8 +147,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-|      PROPERTY       |                                                                    DETAILS                                                                    |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                                     |
@@ -161,8 +161,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -172,8 +172,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -187,14 +187,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                |
-|-----------|-------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -213,8 +213,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.062254 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.689915 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for MSP Testbed infrastructure.
@@ -17,14 +17,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                          |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
-| Owners       | **core-services**                                                                                                                |
-| Service kind | Cloud Run service                                                                                                                |
-| Environments | [test](#test), [robert](#robert)                                                                                                 |
-| Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
-| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
+|     PROPERTY     |                                                                                  DETAILS                                                                                  |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                              |
+| Owners           | **core-services**                                                                                                                                                         |
+| Service kind     | Cloud Run service                                                                                                                                                         |
+| Environments     | [test](#test), [robert](#robert)                                                                                                                                          |
+| Docker image     | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                                                                   |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example)                                          |
+| Rollout Pipeline | [msp-testbed-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/README.md
@@ -37,10 +38,11 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ### test
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
+| Deployment Type     | rollout                                                                                                                           |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |
@@ -49,8 +51,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -60,8 +62,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -75,14 +77,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -101,8 +103,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -134,10 +136,11 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-| PROPERTY            | DETAILS                                                                                                                                       |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                                    DETAILS                                                                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
+| Deployment Type     | rollout                                                                                                                                       |
 | Resources           | [robert Redis](#robert-redis), [robert PostgreSQL instance](#robert-postgresql-instance), [robert BigQuery dataset](#robert-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-robert](https://sourcegraph.slack.com/archives/alerts-msp-testbed-robert)                                                |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-robert-7be9)                                        |
@@ -147,8 +150,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -158,8 +161,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -173,14 +176,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                               |
-| --------- | ----------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                DETAILS                                                |
+|-----------|-------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -199,8 +202,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                             DETAILS                                                              |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       | **core-services**                                                                                                                |
 | Service kind | Cloud Run service                                                                                                                |
@@ -35,8 +35,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ## Rollout
 
-|     PROPERTY      |                                                                                   DETAILS                                                                                   |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 | Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
@@ -48,8 +48,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -61,8 +61,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -72,8 +72,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -87,14 +87,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -113,8 +113,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -146,8 +146,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-|      PROPERTY       |                                                                    DETAILS                                                                    |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                                     |
@@ -160,8 +160,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -171,8 +171,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -186,14 +186,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                |
-|-----------|-------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -212,8 +212,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                  DETAILS                                                                                  |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))                                              |
 | Owners           | **core-services**                                                                                                                                                         |
 | Service kind     | Cloud Run service                                                                                                                                                         |
@@ -38,8 +38,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ### test
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
 | Deployment Type     | rollout                                                                                                                           |
@@ -51,8 +51,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -62,8 +62,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -77,14 +77,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -103,8 +103,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -136,8 +136,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-|      PROPERTY       |                                                                    DETAILS                                                                    |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment Type     | rollout                                                                                                                                       |
@@ -150,8 +150,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -161,8 +161,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -176,14 +176,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY |                                                           DETAILS                                                           |
-|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                |
-|-----------|-------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -202,8 +202,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-|    PROPERTY     |                                                        DETAILS                                                         |
-|-----------------|------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.759877 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.793129 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for MSP Testbed infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                          |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                             DETAILS                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       | **core-services**                                                                                                                |
 | Service kind | Cloud Run service                                                                                                                |
@@ -33,10 +33,10 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 This is a test environment used by the Core Services team for experimenting with MSP infrastructure changes.
 Each Core Services teammate generally focuses their experiments on an individual environment of this service.
 
-## Rollout
+## Rollouts
 
-| PROPERTY          | DETAILS                                                                                                                                                                     |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                   DETAILS                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 | Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
@@ -48,23 +48,24 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### test
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
-| Category            | **test**                                                                                                                          |
+| Category            | **internal**                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                         |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |
 | Errors              | [Sentry `msp-testbed-test`](https://sourcegraph.sentry.io/projects/msp-testbed-test/)                                             |
 | Domain              | [msp-testbed.sgdev.org](https://msp-testbed.sgdev.org)                                                                            |
+| Cloudflare WAF      | ✅                                                                                                                                |
 
-MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
+MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
-| GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
+| GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
 For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
@@ -72,8 +73,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -87,19 +88,19 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
 > [!NOTE]
-> The [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) is required for BOTH read-only and write access to the database.
+> The [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) is required for BOTH read-only and write access to the database.
 
 To connect to the PostgreSQL instance in this environment, use `sg msp` in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository:
 
@@ -113,8 +114,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -146,8 +147,8 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-| PROPERTY            | DETAILS                                                                                                                                       |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                                    DETAILS                                                                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                                     |
@@ -160,8 +161,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -171,8 +172,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -186,14 +187,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                               |
-| --------- | ----------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                DETAILS                                                |
+|-----------|-------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -212,8 +213,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/msp-testbed.md
+++ b/content/departments/engineering/managed-services/msp-testbed.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.671578 +0000 UTC
+Last updated: 2024-04-05 21:23:32.759877 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                          |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                             DETAILS                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `msp-testbed` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml))     |
 | Owners       | **core-services**                                                                                                                |
 | Service kind | Cloud Run service                                                                                                                |
@@ -35,8 +35,8 @@ Each Core Services teammate generally focuses their experiments on an individual
 
 ## Rollout
 
-| PROPERTY          | DETAILS                                                                                                                                                                     |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                   DETAILS                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`msp-testbed-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/msp-testbed-us-central1-rollout?project=msp-testbed-robert-7be9) |
 | Stages            | [test](#test) -> [robert](#robert)                                                                                                                                          |
 
@@ -48,11 +48,11 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### test
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-test-77589aae45d0`](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                     |
 | Category            | **test**                                                                                                                          |
-| Deployment Type     | `rollout`                                                                                                                         |
+| Deployment type     | `rollout`                                                                                                                         |
 | Resources           | [test Redis](#test-redis), [test PostgreSQL instance](#test-postgresql-instance), [test BigQuery dataset](#test-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-test](https://sourcegraph.slack.com/archives/alerts-msp-testbed-test)                                        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-test-77589aae45d0)                      |
@@ -61,8 +61,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -72,8 +72,8 @@ For Terraform Cloud access, see [test Terraform Cloud](#test-terraform-cloud).
 
 The MSP Testbed test service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-test-77589aae45d0) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-test-77589aae45d0)                                                                                                                                                                                                                                          |
@@ -87,14 +87,14 @@ sg msp logs msp-testbed test
 
 #### test Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-test-77589aae45d0) |
 
 #### test PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-test-77589aae45d0) |
 | Databases | `primary`                                                                                                   |
 
@@ -113,8 +113,8 @@ sg msp pg connect -write-access msp-testbed test
 
 #### test BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-test-77589aae45d0`                                                                                        |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |
@@ -146,11 +146,11 @@ sg msp tfc view msp-testbed test
 
 ### robert
 
-| PROPERTY            | DETAILS                                                                                                                                       |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                                    DETAILS                                                                    |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`msp-testbed-robert-7be9`](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                             |
 | Category            | **test**                                                                                                                                      |
-| Deployment Type     | `rollout`                                                                                                                                     |
+| Deployment type     | `rollout`                                                                                                                                     |
 | Resources           | [robert Redis](#robert-redis), [robert PostgreSQL instance](#robert-postgresql-instance), [robert BigQuery dataset](#robert-bigquery-dataset) |
 | Slack notifications | [#alerts-msp-testbed-robert](https://sourcegraph.slack.com/archives/alerts-msp-testbed-robert)                                                |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-robert-7be9)                                        |
@@ -160,8 +160,8 @@ sg msp tfc view msp-testbed test
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -171,8 +171,8 @@ For Terraform Cloud access, see [robert Terraform Cloud](#robert-terraform-cloud
 
 The MSP Testbed robert service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-robert-7be9) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=msp-testbed-robert-7be9)                                                                                                                                                                                                                                          |
@@ -186,14 +186,14 @@ sg msp logs msp-testbed robert
 
 #### robert Redis
 
-| PROPERTY | DETAILS                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                           DETAILS                                                           |
+|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-robert-7be9) |
 
 #### robert PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                               |
-| --------- | ----------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                DETAILS                                                |
+|-----------|-------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-robert-7be9) |
 | Databases | `primary`                                                                                             |
 
@@ -212,8 +212,8 @@ sg msp pg connect -write-access msp-testbed robert
 
 #### robert BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                        DETAILS                                                         |
+|-----------------|------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `msp-testbed-robert-7be9`                                                                                              |
 | Dataset ID      | `msp_testbed`                                                                                                          |
 | Tables          | [`example`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/example.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.761642 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.794923 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Pings Service infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                       DETAILS                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
 | Deployment type     | `subscription`                                                                                         |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.691524 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.54406 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Pings Service infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                       DETAILS                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
-| Deployment Type     | subscription                                                                                           |
+| Deployment Type     | `subscription`                                                                                         |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-pings-prod](https://sourcegraph.slack.com/archives/alerts-pings-prod)                         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=pings-prod-2f4f73edf1db) |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.064188 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.691524 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Pings Service infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                       DETAILS                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
+| Deployment Type     | subscription                                                                                           |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-pings-prod](https://sourcegraph.slack.com/archives/alerts-pings-prod)                         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=pings-prod-2f4f73edf1db) |
@@ -42,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -53,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.673201 +0000 UTC
+Last updated: 2024-04-05 21:23:32.761642 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                       DETAILS                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
-| Deployment Type     | `subscription`                                                                                         |
+| Deployment type     | `subscription`                                                                                         |
 | Resources           |                                                                                                        |
 | Slack notifications | [#alerts-pings-prod](https://sourcegraph.slack.com/archives/alerts-pings-prod)                         |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=pings-prod-2f4f73edf1db) |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.54406 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.673201 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Pings Service infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                       DETAILS                                                        |
+|--------------|----------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
+|      PROPERTY       |                                                DETAILS                                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------|
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
 | Deployment Type     | `subscription`                                                                                         |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                       DETAILS                                                        |
-|--------------|----------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
 | Deployment type     | `subscription`                                                                                         |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                       DETAILS                                                        |
-|--------------|----------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
 | Deployment Type     | `subscription`                                                                                         |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/pings.md
+++ b/content/departments/engineering/managed-services/pings.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                       DETAILS                                                        |
-|--------------|----------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `pings` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/pings/service.yaml))     |
 | Owners       | **core-services**                                                                                                    |
 | Service kind | Cloud Run service                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                DETAILS                                                 |
-|---------------------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
 | Project ID          | [`pings-prod-2f4f73edf1db`](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)      |
 | Category            | **external**                                                                                           |
 | Deployment Type     | subscription                                                                                           |
@@ -43,8 +43,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +54,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Pings Service prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                               DETAILS                                                                                                                                                                |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=pings-prod-2f4f73edf1db) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=pings-prod-2f4f73edf1db)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.065145 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.692555 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Release Registry infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
+| Deployment Type     | manual                                                                                                   |
 | Resources           | [prod PostgreSQL instance](#prod-postgresql-instance)                                                    |
 | Slack notifications | [#alerts-releaseregistry-prod](https://sourcegraph.slack.com/archives/alerts-releaseregistry-prod)       |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-prod-5421) |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -69,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                 DETAILS                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -114,10 +115,11 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
+| Deployment Type     | subscription                                                                                            |
 | Resources           | [dev PostgreSQL instance](#dev-postgresql-instance)                                                     |
 | Slack notifications | [#alerts-releaseregistry-dev](https://sourcegraph.slack.com/archives/alerts-releaseregistry-dev)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-dev-6bac) |
@@ -127,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -138,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -153,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                DETAILS                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                  |
-|---------------------|----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
 | Deployment Type     | manual                                                                                                   |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                 DETAILS                                                 |
-|-----------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,8 +115,8 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
 | Deployment Type     | subscription                                                                                            |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                 |
-|-----------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.692555 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.544894 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Release Registry infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
-| Deployment Type     | manual                                                                                                   |
+| Deployment Type     | `manual`                                                                                                 |
 | Resources           | [prod PostgreSQL instance](#prod-postgresql-instance)                                                    |
 | Slack notifications | [#alerts-releaseregistry-prod](https://sourcegraph.slack.com/archives/alerts-releaseregistry-prod)       |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-prod-5421) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                 DETAILS                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,11 +115,11 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
-| Deployment Type     | subscription                                                                                            |
+| Deployment Type     | `subscription`                                                                                          |
 | Resources           | [dev PostgreSQL instance](#dev-postgresql-instance)                                                     |
 | Slack notifications | [#alerts-releaseregistry-dev](https://sourcegraph.slack.com/archives/alerts-releaseregistry-dev)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-dev-6bac) |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                DETAILS                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.544894 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.674031 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Release Registry infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
 | Deployment Type     | `manual`                                                                                                 |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                 DETAILS                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,8 +115,8 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
 | Deployment Type     | `subscription`                                                                                          |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                DETAILS                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.674031 +0000 UTC
+Last updated: 2024-04-05 21:23:32.762478 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
-| Deployment Type     | `manual`                                                                                                 |
+| Deployment type     | `manual`                                                                                                 |
 | Resources           | [prod PostgreSQL instance](#prod-postgresql-instance)                                                    |
 | Slack notifications | [#alerts-releaseregistry-prod](https://sourcegraph.slack.com/archives/alerts-releaseregistry-prod)       |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-prod-5421) |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                 DETAILS                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,11 +115,11 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
-| Deployment Type     | `subscription`                                                                                          |
+| Deployment type     | `subscription`                                                                                          |
 | Resources           | [dev PostgreSQL instance](#dev-postgresql-instance)                                                     |
 | Slack notifications | [#alerts-releaseregistry-dev](https://sourcegraph.slack.com/archives/alerts-releaseregistry-dev)        |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=releaseregistry-dev-6bac) |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                DETAILS                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                  |
-|---------------------|----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
 | Deployment type     | `manual`                                                                                                 |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                 DETAILS                                                 |
-|-----------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,8 +115,8 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
 | Deployment type     | `subscription`                                                                                          |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                 |
-|-----------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                               DETAILS                                                                |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                 DETAILS                                                  |
-|---------------------|----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
 | Deployment Type     | `manual`                                                                                                 |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                 DETAILS                                                 |
-|-----------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,8 +115,8 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-|      PROPERTY       |                                                 DETAILS                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
 | Deployment Type     | `subscription`                                                                                          |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                DETAILS                                                 |
-|-----------|--------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/releaseregistry.md
+++ b/content/departments/engineering/managed-services/releaseregistry.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.762478 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.795774 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Release Registry infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                               DETAILS                                                                |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `releaseregistry` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/releaseregistry/service.yaml)) |
 | Owners       | **dev-experience**                                                                                                                   |
 | Service kind | Cloud Run service                                                                                                                    |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-prod-5421`](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)    |
 | Category            | **test**                                                                                                 |
 | Deployment type     | `manual`                                                                                                 |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Release Registry prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                 |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-prod-5421) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-prod-5421)                                                                                                                                                                                                                                          |
@@ -70,8 +70,8 @@ sg msp logs releaseregistry prod
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                 DETAILS                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-prod-5421) |
 | Databases | `releaseregistry`                                                                                       |
 
@@ -115,8 +115,8 @@ sg msp tfc view releaseregistry prod
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                 DETAILS                                                 |
+|---------------------|---------------------------------------------------------------------------------------------------------|
 | Project ID          | [`releaseregistry-dev-6bac`](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)     |
 | Category            | **test**                                                                                                |
 | Deployment type     | `subscription`                                                                                          |
@@ -129,8 +129,8 @@ sg msp tfc view releaseregistry prod
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -140,8 +140,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Release Registry dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                DETAILS                                                                                                                                                                |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=releaseregistry-dev-6bac) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=releaseregistry-dev-6bac)                                                                                                                                                                                                                                          |
@@ -155,8 +155,8 @@ sg msp logs releaseregistry dev
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                DETAILS                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=releaseregistry-dev-6bac) |
 | Databases | `releaseregistry`                                                                                      |
 

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.675935 +0000 UTC
+Last updated: 2024-04-05 21:23:32.764435 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                          |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                                     DETAILS                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
-| Deployment Type     | `subscription`                                                                                                              |
+| Deployment type     | `subscription`                                                                                                              |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-dev](https://sourcegraph.slack.com/archives/alerts-sams-dev)                                                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-dev-bfec)                                |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                      DETAILS                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                           |
+|-----------|---------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,11 +129,11 @@ sg msp tfc view sams dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
-| Deployment Type     | `manual`                                                                                                                          |
+| Deployment type     | `manual`                                                                                                                          |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-prod](https://sourcegraph.slack.com/archives/alerts-sams-prod)                                                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-prod-ywuz)                                     |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| PROPERTY |                                                      DETAILS                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                            |
+|-----------|----------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.546867 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.675935 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Self-Serve Cody infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                          |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                                     DETAILS                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | `subscription`                                                                                                              |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                      DETAILS                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                           |
+|-----------|---------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,8 +129,8 @@ sg msp tfc view sams dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | `manual`                                                                                                                          |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| PROPERTY |                                                      DETAILS                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                            |
+|-----------|----------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.694615 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.546867 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Self-Serve Cody infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                          |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                                     DETAILS                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
-| Deployment Type     | subscription                                                                                                                |
+| Deployment Type     | `subscription`                                                                                                              |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-dev](https://sourcegraph.slack.com/archives/alerts-sams-dev)                                                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-dev-bfec)                                |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                      DETAILS                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                           |
+|-----------|---------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,11 +129,11 @@ sg msp tfc view sams dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
-| Deployment Type     | manual                                                                                                                            |
+| Deployment Type     | `manual`                                                                                                                          |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-prod](https://sourcegraph.slack.com/archives/alerts-sams-prod)                                                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-prod-ywuz)                                     |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| PROPERTY |                                                      DETAILS                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                            |
+|-----------|----------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.764435 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.797776 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Self-Serve Cody infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                          |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                                     DETAILS                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
 | Deployment type     | `subscription`                                                                                                              |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                      DETAILS                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                           |
+|-----------|---------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,8 +129,8 @@ sg msp tfc view sams dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
 | Deployment type     | `manual`                                                                                                                          |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| PROPERTY |                                                      DETAILS                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                            |
+|-----------|----------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.068031 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.694615 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Self-Serve Cody infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                          |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   PROPERTY   |                                                                     DETAILS                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
+| Deployment Type     | subscription                                                                                                                |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-dev](https://sourcegraph.slack.com/archives/alerts-sams-dev)                                                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-dev-bfec)                                |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -69,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                      DETAILS                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                           |
+|-----------|---------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -95,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -128,10 +129,11 @@ sg msp tfc view sams dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
+| Deployment Type     | manual                                                                                                                            |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sams-prod](https://sourcegraph.slack.com/archives/alerts-sams-prod)                                                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sams-prod-ywuz)                                     |
@@ -141,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -152,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -167,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| PROPERTY |                                                      DETAILS                                                       |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                           DETAILS                                            |
+|-----------|----------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -193,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                     DETAILS                                                                      |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | subscription                                                                                                                |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY |                                                      DETAILS                                                      |
-|----------|-------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                           |
+| -------- | ----------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                           |
-|-----------|---------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,8 +129,8 @@ sg msp tfc view sams dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | manual                                                                                                                            |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY |                                                      DETAILS                                                       |
-|----------|--------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------ |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                            |
-|-----------|----------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                      |
+| --------- | -------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                     DETAILS                                                                      |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
 | Deployment type     | `subscription`                                                                                                              |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY |                                                      DETAILS                                                      |
-|----------|-------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                           |
+| -------- | ----------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                           |
-|-----------|---------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,8 +129,8 @@ sg msp tfc view sams dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
 | Deployment type     | `manual`                                                                                                                          |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY |                                                      DETAILS                                                       |
-|----------|--------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------ |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                            |
-|-----------|----------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                      |
+| --------- | -------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sams.md
+++ b/content/departments/engineering/managed-services/sams.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                     DETAILS                                                                      |
-|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Service ID   | `sams` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sams/service.yaml))                                   |
 | Owners       | **cody-plg**                                                                                                                                     |
 | Service kind | Cloud Run service                                                                                                                                |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-dev-bfec`](https://console.cloud.google.com/run?project=sams-dev-bfec)                                               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | `subscription`                                                                                                              |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Self-Serve Cody dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                          DETAILS                                                                                                                                                           |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-dev-bfec)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-dev-bfec) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-dev-bfec)                                                                                                                                                                                                                                          |
@@ -70,14 +70,14 @@ sg msp logs sams dev
 
 #### dev Redis
 
-| PROPERTY |                                                      DETAILS                                                      |
-|----------|-------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                           |
+| -------- | ----------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-dev-bfec) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                           |
-|-----------|---------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-dev-bfec) |
 | Databases | `accounts`, `cody_management`                                                               |
 
@@ -96,8 +96,8 @@ sg msp pg connect -write-access sams dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-dev-bfec`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |
@@ -129,8 +129,8 @@ sg msp tfc view sams dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sams-prod-ywuz`](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | `manual`                                                                                                                          |
@@ -143,8 +143,8 @@ sg msp tfc view sams dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -154,8 +154,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Self-Serve Cody prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                           DETAILS                                                                                                                                                           |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sams-prod-ywuz)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sams-prod-ywuz) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sams-prod-ywuz)                                                                                                                                                                                                                                          |
@@ -169,14 +169,14 @@ sg msp logs sams prod
 
 #### prod Redis
 
-| PROPERTY |                                                      DETAILS                                                       |
-|----------|--------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------ |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sams-prod-ywuz) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                           DETAILS                                            |
-|-----------|----------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                      |
+| --------- | -------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sams-prod-ywuz) |
 | Databases | `accounts`, `cody_management`                                                                |
 
@@ -195,8 +195,8 @@ sg msp pg connect -write-access sams prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                                                                                                                                 DETAILS                                                                                                                                                                                                                                                  |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sams-prod-ywuz`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | Dataset ID      | `sams`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/events.bigquerytable.json), [`cody_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/cody_events.bigquerytable.json), [`subscription_events`](https://github.com/sourcegraph/managed-services/blob/main/services/sams/subscription_events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                          DETAILS                                                                           |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
 | Owners       | **core-services**                                                                                                                                          |
 | Service kind | Cloud Run service                                                                                                                                          |
@@ -33,6 +33,7 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
+
 For Google sign-in abuse protection.
 
 ```zsh
@@ -75,8 +76,8 @@ WHERE id = '<CLIENT_ID>'
 
 ## Rollouts
 
-|     PROPERTY      |                                                                                               DETAILS                                                                                                |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
 
@@ -88,8 +89,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment type     | `rollout`                                                                                                                   |
@@ -102,8 +103,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -113,8 +114,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -128,14 +129,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -154,8 +155,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -187,8 +188,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                         |
@@ -201,8 +202,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -212,8 +213,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -227,14 +228,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY |                                                              DETAILS                                                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                    |
-|-----------|--------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -253,8 +254,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                               DETAILS                                                                                                |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                       |
 | Owners           | **core-services**                                                                                                                                                                                    |
 | Service kind     | Cloud Run service                                                                                                                                                                                    |
@@ -34,6 +34,7 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
+
 For Google sign-in abuse protection.
 
 ```zsh
@@ -78,8 +79,8 @@ WHERE id = '<CLIENT_ID>'
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | `rollout`                                                                                                                   |
@@ -92,8 +93,8 @@ WHERE id = '<CLIENT_ID>'
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -103,8 +104,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -118,14 +119,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -144,8 +145,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -177,8 +178,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -191,8 +192,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -202,8 +203,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -217,14 +218,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY |                                                              DETAILS                                                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                    |
-|-----------|--------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -243,8 +244,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.54905 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.677945 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Sourcegraph Accounts infrastructure.
@@ -17,15 +17,14 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                                              |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                       |
-| Owners           | **core-services**                                                                                                                                                                                    |
-| Service kind     | Cloud Run service                                                                                                                                                                                    |
-| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                           |
-| Docker image     | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                                                                    |
-| Source code      | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server)                                           |
-| Rollout Pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
+|   PROPERTY   |                                                                          DETAILS                                                                           |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
+| Owners       | **core-services**                                                                                                                                          |
+| Service kind | Cloud Run service                                                                                                                                          |
+| Environments | [dev](#dev), [prod](#prod)                                                                                                                                 |
+| Docker image | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                          |
+| Source code  | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/README.md
@@ -34,7 +33,6 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
-
 For Google sign-in abuse protection.
 
 ```zsh
@@ -75,12 +73,23 @@ WHERE id = '<CLIENT_ID>'
    VALUES (now(), now(), <USER_ID>, 'ssc', '{ "roles": ["admin"] }');
    ```
 
+## Rollout
+
+|     PROPERTY      |                                                                                               DETAILS                                                                                                |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
+| Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
+
+Changes to Sourcegraph Accounts are continuously delivered to the first stage ([dev](#dev)) of the delivery pipeline.
+
+Promotion of a release to the next stage in the pipeline must be done manually using the GCP Delivery pipeline UI.
+
 ## Environments
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | `rollout`                                                                                                                   |
@@ -93,8 +102,8 @@ WHERE id = '<CLIENT_ID>'
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -104,8 +113,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -119,14 +128,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -145,8 +154,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -178,8 +187,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -192,8 +201,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -203,8 +212,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -218,14 +227,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                      |
-| --------- | ------------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                   DETAILS                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -244,8 +253,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                          DETAILS                                                                           |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
 | Owners       | **core-services**                                                                                                                                          |
 | Service kind | Cloud Run service                                                                                                                                          |
@@ -33,6 +33,7 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
+
 For Google sign-in abuse protection.
 
 ```zsh
@@ -75,8 +76,8 @@ WHERE id = '<CLIENT_ID>'
 
 ## Rollout
 
-|     PROPERTY      |                                                                                               DETAILS                                                                                                |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
 
@@ -88,8 +89,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment type     | `rollout`                                                                                                                   |
@@ -102,8 +103,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -113,8 +114,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -128,14 +129,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -154,8 +155,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -187,8 +188,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                         |
@@ -201,8 +202,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -212,8 +213,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -227,14 +228,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY |                                                              DETAILS                                                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                    |
-|-----------|--------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -253,8 +254,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                              DETAILS                                                                                               |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                     |
 | Owners           | **core-services**                                                                                                                                                                                  |
 | Service kind     | Cloud Run service                                                                                                                                                                                  |
@@ -34,6 +34,7 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
+
 For Google sign-in abuse protection.
 
 ```zsh
@@ -78,8 +79,8 @@ WHERE id = '<CLIENT_ID>'
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | rollout                                                                                                                     |
@@ -92,8 +93,8 @@ WHERE id = '<CLIENT_ID>'
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -103,8 +104,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -118,14 +119,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -144,8 +145,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -177,8 +178,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | rollout                                                                                                                           |
@@ -191,8 +192,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -202,8 +203,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -217,14 +218,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY |                                                              DETAILS                                                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                    |
-|-----------|--------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -243,8 +244,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.677945 +0000 UTC
+Last updated: 2024-04-05 21:23:32.766586 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                                    |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                          DETAILS                                                                           |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
 | Owners       | **core-services**                                                                                                                                          |
 | Service kind | Cloud Run service                                                                                                                                          |
@@ -33,7 +33,6 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
-
 For Google sign-in abuse protection.
 
 ```zsh
@@ -76,8 +75,8 @@ WHERE id = '<CLIENT_ID>'
 
 ## Rollout
 
-| PROPERTY          | DETAILS                                                                                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                               DETAILS                                                                                                |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
 
@@ -89,11 +88,11 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
-| Deployment Type     | `rollout`                                                                                                                   |
+| Deployment type     | `rollout`                                                                                                                   |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-dev](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-dev)                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-dev-csvc)                |
@@ -103,8 +102,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -114,8 +113,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -129,14 +128,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -155,8 +154,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -188,11 +187,11 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
-| Deployment Type     | `rollout`                                                                                                                         |
+| Deployment type     | `rollout`                                                                                                                         |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-prod](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-prod)                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-prod-csvc)                     |
@@ -202,8 +201,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -213,8 +212,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -228,14 +227,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                      |
-| --------- | ------------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                   DETAILS                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -254,8 +253,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.766586 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.799891 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Sourcegraph Accounts infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                                    |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                          DETAILS                                                                           |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
 | Owners       | **core-services**                                                                                                                                          |
 | Service kind | Cloud Run service                                                                                                                                          |
@@ -33,7 +33,6 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
-
 For Google sign-in abuse protection.
 
 ```zsh
@@ -74,10 +73,10 @@ WHERE id = '<CLIENT_ID>'
    VALUES (now(), now(), <USER_ID>, 'ssc', '{ "roles": ["admin"] }');
    ```
 
-## Rollout
+## Rollouts
 
-| PROPERTY          | DETAILS                                                                                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                               DETAILS                                                                                                |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
 
@@ -89,8 +88,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment type     | `rollout`                                                                                                                   |
@@ -103,8 +102,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -114,8 +113,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -129,14 +128,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -155,8 +154,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -188,8 +187,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment type     | `rollout`                                                                                                                         |
@@ -202,8 +201,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -213,8 +212,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -228,14 +227,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                      |
-| --------- | ------------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                   DETAILS                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -254,8 +253,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                          DETAILS                                                                           |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
 | Owners       | **core-services**                                                                                                                                          |
 | Service kind | Cloud Run service                                                                                                                                          |
@@ -33,6 +33,7 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
+
 For Google sign-in abuse protection.
 
 ```zsh
@@ -75,8 +76,8 @@ WHERE id = '<CLIENT_ID>'
 
 ## Rollout
 
-|     PROPERTY      |                                                                                               DETAILS                                                                                                |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                         |
 
@@ -88,8 +89,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                           DETAILS                                                           |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
 | Deployment Type     | `rollout`                                                                                                                   |
@@ -102,8 +103,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -113,8 +114,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -128,14 +129,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY |                                                              DETAILS                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                           |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -154,8 +155,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -187,8 +188,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-|      PROPERTY       |                                                              DETAILS                                                              |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
 | Deployment Type     | `rollout`                                                                                                                         |
@@ -201,8 +202,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -212,8 +213,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -227,14 +228,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY |                                                              DETAILS                                                               |
-|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY | DETAILS                                                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  |                                                   DETAILS                                                    |
-|-----------|--------------------------------------------------------------------------------------------------------------|
+| PROPERTY  | DETAILS                                                                                                      |
+| --------- | ------------------------------------------------------------------------------------------------------------ |
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -253,8 +254,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.696665 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.54905 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Sourcegraph Accounts infrastructure.
@@ -17,15 +17,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                                            |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                     |
-| Owners           | **core-services**                                                                                                                                                                                  |
-| Service kind     | Cloud Run service                                                                                                                                                                                  |
-| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                         |
-| Docker image     | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                                                                  |
-| Source code      | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server)                                         |
-| Rollout Pipeline | [sourcegraph-accounts-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
+|     PROPERTY     |                                                                                               DETAILS                                                                                                |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                       |
+| Owners           | **core-services**                                                                                                                                                                                    |
+| Service kind     | Cloud Run service                                                                                                                                                                                    |
+| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                           |
+| Docker image     | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                                                                    |
+| Source code      | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server)                                           |
+| Rollout Pipeline | [`sourcegraph-accounts-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/README.md
@@ -34,7 +34,6 @@ Automatically generated from the service README: https://github.com/sourcegraph/
 ### Operators cheat sheet
 
 #### Get email domain stats
-
 For Google sign-in abuse protection.
 
 ```zsh
@@ -79,11 +78,11 @@ WHERE id = '<CLIENT_ID>'
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
-| Deployment Type     | rollout                                                                                                                     |
+| Deployment Type     | `rollout`                                                                                                                   |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-dev](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-dev)                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-dev-csvc)                |
@@ -93,8 +92,8 @@ WHERE id = '<CLIENT_ID>'
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -104,8 +103,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -119,14 +118,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -145,8 +144,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -178,11 +177,11 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
-| Deployment Type     | rollout                                                                                                                           |
+| Deployment Type     | `rollout`                                                                                                                         |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-prod](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-prod)                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-prod-csvc)                     |
@@ -192,8 +191,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -203,8 +202,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -218,14 +217,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                      |
-| --------- | ------------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                   DETAILS                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -244,8 +243,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/sourcegraph-accounts.md
+++ b/content/departments/engineering/managed-services/sourcegraph-accounts.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.070763 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.696665 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Sourcegraph Accounts infrastructure.
@@ -17,23 +17,72 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                                    |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID   | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))             |
-| Owners       | **core-services**                                                                                                                                          |
-| Service kind | Cloud Run service                                                                                                                                          |
-| Environments | [dev](#dev), [prod](#prod)                                                                                                                                 |
-| Docker image | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                          |
-| Source code  | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server) |
+|     PROPERTY     |                                                                                              DETAILS                                                                                               |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `sourcegraph-accounts` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/service.yaml))                                                     |
+| Owners           | **core-services**                                                                                                                                                                                  |
+| Service kind     | Cloud Run service                                                                                                                                                                                  |
+| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                         |
+| Docker image     | `us-central1-docker.pkg.dev/sourcegraph-dev/sourcegraph-accounts/accounts-server`                                                                                                                  |
+| Source code      | [`github.com/sourcegraph/sourcegraph-accounts` - `cmd/accounts-server`](https://github.com/sourcegraph/sourcegraph-accounts/tree/HEAD/cmd/accounts-server)                                         |
+| Rollout Pipeline | [sourcegraph-accounts-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/sourcegraph-accounts-us-central1-rollout?project=sourcegraph-accounts-prod-csvc) |
+
+<!--
+Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/README.md
+-->
+
+### Operators cheat sheet
+
+#### Get email domain stats
+For Google sign-in abuse protection.
+
+```zsh
+$ curl -s \
+        -H "Authorization: Bearer $MANAGEMENT_SECRET" \
+        https://accounts.sourcegraph.com/api/management/v1/email-domain-stats | jq
+```
+
+#### Create a new IdP client
+
+```zsh
+$ curl -s -X POST \
+        -H "Authorization: Bearer $MANAGEMENT_SECRET" \
+        https://accounts.sourcegraph.com/api/management/v1/identity-provider/clients \
+--data '{"name": "<SERVICE NAME>", "scopes": ["<SCOPE>"], "redirect_uris": ["<REDIRECT_URI>"]}' | jq
+```
+
+#### Add new scope to an IdP client
+
+Connect to the "accounts" database:
+
+```sql
+UPDATE idp_clients
+SET scopes = scopes || '["<SCOPE>"]'::jsonb
+WHERE id = '<CLIENT_ID>'
+```
+
+#### Assign SSC admin role
+
+1. Connect to the "accounts" database.
+1. Get the user ID via email:
+   ```sql
+   SELECT user_id FROM emails WHERE email = '<EMAIL>';
+   ```
+1. Insert metadata for `ssc`:
+   ```sql
+   INSERT INTO user_metadata (created_at, updated_at, user_id, scope, metadata)
+   VALUES (now(), now(), <USER_ID>, 'ssc', '{ "roles": ["admin"] }');
+   ```
 
 ## Environments
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                           DETAILS                                                           |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-dev-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)               |
 | Category            | **test**                                                                                                                    |
+| Deployment Type     | rollout                                                                                                                     |
 | Resources           | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-dev](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-dev)                  |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-dev-csvc)                |
@@ -43,8 +92,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +103,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Sourcegraph Accounts dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-dev-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-dev-csvc)                                                                                                                                                                                                                                          |
@@ -69,14 +118,14 @@ sg msp logs sourcegraph-accounts dev
 
 #### dev Redis
 
-| PROPERTY | DETAILS                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-dev-csvc) |
 
 #### dev PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------------------- |
+| PROPERTY  |                                                   DETAILS                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-dev-csvc) |
 | Databases | `accounts`                                                                                                  |
 
@@ -95,8 +144,8 @@ sg msp pg connect -write-access sourcegraph-accounts dev
 
 #### dev BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-dev-csvc`                                                                                                                                                                                                                                        |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |
@@ -128,10 +177,11 @@ sg msp tfc view sourcegraph-accounts dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                              DETAILS                                                              |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`sourcegraph-accounts-prod-csvc`](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                   |
 | Category            | **external**                                                                                                                      |
+| Deployment Type     | rollout                                                                                                                           |
 | Resources           | [prod Redis](#prod-redis), [prod PostgreSQL instance](#prod-postgresql-instance), [prod BigQuery dataset](#prod-bigquery-dataset) |
 | Slack notifications | [#alerts-sourcegraph-accounts-prod](https://sourcegraph.slack.com/archives/alerts-sourcegraph-accounts-prod)                      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=sourcegraph-accounts-prod-csvc)                     |
@@ -141,8 +191,8 @@ sg msp tfc view sourcegraph-accounts dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -152,8 +202,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Sourcegraph Accounts prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                   DETAILS                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=sourcegraph-accounts-prod-csvc) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=sourcegraph-accounts-prod-csvc)                                                                                                                                                                                                                                          |
@@ -167,14 +217,14 @@ sg msp logs sourcegraph-accounts prod
 
 #### prod Redis
 
-| PROPERTY | DETAILS                                                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| PROPERTY |                                                              DETAILS                                                               |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=sourcegraph-accounts-prod-csvc) |
 
 #### prod PostgreSQL instance
 
-| PROPERTY  | DETAILS                                                                                                      |
-| --------- | ------------------------------------------------------------------------------------------------------------ |
+| PROPERTY  |                                                   DETAILS                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------|
 | Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=sourcegraph-accounts-prod-csvc) |
 | Databases | `accounts`                                                                                                   |
 
@@ -193,8 +243,8 @@ sg msp pg connect -write-access sourcegraph-accounts prod
 
 #### prod BigQuery dataset
 
-| PROPERTY        | DETAILS                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY     |                                                                                                                                DETAILS                                                                                                                                 |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dataset Project | `sourcegraph-accounts-prod-csvc`                                                                                                                                                                                                                                       |
 | Dataset ID      | `sourcegraph_accounts`                                                                                                                                                                                                                                                 |
 | Tables          | [`user_emails`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/user_emails.bigquerytable.json), [`events`](https://github.com/sourcegraph/managed-services/blob/main/services/sourcegraph-accounts/events.bigquerytable.json) |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.679906 +0000 UTC
+Last updated: 2024-04-05 21:23:32.768521 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
-| Deployment Type     | `manual`                                                                                                      |
+| Deployment type     | `manual`                                                                                                      |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-support-integration-prod](https://sourcegraph.slack.com/archives/alerts-support-integration-prod)    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=support-integration-prod-549b)  |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                    DETAILS                                                    |
-|---------------------|---------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
 | Deployment type     | `manual`                                                                                                      |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.074592 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.698497 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Support Integration infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,10 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
+| Deployment Type     | manual                                                                                                        |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-support-integration-prod](https://sourcegraph.slack.com/archives/alerts-support-integration-prod)    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=support-integration-prod-549b)  |
@@ -43,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -54,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.698497 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.550867 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Support Integration infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,11 +30,11 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
-| Deployment Type     | manual                                                                                                        |
+| Deployment Type     | `manual`                                                                                                      |
 | Resources           |                                                                                                               |
 | Slack notifications | [#alerts-support-integration-prod](https://sourcegraph.slack.com/archives/alerts-support-integration-prod)    |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=support-integration-prod-549b)  |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                    DETAILS                                                    |
-|---------------------|---------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
 | Deployment Type     | `manual`                                                                                                      |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.550867 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.679906 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Support Integration infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
 | Deployment Type     | `manual`                                                                                                      |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-|      PROPERTY       |                                                    DETAILS                                                    |
-|---------------------|---------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
 | Deployment Type     | manual                                                                                                        |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
-|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/support-integration.md
+++ b/content/departments/engineering/managed-services/support-integration.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.768521 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.801662 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Support Integration infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `support-integration` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/support-integration/service.yaml)) |
 | Owners       | **Customer Support**                                                                                                                         |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -30,8 +30,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                    DETAILS                                                    |
+|---------------------|---------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`support-integration-prod-549b`](https://console.cloud.google.com/run?project=support-integration-prod-549b) |
 | Category            | **internal**                                                                                                  |
 | Deployment type     | `manual`                                                                                                      |
@@ -44,8 +44,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                       |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Internal Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -55,8 +55,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Support Integration prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    PROPERTY    |                                                                                                                                                                  DETAILS                                                                                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=support-integration-prod-549b)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=support-integration-prod-549b) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=support-integration-prod-549b)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -3,7 +3,7 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 18:33:05.680845 +0000 UTC
+Last updated: 2024-04-05 21:23:32.769494 +0000 UTC
 Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
 | Owners       | **core-services**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -65,8 +65,8 @@ The production Telemetry Gateway instance has custom metrics dashboard defined i
 
 ## Rollout
 
-| PROPERTY          | DETAILS                                                                                                                                                                                     |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                           DETAILS                                                                                           |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
 
@@ -78,11 +78,11 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
-| Deployment Type     | `rollout`                                                                                                 |
+| Deployment type     | `rollout`                                                                                                 |
 | Resources           |                                                                                                           |
 | Slack notifications | [#alerts-telemetry-gateway-dev](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-dev)      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-dev-0050) |
@@ -91,8 +91,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -102,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -142,11 +142,11 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
-| Deployment Type     | `rollout`                                                                                                  |
+| Deployment type     | `rollout`                                                                                                  |
 | Resources           |                                                                                                            |
 | Slack notifications | [#alerts-telemetry-gateway-prod](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-prod)     |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-prod-acae) |
@@ -155,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -166,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
 | Owners       | **core-services**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -65,8 +65,8 @@ The production Telemetry Gateway instance has custom metrics dashboard defined i
 
 ## Rollout
 
-|     PROPERTY      |                                                                                           DETAILS                                                                                           |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
 
@@ -78,8 +78,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                  DETAILS                                                  |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment type     | `rollout`                                                                                                 |
@@ -91,8 +91,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -102,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -142,8 +142,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-|      PROPERTY       |                                                  DETAILS                                                   |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment type     | `rollout`                                                                                                  |
@@ -155,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -166,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 20:09:13.699424 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
+Last updated: 2024-04-04 18:45:01.551773 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
 -->
 
 This document describes operational guidance for Telemetry Gateway infrastructure.
@@ -17,15 +17,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                                   |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                  |
-| Owners           | **core-services**                                                                                                                                                                         |
-| Service kind     | Cloud Run service                                                                                                                                                                         |
-| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                |
-| Docker image     | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                                                                           |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway)                                              |
-| Rollout Pipeline | [telemetry-gateway-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
+|     PROPERTY     |                                                                                           DETAILS                                                                                           |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                    |
+| Owners           | **core-services**                                                                                                                                                                           |
+| Service kind     | Cloud Run service                                                                                                                                                                           |
+| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                  |
+| Docker image     | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                                                                             |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway)                                                |
+| Rollout Pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/README.md
@@ -61,11 +61,11 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
-| Deployment Type     | rollout                                                                                                   |
+| Deployment Type     | `rollout`                                                                                                 |
 | Resources           |                                                                                                           |
 | Slack notifications | [#alerts-telemetry-gateway-dev](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-dev)      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-dev-0050) |
@@ -74,8 +74,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -85,8 +85,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -125,11 +125,11 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
-| Deployment Type     | rollout                                                                                                    |
+| Deployment Type     | `rollout`                                                                                                  |
 | Resources           |                                                                                                            |
 | Slack notifications | [#alerts-telemetry-gateway-prod](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-prod)     |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-prod-acae) |
@@ -138,8 +138,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -149,8 +149,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
 | Owners       | **core-services**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -65,8 +65,8 @@ The production Telemetry Gateway instance has custom metrics dashboard defined i
 
 ## Rollout
 
-|     PROPERTY      |                                                                                           DETAILS                                                                                           |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
 
@@ -78,8 +78,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                  DETAILS                                                  |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment Type     | `rollout`                                                                                                 |
@@ -91,8 +91,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -102,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -142,8 +142,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-|      PROPERTY       |                                                  DETAILS                                                   |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment Type     | `rollout`                                                                                                  |
@@ -155,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -166,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-04 18:45:01.551773 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/6d96fe3d4aed2366f4accae010febe949ecaefdf
+Last updated: 2024-04-05 18:33:05.680845 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
 -->
 
 This document describes operational guidance for Telemetry Gateway infrastructure.
@@ -17,15 +17,14 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY         | DETAILS                                                                                                                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                    |
-| Owners           | **core-services**                                                                                                                                                                           |
-| Service kind     | Cloud Run service                                                                                                                                                                           |
-| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                  |
-| Docker image     | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                                                                             |
-| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway)                                                |
-| Rollout Pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
+| Owners       | **core-services**                                                                                                                            |
+| Service kind | Cloud Run service                                                                                                                            |
+| Environments | [dev](#dev), [prod](#prod)                                                                                                                   |
+| Docker image | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                              |
+| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/README.md
@@ -57,12 +56,30 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 2. Check for pings, as that mechanism has not changed, and validate that the instance is is on 5.2.1+
 3. If the above don't reveal anything, reach out to #discuss-core-services for further debugging at the Telemetry Gateway level.
 
+### Custom metrics
+
+The Telemetry Gateway exports some custom metrics for diagnostics on event ingestion volume as well as export size distributions.
+These metrics indicate what kinds of event volumes Sourcegraph instances are emitting.
+
+The production Telemetry Gateway instance has custom metrics dashboard defined in GCP monitoring: [Telemetry Gateway - Custom Metrics](https://console.cloud.google.com/monitoring/dashboards/builder/77c54bef-6a73-42ae-b0e8-b4c777c417e2?project=telemetry-gateway-prod-acae)
+
+## Rollout
+
+|     PROPERTY      |                                                                                           DETAILS                                                                                           |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
+| Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
+
+Changes to Telemetry Gateway are continuously delivered to the first stage ([dev](#dev)) of the delivery pipeline.
+
+Promotion of a release to the next stage in the pipeline must be done manually using the GCP Delivery pipeline UI.
+
 ## Environments
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment Type     | `rollout`                                                                                                 |
@@ -74,8 +91,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -85,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -125,8 +142,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment Type     | `rollout`                                                                                                  |
@@ -138,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -149,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-03 15:25:17.075841 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/ffe69b92d094a0a3d3c44ecd6382a7195e64c708
+Last updated: 2024-04-03 20:09:13.699424 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/05e843e1e494d583b307906a36d4a49b4fb655de
 -->
 
 This document describes operational guidance for Telemetry Gateway infrastructure.
@@ -17,14 +17,15 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
-| Owners       | **core-services**                                                                                                                            |
-| Service kind | Cloud Run service                                                                                                                            |
-| Environments | [dev](#dev), [prod](#prod)                                                                                                                   |
-| Docker image | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                              |
-| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway) |
+|     PROPERTY     |                                                                                          DETAILS                                                                                          |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                  |
+| Owners           | **core-services**                                                                                                                                                                         |
+| Service kind     | Cloud Run service                                                                                                                                                                         |
+| Environments     | [dev](#dev), [prod](#prod)                                                                                                                                                                |
+| Docker image     | `index.docker.io/sourcegraph/telemetry-gateway`                                                                                                                                           |
+| Source code      | [`github.com/sourcegraph/sourcegraph` - `cmd/telemetry-gateway`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/telemetry-gateway)                                              |
+| Rollout Pipeline | [telemetry-gateway-us-central1-rollout](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 
 <!--
 Automatically generated from the service README: https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/README.md
@@ -60,10 +61,11 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
+| Deployment Type     | rollout                                                                                                   |
 | Resources           |                                                                                                           |
 | Slack notifications | [#alerts-telemetry-gateway-dev](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-dev)      |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-dev-0050) |
@@ -72,8 +74,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -83,8 +85,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -123,10 +125,11 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
+| Deployment Type     | rollout                                                                                                    |
 | Resources           |                                                                                                            |
 | Slack notifications | [#alerts-telemetry-gateway-prod](https://sourcegraph.slack.com/archives/alerts-telemetry-gateway-prod)     |
 | Alerts              | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=telemetry-gateway-prod-acae) |
@@ -135,8 +138,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -146,8 +149,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -3,8 +3,8 @@
 <!--
 Generated documentation; DO NOT EDIT. Regenerate using this command: 'sg msp operations generate-handbook-pages'
 
-Last updated: 2024-04-05 21:23:32.769494 +0000 UTC
-Generated from: https://github.com/sourcegraph/managed-services/tree/10ea0eca50aa33a87ebfeea5eae1b70123165043
+Last updated: 2024-04-08 10:19:19.802551 +0000 UTC
+Generated from: https://github.com/sourcegraph/managed-services/tree/1d49a322f05521dba8109692c72c1a665a89c5a9
 -->
 
 This document describes operational guidance for Telemetry Gateway infrastructure.
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-| PROPERTY     | DETAILS                                                                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|   PROPERTY   |                                                                   DETAILS                                                                    |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
 | Owners       | **core-services**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -63,10 +63,10 @@ These metrics indicate what kinds of event volumes Sourcegraph instances are emi
 
 The production Telemetry Gateway instance has custom metrics dashboard defined in GCP monitoring: [Telemetry Gateway - Custom Metrics](https://console.cloud.google.com/monitoring/dashboards/builder/77c54bef-6a73-42ae-b0e8-b4c777c417e2?project=telemetry-gateway-prod-acae)
 
-## Rollout
+## Rollouts
 
-| PROPERTY          | DETAILS                                                                                                                                                                                     |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     PROPERTY      |                                                                                           DETAILS                                                                                           |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
 
@@ -78,8 +78,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-| PROPERTY            | DETAILS                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment type     | `rollout`                                                                                                 |
@@ -91,8 +91,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -102,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -142,8 +142,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-| PROPERTY            | DETAILS                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+|      PROPERTY       |                                                  DETAILS                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------------|
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment type     | `rollout`                                                                                                  |
@@ -155,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -166,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|   PROPERTY   |                                                                   DETAILS                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY     | DETAILS                                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID   | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))     |
 | Owners       | **core-services**                                                                                                                            |
 | Service kind | Cloud Run service                                                                                                                            |
@@ -65,8 +65,8 @@ The production Telemetry Gateway instance has custom metrics dashboard defined i
 
 ## Rollouts
 
-|     PROPERTY      |                                                                                           DETAILS                                                                                           |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY          | DETAILS                                                                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Delivery pipeline | [`telemetry-gateway-us-central1-rollout`](https://console.cloud.google.com/deploy/delivery-pipelines/us-central1/telemetry-gateway-us-central1-rollout?project=telemetry-gateway-prod-acae) |
 | Stages            | [dev](#dev) -> [prod](#prod)                                                                                                                                                                |
 
@@ -78,8 +78,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 ### dev
 
-|      PROPERTY       |                                                  DETAILS                                                  |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment type     | `rollout`                                                                                                 |
@@ -91,8 +91,8 @@ Promotion of a release to the next stage in the pipeline must be done manually u
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -102,8 +102,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -142,8 +142,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-|      PROPERTY       |                                                  DETAILS                                                   |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment type     | `rollout`                                                                                                  |
@@ -155,8 +155,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -166,8 +166,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                          DETAILS                                                                                          |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                  |
 | Owners           | **core-services**                                                                                                                                                                         |
 | Service kind     | Cloud Run service                                                                                                                                                                         |
@@ -61,8 +61,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 ### dev
 
-|      PROPERTY       |                                                  DETAILS                                                  |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment Type     | rollout                                                                                                   |
@@ -74,8 +74,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -85,8 +85,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -125,8 +125,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-|      PROPERTY       |                                                  DETAILS                                                   |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment Type     | rollout                                                                                                    |
@@ -138,8 +138,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -149,8 +149,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/managed-services/telemetry-gateway.md
+++ b/content/departments/engineering/managed-services/telemetry-gateway.md
@@ -17,8 +17,8 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 
 ## Service overview
 
-|     PROPERTY     |                                                                                           DETAILS                                                                                           |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY         | DETAILS                                                                                                                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Service ID       | `telemetry-gateway` ([specification](https://github.com/sourcegraph/managed-services/blob/main/services/telemetry-gateway/service.yaml))                                                    |
 | Owners           | **core-services**                                                                                                                                                                           |
 | Service kind     | Cloud Run service                                                                                                                                                                           |
@@ -61,8 +61,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 ### dev
 
-|      PROPERTY       |                                                  DETAILS                                                  |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-dev-0050`](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)   |
 | Category            | **test**                                                                                                  |
 | Deployment Type     | `rollout`                                                                                                 |
@@ -74,8 +74,8 @@ Please reach out to #discuss-analytics for assistance in querying the dataset - 
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
-|          ACCESS          |                                                                                                                                                                        ENTITLE REQUEST TEMPLATE                                                                                                                                                                        |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | GCP project read access  | [Read-only Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)    |
 | GCP project write access | [Write access Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -85,8 +85,8 @@ For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
 
 The Telemetry Gateway dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-dev-0050) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-dev-0050)                                                                                                                                                                                                                                          |
@@ -125,8 +125,8 @@ sg msp tfc view telemetry-gateway dev
 
 ### prod
 
-|      PROPERTY       |                                                  DETAILS                                                   |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| PROPERTY            | DETAILS                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Project ID          | [`telemetry-gateway-prod-acae`](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)  |
 | Category            | **external**                                                                                               |
 | Deployment Type     | `rollout`                                                                                                  |
@@ -138,8 +138,8 @@ sg msp tfc view telemetry-gateway dev
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 
-|          ACCESS          |                                                                                                                                                                      ENTITLE REQUEST TEMPLATE                                                                                                                                                                      |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCESS                   | ENTITLE REQUEST TEMPLATE                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | GCP project read access  | [Read-only Entitle request for the 'Managed Services ' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D)   |
 | GCP project write access | [Write access Entitle request for the 'Managed Services' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
@@ -149,8 +149,8 @@ For Terraform Cloud access, see [prod Terraform Cloud](#prod-terraform-cloud).
 
 The Telemetry Gateway prod service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
 
-|    PROPERTY    |                                                                                                                                                                 DETAILS                                                                                                                                                                  |
-|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROPERTY       | DETAILS                                                                                                                                                                                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Console        | [Cloud Run service](https://console.cloud.google.com/run?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                            |
 | Service logs   | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=telemetry-gateway-prod-acae) |
 | Service traces | [Cloud Trace](https://console.cloud.google.com/traces/list?project=telemetry-gateway-prod-acae)                                                                                                                                                                                                                                          |

--- a/content/departments/engineering/teams/core-services/managed-services/platform.md
+++ b/content/departments/engineering/teams/core-services/managed-services/platform.md
@@ -41,6 +41,7 @@ From a simple service configuration YAML ([examples](https://github.com/sourcegr
   - Shortcuts to relevant UIs in `sg msp tfc view`, `sg msp logs`, etc.
   - Securely connect to your PostgreSQL instance using `sg msp pg connect`
 - Generated infrastructure guidance, rendered in the [Managed Services infrastructure](../../../managed-services/index.md) pages.
+- Continuous delivery via [Cloud Deploy delivery pipelines](./rollout.md)
 
 See [our GitHub roadmap](https://github.com/orgs/sourcegraph/projects/375/views/1) and [2023 Q3 Managed Services Platform (MSP) proof-of-concept update](https://docs.google.com/document/d/1DSqKqCgXW2m0TCVBmDSasY2Hxb9cp9Uv_NgF4MEfAto/edit) for more details on things we will be adding to MSP.
 

--- a/content/departments/engineering/teams/core-services/managed-services/rollout.md
+++ b/content/departments/engineering/teams/core-services/managed-services/rollout.md
@@ -1,15 +1,15 @@
 # MSP Cloud Deploy Rollouts
 
-The Sourcegraph Managed Services Platform supports [GCP Cloud Deploy](https://cloud.google.com/deploy) to provision a delivery pipeline for services. The pipeline can be composed of one or more stages. When a new version of your service is built it can be deployed to the first stage of the pipeline and manually promoted to the next stage(s).
+The Sourcegraph Managed Services Platform supports [GCP Cloud Deploy](https://cloud.google.com/deploy) to provision a delivery pipeline for services. The pipeline can be composed of one or more stages. When a new version of your service is built it is deployed to the first stage of the pipeline and can be manually promoted to the next stage(s).
 As such if your service is composed of `development` and `production` environments; new versions can be continuously delivered to `development` and manually promoted to `production` after they have been tested.
 
 ## Configuring Rollouts
 
-Configuring rollouts requires making changes to the MSP specifiction for a service and to your CI pipeline which builds and publishes Docker images for your service. For any configuration help reach out in #discuss-core-services
+Configuring rollouts requires making changes to the MSP specifiction for a service and to your CI pipeline which builds and publishes Docker images for your service. For any configuration help reach out in #discuss-core-services.
 
 ### MSP Specification
 
-To configure rollouts for a service a top-level `rollout` object defines the stages (environments) and the order through which releases progress. Each service included in the rollout must specify a `deploy.type` of `rollout`
+To configure rollouts for a service a top-level `rollout` object defines the stages (environments) and the order through which releases progress. Each service included in the rollout must specify a `deploy.type` of `rollout`.
 
 Below is a minified MSP specification detailing the required configuration to use Cloud Deploy.
 
@@ -83,7 +83,7 @@ jobs:
       ARTIFACT_REPOSITORY: us-central1-docker.pkg.dev/sourcegraph-dev/msp-example
       ARTIFACT_HOST: us-central1-docker.pkg.dev
     steps:
-      # checkout repo ..
+      # checkout repo
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/content/departments/engineering/teams/core-services/managed-services/rollout.md
+++ b/content/departments/engineering/teams/core-services/managed-services/rollout.md
@@ -30,19 +30,19 @@ rollout:
   serviceAccount: sourcegraph-sa@ci-project.iam.gserviceaccount.com
 
 environments:
-- id: development
-  projectID: msp-example-development-0000
-  category: test
-  deploy:
-    type: rollout
-  # ...
+  - id: development
+    projectID: msp-example-development-0000
+    category: test
+    deploy:
+      type: rollout
+    # ...
 
-- id: production
-  projectID: msp-example-production-0000
-  category: external
-  deploy:
-    type: rollout
-  # ...
+  - id: production
+    projectID: msp-example-production-0000
+    category: external
+    deploy:
+      type: rollout
+    # ...
 ```
 
 ### CI Configuration
@@ -64,6 +64,7 @@ msp_delivery(
 ```
 
 The following must be modifed to match your service:
+
 - `gcp_project`: the GCP `projectID` of the **last** stage of the pipeline
 - `msp_service_id`: the `service.id` of your service
 - `repository`: the docker image repository where your service images are pushed
@@ -97,7 +98,7 @@ jobs:
         with:
           # Workload identity should be configured in the `infrastructure` repo
           # See https://github.com/sourcegraph/infrastructure/blob/1a82cd96e84cf329ad5d697d8b349b12bc419ed7/managed-services/sourcegraph-accounts-publishing-pipeline/main.tf for an example
-          workload_identity_provider: "projects/1234567890/locations/global/workloadIdentityPools/msp-example-publishing-provider/providers/msp-example-publishing-provider"
+          workload_identity_provider: 'projects/1234567890/locations/global/workloadIdentityPools/msp-example-publishing-provider/providers/msp-example-publishing-provider'
           # Service account must match the service account specified in the MSP rollout specification
           service_account: wi-gh-msp-example-publishing@ci-project.iam.gserviceaccount.com
       # Authenticate to the registry
@@ -126,14 +127,14 @@ jobs:
 ```
 
 The following must be modifed to match your service:
+
 - `workload_identity_provider`: provider configured in the `infrastructure` repo
 - `service_account`: service account configured in the `infrastructure` repo
 - `MSP_SERVICE_ID`: the `service.id` of your service
 - `GCP_PROJECT`: the GCP `projectID` of the **last** stage of the pipeline
 
-
-
 The `msp_deploy.sh` script has the following contents and should be located at `.github/workflows/msp_deploy.sh`
+
 ```sh
 #!/usr/bin/env bash
 

--- a/content/departments/engineering/teams/core-services/managed-services/rollout.md
+++ b/content/departments/engineering/teams/core-services/managed-services/rollout.md
@@ -1,0 +1,170 @@
+# MSP Cloud Deploy Rollouts
+
+The Sourcegraph Managed Services Platform supports [GCP Cloud Deploy](https://cloud.google.com/deploy) to provision a delivery pipeline for services. The pipeline can be composed of one or more stages. When a new version of your service is built it can be deployed to the first stage of the pipeline and manually promoted to the next stage(s).
+As such if your service is composed of `development` and `production` environments; new versions can be continuously delivered to `development` and manually promoted to `production` after they have been tested.
+
+## Configuring Rollouts
+
+Configuring rollouts requires making changes to the MSP specifiction for a service and to your CI pipeline which builds and publishes Docker images for your service. For any configuration help reach out in #discuss-core-services
+
+### MSP Specification
+
+To configure rollouts for a service a top-level `rollout` object defines the stages (environments) and the order through which releases progress. Each service included in the rollout must specify a `deploy.type` of `rollout`
+
+Below is a minified MSP specification detailing the required configuration to use Cloud Deploy.
+
+```yaml
+service:
+  id: msp-example
+  # ...
+build:
+  # ...
+
+# Rollout configures how releases should roll out through a set of environments.
+rollout:
+  # Stages specifies the order and environments through which releases progress.
+  stages:
+    - environment: development
+    - environment: production
+  # ServiceAccount is the email address of the service account to provision IAM access to create releases. Can be used to give access to the Service Account used in your CI pipeline
+  serviceAccount: sourcegraph-sa@ci-project.iam.gserviceaccount.com
+
+environments:
+- id: development
+  projectID: msp-example-development-0000
+  category: test
+  deploy:
+    type: rollout
+  # ...
+
+- id: production
+  projectID: msp-example-production-0000
+  category: external
+  deploy:
+    type: rollout
+  # ...
+```
+
+### CI Configuration
+
+> [!NOTE]
+> The recommended CI configuration is subject to change as improvements are made to simplify the process. Any improvements should not break existing configurations
+
+#### Buildkite
+
+In the [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph) monorepo using Buildkite & Bazel the `msp_delivery` Bazel rule can be used.
+
+```bazel
+msp_delivery(
+    name = "msp_deploy",
+    gcp_project = "msp-example-production-0000",
+    msp_service_id = "msp-example",
+    repository = "us.gcr.io/sourcegraph-dev/msp-example",
+)
+```
+
+The following must be modifed to match your service:
+- `gcp_project`: the GCP `projectID` of the **last** stage of the pipeline
+- `msp_service_id`: the `service.id` of your service
+- `repository`: the docker image repository where your service images are pushed
+
+The Bazel rule must be specified in the same `BUILD.bazel` file which includes the `oci_push` rule named `candidate_push` for your service.
+
+> [!IMPORTANT]
+> When using Bazel + Buildkite the Service Account in the [MSP Specification](#MSP-Specification) must be set to `sourcegraph-aspect-workflow@aspect-dev.iam.gserviceaccount.com`
+
+#### GitHub Action
+
+```yaml
+jobs:
+  delivery:
+    env:
+      ARTIFACT_REPOSITORY: us-central1-docker.pkg.dev/sourcegraph-dev/msp-example
+      ARTIFACT_HOST: us-central1-docker.pkg.dev
+    steps:
+      # checkout repo ..
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Compute short sha to use in Docker tag
+      - name: Compute short commit SHA
+        id: short-sha
+        uses: benjlevesque/short-sha@v2.1
+      # Authenticate to Google using Workload Identity
+      - name: gcloud auth
+        uses: google-github-actions/auth@v2
+        with:
+          # Workload identity should be configured in the `infrastructure` repo
+          # See https://github.com/sourcegraph/infrastructure/blob/1a82cd96e84cf329ad5d697d8b349b12bc419ed7/managed-services/sourcegraph-accounts-publishing-pipeline/main.tf for an example
+          workload_identity_provider: "projects/1234567890/locations/global/workloadIdentityPools/msp-example-publishing-provider/providers/msp-example-publishing-provider"
+          # Service account must match the service account specified in the MSP rollout specification
+          service_account: wi-gh-msp-example-publishing@ci-project.iam.gserviceaccount.com
+      # Authenticate to the registry
+      - name: gcloud docker auth
+        run: gcloud auth configure-docker ${{ env.ARTIFACT_HOST }}
+      # Build and push the image using the tag `<short_sha>_<github.run_id>`
+      # This tag is used by the rollout
+      - name: Build and push images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.ARTIFACT_REPOSITORY }}:${{ steps.short-sha.outputs.sha }}_${{ github.run_id }}
+      # Run the `msp_deploy.sh` script to create a release
+      - name: MSP deploy rollout
+        working-directory: .github/workflows
+        run: |
+          export MSP_SERVICE_ID=msp-example
+          export GCP_PROJECT=msp-example-production-0000
+          export GCP_REGION=us-central1
+          export BUILD_NUMBER=${{ github.run_id }}
+          export BUILD_AUTHOR=$(echo "${{github.actor}}" | tr "[:upper:]" "[:lower:]")
+          export COMMIT=${GITHUB_SHA}
+          ./msp_deploy.sh
+```
+
+The following must be modifed to match your service:
+- `workload_identity_provider`: provider configured in the `infrastructure` repo
+- `service_account`: service account configured in the `infrastructure` repo
+- `MSP_SERVICE_ID`: the `service.id` of your service
+- `GCP_PROJECT`: the GCP `projectID` of the **last** stage of the pipeline
+
+
+
+The `msp_deploy.sh` script has the following contents and should be located at `.github/workflows/msp_deploy.sh`
+```sh
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# Service Specific Parameters
+: "${MSP_SERVICE_ID:?"MSP_SERVICE_ID is required"}"
+: "${GCP_PROJECT:?"GCP_PROJECT is required"}"
+: "${GCP_REGION:?"GCP_REGION is required"}"
+
+# CI Variables
+: "${BUILD_NUMBER:?"BUILD_NUMBER is required"}"
+: "${COMMIT:?"COMMIT is required"}"
+: "${BUILD_AUTHOR:?"BUILD_AUTHOR is required"}"
+
+# Computed Variables
+GCP_CLOUDRUN_SKAFFOLD_SOURCE="gs://${GCP_PROJECT}-cloudrun-skaffold/source.tar.gz"
+GCP_DELIVERY_PIPELINE="${MSP_SERVICE_ID}-${GCP_REGION}-rollout"
+SHORT_SHA="${COMMIT:0:7}"
+TAG="${SHORT_SHA}_${BUILD_NUMBER}"
+# resource ids must be lower-case letters, numbers, and hyphens,
+# with the first character a letter, the last a letter or a number,
+# and a 63 character maximum
+RELEASE_NAME="deploy-${SHORT_SHA}-${BUILD_NUMBER}"
+
+# Create the Cloud Deploy release
+1>&2 gcloud deploy releases create "${RELEASE_NAME}" \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --delivery-pipeline="${GCP_DELIVERY_PIPELINE}" \
+    --source="${GCP_CLOUDRUN_SKAFFOLD_SOURCE}" \
+    --labels="commit=${COMMIT},author=${BUILD_AUTHOR}" \
+    --deploy-parameters="customTarget/tag=${TAG}"
+```


### PR DESCRIPTION
Add a page explaining how to configure the rollout feature
Adds a row to each environment's details table specifying the deployment type used.

If a service uses rollouts a row with a link to the delivery pipeline is added to the service overview

includes changes from this pr: https://github.com/sourcegraph/sourcegraph/pull/61610