### PR TITLE
Fix broken link in migration banner

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -23,7 +23,7 @@ export function Banner({ path }: { path: string }): JSX.Element {
                 please maintain an equivalent in the new{' '}
                 <a href="https://www.notion.so/sourcegraph">Notion-based handbook</a>. You can set up a redirection to
                 the corresponding Notion page by making a pull request against{' '}
-                <a href="https://github.com/sourcegraph/handbook/blob/main/data/notion_migration.yml">this file</a> to
+                <a href="https://github.com/sourcegraph/handbook/blob/main/data/notion_migration.yaml">this file</a> to
                 match the handbook path with the new Notion page.
             </div>
         </aside>,


### PR DESCRIPTION
Classic mistake, file is a `.yaml` and original link was a `.yml`. I've tested the new URL now the file is in main. 