### PR TITLE
components: add deprecation banner to all pages

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -7,7 +7,24 @@ import React from 'react'
 export function Banner({ path }: { path: string }): JSX.Element {
     // Banners should each be an <aside> with the appropriate className to indicate the
     // admonition type.
-    const banners: React.ReactElement[] = []
+
+    const banners: React.ReactElement[] = [
+        // Deprecation notice
+        <aside className="warning" key="deprecation-banner">
+            <div>
+                ⚠️ We are in the process of migrating to Notion as Sourcegraph's handbook platform.{' '}
+                <b>
+                    This content may represent incomplete, or out-of-date processes - please look for the equivalent
+                    page in the new site at <a href="https://sourcegraph.notion.site">sourcegraph.notion.site</a>.
+                </b>
+                <br />
+                <br />
+                The contents of this page will only be retained until <b>end of May 2024</b>. If you own this page,
+                please maintain an equivalent in the new{' '}
+                <a href="https://www.notion.so/sourcegraph">Notion-based handbook</a>.
+            </div>
+        </aside>,
+    ]
 
     // Inject warning banners to pages with cloud in the path - this helps us communicate
     // to customers that for finalized documentation, they should refer elsewhere.


### PR DESCRIPTION
As titled - there are already discrepancies between handbook and Notion, we should more aggressively direct users to the new equivalents. This adds a banner on top of every handbook page automatically. I based the end-of-May EOL date on [this Slack message](https://sourcegraph.slack.com/archives/C02FSM7DU/p1714148599967949)

<img width="1027" alt="image" src="https://github.com/sourcegraph/handbook/assets/23356519/f704e099-2906-4363-9402-e8ac0c261304">
