### PR TITLE
add felix kling email

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -963,6 +963,7 @@ andrew_norrish:
 
 felix_kling:
   name: Felix Kling
+  email: felix.kling@sourcegraph.com
   reports_to: code_search_lead
   role: Software Engineer
   github: fkling


### PR DESCRIPTION
Without this build-tracker can't find @fkling Slack ID 😄 

Tested locally after this change:
```
go run ./dev/sg teammate details felix kling

  Name       : Felix Kling
  Slack      : felix.kling
  Email      : felix.kling@sourcegraph.com mailto:felix.kling@sourcegraph.com
  GitHub     : fkling https://github.com/fkling
  Location   :
  Role       : Software Engineer
  Description:
```