### PR TITLE
Clarify purpose of the policy

### DIFF
--- a/content/company-info-and-process/policies/access-control-policy.md
+++ b/content/company-info-and-process/policies/access-control-policy.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The purpose of this policy is to limit access to information and information processing systems to authorized parties in order to protect our customers, employees, contractors, and other partners from harm caused by both deliberate and inadvertent misuse. Furthermore, this policy outlines Sourcegraph’s approach to credential management used for authentication on company assets as application of poor credentials in service and system can lead to disclosure of sensitive information and data breaches. Our intention in publishing this policy is to outline information security practices intended to protect Sourcegraph’s assets, not to impose restrictions.
+The purpose of this policy is to limit access to information and information processing systems to authorized parties in order to protect our customers, employees, contractors, and other partners from harm caused by both deliberate and inadvertent misuse. Furthermore, this policy outlines Sourcegraph’s approach to credential management used for authentication on company assets as application of poor credentials in service and system can lead to disclosure of sensitive information and data breaches. Our intention in publishing this policy is to outline information security practices intended to protect Sourcegraph’s assets, not to impose arbitrary restrictions.
 
 ## Scope
 

--- a/content/company-info-and-process/policies/information-security-policy.md
+++ b/content/company-info-and-process/policies/information-security-policy.md
@@ -2,7 +2,7 @@
 
 ## Overview & Policy Purpose
 
-The purpose of this policy is to communicate our information security policies and outline the acceptable use and protection of Sourcegraph’s information and assets. Sourcegraph has a requirement to protect its data/assets from accidental or malicious disclosure, modification or destruction. These rules are in place to protect customers, employees, and Sourcegraph. Inappropriate use exposes Sourcegraph to risks including virus attacks, network systems and services being compromised, and legal and compliance issues. Our intention in publishing this policy is to protect Sourcegraph’s assets, not to impose restrictions.
+The purpose of this policy is to communicate our information security policies and outline the acceptable use and protection of Sourcegraph’s information and assets. Sourcegraph has a requirement to protect its data/assets from accidental or malicious disclosure, modification or destruction. These rules are in place to protect customers, employees, and Sourcegraph. Inappropriate use exposes Sourcegraph to risks including virus attacks, network systems and services being compromised, and legal and compliance issues. Our intention in publishing this policy is to protect Sourcegraph’s assets, not to impose arbitrary restrictions.
 
 The Sourcegraph “Information Security Policy” consists of this policy and all Sourcegraph policies listed in our handbook policy page.
 Effective security is a team effort involving the participation and support of every Sourcegraph employee or contractor who deals with information and/or information systems. It is the responsibility of every team member to read and understand this policy, and to conduct their activities accordingly.


### PR DESCRIPTION
Changed the sentence about the purpose of the policy to say, "not to impose arbitrary restrictions" (added "arbitrary") because the policy does impose restrictions, but those restrictions are intended to protect Sourcegraph's assets, so are not arbitrary. It's a bit of a nit perhaps.
Perhaps the "restrictions" clause should not even be included, and the purpose statement should just be "to protect Sourcegraph's assets".